### PR TITLE
Log flag name when failed to compute it locally

### DIFF
--- a/featureflags.go
+++ b/featureflags.go
@@ -201,7 +201,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 	}
 
 	if err != nil {
-		poller.Errorf("Unable to compute flag locally - %s", err)
+		poller.Errorf("Unable to compute flag locally (%s) - %s", featureFlag.Key, err)
 	}
 
 	if (err != nil || result == nil) && !flagConfig.OnlyEvaluateLocally {
@@ -226,7 +226,7 @@ func (poller *FeatureFlagsPoller) GetAllFlags(flagConfig FeatureFlagPayloadNoKey
 		for _, storedFlag := range featureFlags {
 			result, err := poller.computeFlagLocally(storedFlag, flagConfig.DistinctId, flagConfig.Groups, flagConfig.PersonProperties, flagConfig.GroupProperties)
 			if err != nil {
-				poller.Errorf("Unable to compute flag locally - %s", err)
+				poller.Errorf("Unable to compute flag locally (%s) - %s", storedFlag.Key, err)
 				fallbackToDecide = true
 			} else {
 				response[storedFlag.Key] = result


### PR DESCRIPTION
Atm it is impossible to tell which flag failed to be computed locally.

Before:

```
Unable to compute flag locally - Can't determine if feature flag is enabled or not with given properties
```

After:

```
Unable to compute flag locally (my_test) - Can't determine if feature flag is enabled or not with given properties
```