### PR TITLE
Fix default feature flags polling interval

### DIFF
--- a/config.go
+++ b/config.go
@@ -132,7 +132,7 @@ func makeConfig(c Config) Config {
 	}
 
 	if c.DefaultFeatureFlagsPollingInterval == 0 {
-		c.DefaultFeatureFlagsPollingInterval = DefaultInterval
+		c.DefaultFeatureFlagsPollingInterval = DefaultFeatureFlagsPollingInterval
 	}
 
 	if c.Transport == nil {


### PR DESCRIPTION
Docs specify that default interval is 5 minutes while in practice it is 5 seconds.