### PR TITLE
Replace xtgo/uuid with Google's uuid library

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,10 @@
 package posthog
 
 import (
-	"github.com/xtgo/uuid"
 	"net/http"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Instances of this type carry the different configuration options that may
@@ -168,5 +169,9 @@ func makeConfig(c Config) Config {
 // This function returns a string representation of a UUID, it's the default
 // function used for generating unique IDs.
 func uid() string {
-	return uuid.NewRandom().String()
+	new_uuid, err := uuid.NewRandom()
+	if err != nil {
+		return ""
+	}
+	return new_uuid.String()
 }

--- a/config.go
+++ b/config.go
@@ -169,9 +169,6 @@ func makeConfig(c Config) Config {
 // This function returns a string representation of a UUID, it's the default
 // function used for generating unique IDs.
 func uid() string {
-	new_uuid, err := uuid.NewRandom()
-	if err != nil {
-		return ""
-	}
+	new_uuid, _ := uuid.NewRandom()
 	return new_uuid.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/posthog/posthog-go
 go 1.15
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/urfave/cli v1.22.5
-	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -8,7 +10,5 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
-github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
 The xtgo/uuid library is 11 years old, and has been superseded by google/uuid
 
Simple change to just switch over to the new uuid library, increasing supportability. 