### PR TITLE
Add historical_migration flag to config

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,10 @@ type Config struct {
 	// will override DefaultFeatureFlagsPollingInterval.
 	NextFeatureFlagsPollingTick func() time.Duration
 
+	// Flag to enable historical migration
+	// See more in our migration docs: https://posthog.com/docs/migrate
+	HistoricalMigration bool
+
 	// The HTTP transport used by the client, this allows an application to
 	// redefine how requests are being sent at the HTTP level (for example,
 	// to change the connection pooling policy).

--- a/message.go
+++ b/message.go
@@ -55,8 +55,9 @@ func makeTimestamp(t time.Time, def time.Time) time.Time {
 // export this type because it's only meant to be used internally to send groups
 // of messages in one API call.
 type batch struct {
-	ApiKey   string    `json:"api_key"`
-	Messages []message `json:"batch"`
+	ApiKey              string    `json:"api_key"`
+	HistoricalMigration bool      `json:"historical_migration,omitempty"`
+	Messages            []message `json:"batch"`
 }
 
 type APIMessage interface{}

--- a/posthog.go
+++ b/posthog.go
@@ -363,8 +363,9 @@ func (c *client) send(msgs []message) {
 	const attempts = 10
 
 	b, err := json.Marshal(batch{
-		ApiKey:   c.key,
-		Messages: msgs,
+		ApiKey:              c.key,
+		HistoricalMigration: c.HistoricalMigration,
+		Messages:            msgs,
 	})
 
 	if err != nil {

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -231,6 +231,57 @@ func ExampleCapture() {
 
 }
 
+func ExampleHistoricalMigrationCapture() {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
+		Endpoint:            server.URL,
+		BatchSize:           1,
+		now:                 mockTime,
+		uid:                 mockId,
+		HistoricalMigration: true,
+	})
+	defer client.Close()
+
+	client.Enqueue(Capture{
+		Event:      "Download",
+		DistinctId: "123456",
+		Properties: Properties{
+			"application": "PostHog Go",
+			"version":     "1.0.0",
+			"platform":    "macos", // :)
+		},
+		SendFeatureFlags: false,
+	})
+
+	fmt.Printf("%s\n", <-body)
+	// Output:
+	// {
+	//   "api_key": "Csyjlnlun3OzyNJAafdlv",
+	//   "batch": [
+	//     {
+	//       "distinct_id": "123456",
+	//       "event": "Download",
+	//       "library": "posthog-go",
+	//       "library_version": "1.0.0",
+	//       "properties": {
+	//         "$lib": "posthog-go",
+	//         "$lib_version": "1.0.0",
+	//         "application": "PostHog Go",
+	//         "platform": "macos",
+	//         "version": "1.0.0"
+	//       },
+	//       "send_feature_flags": false,
+	//       "timestamp": "2009-11-10T23:00:00Z",
+	//       "type": "capture"
+	//     }
+	//   ],
+	//   "historical_migration": true
+	// }
+
+}
+
 func TestEnqueue(t *testing.T) {
 	tests := map[string]struct {
 		ref string


### PR DESCRIPTION
The [Mixpanel migration tool](https://github.com/stablecog/mixpanel-to-posthog) uses Go. Go is missing support for the historical migrations flag. It is relatively simple to add, so I did it.

Added test and tested locally with the migration tool using the updated package.
