### PR TITLE
Support multiple cohorts in local evaluation

### DIFF
--- a/featureflags.go
+++ b/featureflags.go
@@ -657,7 +657,7 @@ func (poller *FeatureFlagsPoller) decide(requestData []byte, headers [][2]string
 }
 
 func (poller *FeatureFlagsPoller) localEvaluationFlags(headers [][2]string) (*http.Response, error) {
-	localEvaluationEndpoint := "api/feature_flag/local_evaluation"
+	localEvaluationEndpoint := "api/feature_flag/local_evaluation?send_cohorts"
 
 	url, err := url.Parse(poller.Endpoint + "/" + localEvaluationEndpoint + "")
 	if err != nil {


### PR DESCRIPTION
> 3. There's more than one cohort in the feature flag definition.

This restriction is annoying. And it seems it could be resolved rather easily. Copying what [NodeJS SDK does](https://github.com/PostHog/posthog-js-lite/blob/a91b96a/posthog-node/src/feature-flags.ts#L411).

Ref: https://posthog.com/docs/feature-flags/local-evaluation