### PR TITLE
Allow to configure when next flags polling happens

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	// Interval at which to fetch new feature flags, 5min by default
 	DefaultFeatureFlagsPollingInterval time.Duration
 
+	// Calculate when feature flags should be polled next. Setting this property
+	// will override DefaultFeatureFlagsPollingInterval.
+	NextFeatureFlagsPollingTick func() time.Duration
+
 	// The HTTP transport used by the client, this allows an application to
 	// redefine how requests are being sent at the HTTP level (for example,
 	// to change the connection pooling policy).

--- a/posthog.go
+++ b/posthog.go
@@ -111,7 +111,15 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 	}
 
 	if len(c.PersonalApiKey) > 0 {
-		c.featureFlagsPoller = newFeatureFlagsPoller(c.key, c.Config.PersonalApiKey, c.Errorf, c.Endpoint, c.http, c.DefaultFeatureFlagsPollingInterval)
+		c.featureFlagsPoller = newFeatureFlagsPoller(
+			c.key,
+			c.Config.PersonalApiKey,
+			c.Errorf,
+			c.Endpoint,
+			c.http,
+			c.DefaultFeatureFlagsPollingInterval,
+			c.NextFeatureFlagsPollingTick,
+		)
 	}
 
 	go c.loop()


### PR DESCRIPTION
TLDR: We want to poll at the same time from all instances.

Atm the feature flags poller will be executed every 5 minutes by default. When running posthog poller from multiple instances we have no guarantees when flags will be fetched. In the example below we will have different state on two instances between 12:10-12:12.

This PR allows specifying a function that would calculate when flags should be fetched next.

```mermaid
sequenceDiagram
    participant A as Instance A
    participant P as Posthog
    participant B as Instance B

    Note over A: Start new instance at 12:00
    Note over B: Start new instance at 12:02
    A->>P: Poll flags at 12:05
    B->>P: Poll flags at 12:07
    A->>P: Poll flags at 12:10
    P->>P: Disable the flag in the dashboard
    B->>P: Poll flags at 12:12
```
