### PR TITLE
Refine error messages and minor improvements

### DIFF
--- a/feature_flags_test.go
+++ b/feature_flags_test.go
@@ -325,7 +325,7 @@ func TestFlagGroup(t *testing.T) {
 				t.Errorf("Expected personProperties to be map[region:Canada], got %s", reqBody.PersonProperties)
 			}
 
-			groupPropertiesEquality := reflect.DeepEqual(reqBody.GroupProperties, map[string]Properties{"company": Properties{"name": "Project Name 1"}})
+			groupPropertiesEquality := reflect.DeepEqual(reqBody.GroupProperties, map[string]Properties{"company": {"name": "Project Name 1"}})
 			if !groupPropertiesEquality {
 				t.Errorf("Expected groupProperties to be map[company:map[name:Project Name 1]], got %s", reqBody.GroupProperties)
 			}

--- a/featureflags.go
+++ b/featureflags.go
@@ -311,7 +311,7 @@ func (poller *FeatureFlagsPoller) computeFlagLocally(
 		groupName, exists := poller.groups[fmt.Sprintf("%d", *flag.Filters.AggregationGroupTypeIndex)]
 
 		if !exists {
-			errMessage := "Flag has unknown group type index"
+			errMessage := "flag has unknown group type index"
 			return nil, errors.New(errMessage)
 		}
 
@@ -467,7 +467,7 @@ func matchCohort(property FlagProperty, properties Properties, cohorts map[strin
 	cohortId := fmt.Sprint(property.Value)
 	propertyGroup, ok := cohorts[cohortId]
 	if !ok {
-		return false, fmt.Errorf("Can't match cohort: cohort %s not found", cohortId)
+		return false, fmt.Errorf("can't match cohort: cohort %s not found", cohortId)
 	}
 
 	return matchPropertyGroup(propertyGroup, properties, cohorts)
@@ -578,7 +578,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 		return false, &InconclusiveMatchError{"Can't match properties with operator is_not_set"}
 	}
 
-	override_value, _ := properties[key]
+	override_value := properties[key]
 
 	if operator == "exact" {
 		switch t := value.(type) {
@@ -637,7 +637,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 			valueString = strconv.Itoa(valueInt)
 			r, err = regexp.Compile(valueString)
 		} else {
-			errMessage := "Regex expression not allowed"
+			errMessage := "regex expression not allowed"
 			return false, errors.New(errMessage)
 		}
 
@@ -653,7 +653,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 			valueString = strconv.Itoa(valueInt)
 			match = r.MatchString(valueString)
 		} else {
-			errMessage := "Value type not supported"
+			errMessage := "value type not supported"
 			return false, errors.New(errMessage)
 		}
 
@@ -707,12 +707,12 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 func validateOrderable(firstValue interface{}, secondValue interface{}) (float64, float64, error) {
 	convertedFirstValue, err := interfaceToFloat(firstValue)
 	if err != nil {
-		errMessage := "Value 1 is not orderable"
+		errMessage := "value 1 is not orderable"
 		return 0, 0, errors.New(errMessage)
 	}
 	convertedSecondValue, err := interfaceToFloat(secondValue)
 	if err != nil {
-		errMessage := "Value 2 is not orderable"
+		errMessage := "value 2 is not orderable"
 		return 0, 0, errors.New(errMessage)
 	}
 
@@ -809,7 +809,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlags() ([]FeatureFlag, error) {
 	_, closed := <-poller.loaded
 	if closed && poller.featureFlags == nil {
 		// There was an error with initial flag fetching
-		return nil, fmt.Errorf("Flags were not successfully fetched yet")
+		return nil, fmt.Errorf("flags were not successfully fetched yet")
 	}
 
 	return poller.featureFlags, nil

--- a/timeout_16.go
+++ b/timeout_16.go
@@ -6,6 +6,6 @@ package posthog
 import "net/http"
 
 // http clients on versions of go after 1.6 always support timeout.
-func supportsTimeout(transport http.RoundTripper) bool {
+func supportsTimeout(_ http.RoundTripper) bool {
 	return true
 }


### PR DESCRIPTION
Hello, 

I have made this PR, which introduces a few small QoL changes to the posthog-go repo:

1. [Error messages should be lowercase](https://staticcheck.dev/docs/checks#ST1005) as they are typically wrapped.
2. Use `_` for unused parameters.
3. Removed a redundant type definition.
4. Removed an unnecessary `ok` assignment on map access. 

These changes aim to improve code readability and adhere to Go best practices. Most of these were flagged by gopls.

I'd appreciate your review and feedback. Please let me know if you have any questions or suggestions for further improvements.

Thank you for your time!