### PR TITLE
Do not push to the loaded channel when flags' request fails

### DIFF
--- a/feature_flags_test.go
+++ b/feature_flags_test.go
@@ -617,13 +617,9 @@ func TestFeatureFlagNullComeIntoPlayOnlyWhenDecideErrorsOut(t *testing.T) {
 
 	defer server.Close()
 
-	// TODO: Make this nicer, right now if all local evaluation requests fail, we block
-	// on waiting for atleast one request to happen before returning flags,
-	//  which can be suboptimal
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey:                     "some very secret key",
-		Endpoint:                           server.URL,
-		DefaultFeatureFlagsPollingInterval: 5 * time.Second,
+		PersonalApiKey: "some very secret key",
+		Endpoint:       server.URL,
 	})
 	defer client.Close()
 

--- a/posthog.go
+++ b/posthog.go
@@ -305,7 +305,7 @@ func (c *client) GetFeatureFlags() ([]FeatureFlag, error) {
 		c.Errorf(errorMessage)
 		return nil, errors.New(errorMessage)
 	}
-	return c.featureFlagsPoller.GetFeatureFlags(), nil
+	return c.featureFlagsPoller.GetFeatureFlags()
 }
 
 func (c *client) GetAllFlags(flagConfig FeatureFlagPayloadNoKey) (map[string]interface{}, error) {


### PR DESCRIPTION
If we get HTTP timeouts or server errors then this SDK will happily block itself.

In case of an error `poller.loaded <- false` will block indefinitely since we read from this channel only once. Blocking on the channel will in turn block the infinite loop that polls for the latest state. SDK users are not blocked but will get outdated flags' state.

Tests before:

```
> go test -run TestFetchFlagsFails -timeout 5s

panic: test timed out after 5s
running tests:
	TestFetchFlagsFails (5s)

...

goroutine 35 [chan send]:
github.com/posthog/posthog-go.(*FeatureFlagsPoller).ForceReload(...)
	/Users/roman/Code/trial/posthog-go/featureflags.go:874
github.com/posthog/posthog-go.(*client).ReloadFeatureFlags(0x140001a40d8?)
	/Users/roman/Code/trial/posthog-go/posthog.go:272 +0x34
github.com/posthog/posthog-go.TestFetchFlagsFails(0x140001a8680)
	/Users/roman/Code/trial/posthog-go/feature_flags_test.go:3416 +0x1ac
testing.tRunner(0x140001a8680, 0x104706608)
	/nix/store/k9srp8ngvblscg68fdpcyqkydh86429k-go-1.22.1/share/go/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
	/nix/store/k9srp8ngvblscg68fdpcyqkydh86429k-go-1.22.1/share/go/src/testing/testing.go:1742 +0x318

goroutine 37 [chan send]:
github.com/posthog/posthog-go.(*FeatureFlagsPoller).fetchNewFeatureFlags(0x140002061c0)
	/Users/roman/Code/trial/posthog-go/featureflags.go:179 +0x124
github.com/posthog/posthog-go.(*FeatureFlagsPoller).run(0x140002061c0)
	/Users/roman/Code/trial/posthog-go/featureflags.go:166 +0xac
created by github.com/posthog/posthog-go.newFeatureFlagsPoller in goroutine 35
	/Users/roman/Code/trial/posthog-go/featureflags.go:148 +0x1e8

...
```

Here you can see that we are waiting on

```
github.com/posthog/posthog-go.(*FeatureFlagsPoller).fetchNewFeatureFlags(0x140002061c0)
	/Users/roman/Code/trial/posthog-go/featureflags.go:179 +0x124
```

which is `poller.loaded <- false`