### PR TITLE
Initialize properties map when sending feature flags

### DIFF
--- a/posthog.go
+++ b/posthog.go
@@ -189,6 +189,11 @@ func (c *client) Enqueue(msg Message) (err error) {
 			if err != nil {
 				c.Errorf("unable to get feature variants - %s", err)
 			}
+
+			if m.Properties == nil {
+				m.Properties = NewProperties()
+			}
+
 			for feature, variant := range featureVariants {
 				propKey := fmt.Sprintf("$feature/%s", feature)
 				m.Properties[propKey] = variant

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -929,3 +929,41 @@ func TestDisabledFlag(t *testing.T) {
 		t.Errorf("flag listed in /decide/ response should have value 'false'")
 	}
 }
+
+func TestCaptureSendFlags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fixture("test-api-feature-flag.json")))
+	}))
+	defer server.Close()
+
+	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
+		Endpoint:  server.URL,
+		Verbose:   true,
+		Logger:    t,
+		BatchSize: 1,
+		now:       mockTime,
+		uid:       mockId,
+
+		PersonalApiKey: "some very secret key",
+	})
+	defer client.Close()
+
+	// Without this call client.Close hangs forever
+	// Ref: https://github.com/PostHog/posthog-go/issues/28
+	client.IsFeatureEnabled(
+		FeatureFlagPayload{
+			Key:        "simpleFlag",
+			DistinctId: "hey",
+		},
+	)
+
+	err := client.Enqueue(Capture{
+		Event:            "Download",
+		DistinctId:       "123456",
+		SendFeatureFlags: true,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
When capturing an event with SendFeatureFlags set to true and no properties defined posthog panics with nil pointer.

Panic:

```
github.com/posthog/posthog-go.(*client).Enqueue(0x4000abba00, {0x420b130?, 0x40015705a0?) 
  /root/go/pkg/mod/github.com/posthog/posthog-go@v0.0.0-20240110105835-f2ee529330e9/posthog.go:194
```

Example:

```go
client.Enqueue(posthog.Capture{
	DistinctId: user.ID,
	Event:      "test_event",
	SendFeatureFlags: true,
})
```