### PR TITLE
fix(flags): Don't match unknown operators

### DIFF
--- a/feature_flags_test.go
+++ b/feature_flags_test.go
@@ -27,6 +27,28 @@ func TestMatchPropertyValue(t *testing.T) {
 	}
 
 }
+
+
+func TestMatchPropertyInvalidOperator(t *testing.T) {
+	property := Property{
+		Key:      "Browser",
+		Value:    "Chrome",
+		Operator: "is_unknown",
+	}
+
+	properties := NewProperties().Set("Browser", "Chrome")
+
+	isMatch, err := matchProperty(property, properties)
+
+	if isMatch == true {
+		t.Error("Should not match")
+	}
+
+	if _, ok := err.(*InconclusiveMatchError); !ok {
+		t.Error("Error type is not a match")
+	}
+
+}
 func TestMatchPropertySlice(t *testing.T) {
 
 	property := Property{

--- a/featureflags.go
+++ b/featureflags.go
@@ -531,7 +531,8 @@ func matchProperty(property Property, properties Properties) (bool, error) {
 		return overrideValueOrderable <= valueOrderable, nil
 	}
 
-	return false, nil
+	return false, &InconclusiveMatchError{"Unknown operator: " + operator}
+
 }
 
 func validateOrderable(firstValue interface{}, secondValue interface{}) (float64, float64, error) {


### PR DESCRIPTION
When the operator type is unknown, raise inconclusive match error, so we don't incorrectly match on unknown operator types, which is pretty important for when we extend flags to support more operators.