### PR TITLE
feat(flags): fall back to `/decide` endpoint for `GetFeatureFlag` and `GetAllFlags` so that users can use this library without needing a personal API Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 2.0.0 - 2022-08-15
+# Changelog
+
+## 2.0.1 - 2024-08-07
+
+1. The client will fall back to the `/decide` endpoint when evaluating feature flags if the user does not wish to provide a PersonalApiKey.  This fixes an issue where users were unable to use this SDK without providing a PersonalApiKey.  This fallback will make feature flag usage less performant, but will save users money by not making them pay for public API access.
+
+## 2.0.0 - 2022-08-15
 
 Breaking changes:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ import (
 )
 
 func main() {
-    client := posthog.New(os.Getenv("POSTHOG_API_KEY"))
+    client := posthog.New(os.Getenv("POSTHOG_API_KEY")) // This value must be set to the project API key in PostHog
+    // alternatively, you can do 
+    // client, _ := posthog.NewWithConfig(
+    //     os.Getenv("POSTHOG_API_KEY"),
+    //     posthog.Config{
+    //         PersonalApiKey: "your personal API key", // Set this to your personal API token you want feature flag evaluation to be more performant.  This will incur more costs, though
+    //         Endpoint:       "https://us.i.posthog.com",
+    //     },
+    // )
     defer client.Close()
 
     // Capture an event
@@ -54,8 +62,35 @@ func main() {
       Properties: posthog.NewProperties().
         Set("$current_url", "https://example.com"),
     })
+
+    // Check if a feature flag is enabled
+    isMyFlagEnabled, err := client.IsFeatureEnabled(
+            FeatureFlagPayload{
+                Key:        "flag-key",
+                DistinctId: "distinct_id_of_your_user",
+            })
+
+    if isMyFlagEnabled == true {
+        // Do something differently for this user
+    }
 }
 
+```
+
+## Testing Locally
+
+You can run your Go app against a local build of `posthog-go` by making the following change to your `go.mod` file for whichever your app, e.g.
+
+```Go
+module example/posthog-go-app
+
+go 1.22.5
+
+require github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103
+
+require github.com/google/uuid v1.3.0 // indirect
+
+replace github.com/posthog/posthog-go => /path-to-your-local/posthog-go
 ```
 
 ## Questions?

--- a/config.go
+++ b/config.go
@@ -18,8 +18,11 @@ type Config struct {
 	// `DefaultEndpoint` by default.
 	Endpoint string
 
-	// You must specify a Personal API Key to use feature flags
-	// More information on how to get one: https://posthog.com/docs/api/overview
+	// Specifying a Personal API key will make feature flag evaluation more performant,
+	// but it's not required for feature flags.  If you don't have a personal API key,
+	// you can leave this field empty, and all of the relevant feature flag evaluation
+	// methods will still work.
+	// Information on how to get a personal API key: https://posthog.com/docs/api/overview
 	PersonalApiKey string
 
 	// The flushing interval of the client. Messages will be sent when they've

--- a/feature_flags_test.go
+++ b/feature_flags_test.go
@@ -325,7 +325,7 @@ func TestFlagGroup(t *testing.T) {
 				t.Errorf("Expected personProperties to be map[region:Canada], got %s", reqBody.PersonProperties)
 			}
 
-			groupPropertiesEquality := reflect.DeepEqual(reqBody.GroupProperties, map[string]Properties{"company": Properties{"name": "Project Name 1"}})
+			groupPropertiesEquality := reflect.DeepEqual(reqBody.GroupProperties, map[string]Properties{"company": {"name": "Project Name 1"}})
 			if !groupPropertiesEquality {
 				t.Errorf("Expected groupProperties to be map[company:map[name:Project Name 1]], got %s", reqBody.GroupProperties)
 			}

--- a/featureflags.go
+++ b/featureflags.go
@@ -311,7 +311,7 @@ func (poller *FeatureFlagsPoller) computeFlagLocally(
 		groupName, exists := poller.groups[fmt.Sprintf("%d", *flag.Filters.AggregationGroupTypeIndex)]
 
 		if !exists {
-			errMessage := "Flag has unknown group type index"
+			errMessage := "flag has unknown group type index"
 			return nil, errors.New(errMessage)
 		}
 
@@ -467,7 +467,7 @@ func matchCohort(property FlagProperty, properties Properties, cohorts map[strin
 	cohortId := fmt.Sprint(property.Value)
 	propertyGroup, ok := cohorts[cohortId]
 	if !ok {
-		return false, fmt.Errorf("Can't match cohort: cohort %s not found", cohortId)
+		return false, fmt.Errorf("can't match cohort: cohort %s not found", cohortId)
 	}
 
 	return matchPropertyGroup(propertyGroup, properties, cohorts)
@@ -578,7 +578,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 		return false, &InconclusiveMatchError{"Can't match properties with operator is_not_set"}
 	}
 
-	override_value, _ := properties[key]
+	override_value := properties[key]
 
 	if operator == "exact" {
 		switch t := value.(type) {
@@ -637,7 +637,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 			valueString = strconv.Itoa(valueInt)
 			r, err = regexp.Compile(valueString)
 		} else {
-			errMessage := "Regex expression not allowed"
+			errMessage := "regex expression not allowed"
 			return false, errors.New(errMessage)
 		}
 
@@ -653,7 +653,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 			valueString = strconv.Itoa(valueInt)
 			match = r.MatchString(valueString)
 		} else {
-			errMessage := "Value type not supported"
+			errMessage := "value type not supported"
 			return false, errors.New(errMessage)
 		}
 
@@ -707,12 +707,12 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 func validateOrderable(firstValue interface{}, secondValue interface{}) (float64, float64, error) {
 	convertedFirstValue, err := interfaceToFloat(firstValue)
 	if err != nil {
-		errMessage := "Value 1 is not orderable"
+		errMessage := "value 1 is not orderable"
 		return 0, 0, errors.New(errMessage)
 	}
 	convertedSecondValue, err := interfaceToFloat(secondValue)
 	if err != nil {
-		errMessage := "Value 2 is not orderable"
+		errMessage := "value 2 is not orderable"
 		return 0, 0, errors.New(errMessage)
 	}
 
@@ -809,7 +809,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlags() ([]FeatureFlag, error) {
 	_, closed := <-poller.loaded
 	if closed && poller.featureFlags == nil {
 		// There was an error with initial flag fetching
-		return nil, fmt.Errorf("Flags were not successfully fetched yet")
+		return nil, fmt.Errorf("flags were not successfully fetched yet")
 	}
 
 	return poller.featureFlags, nil

--- a/posthog.go
+++ b/posthog.go
@@ -305,10 +305,12 @@ func (c *client) GetFeatureFlag(flagConfig FeatureFlagPayload) (interface{}, err
 	var err error
 
 	if c.featureFlagsPoller != nil {
-		// get feature flags from the poller, which uses the personal api key
+		// get feature flag from the poller, which uses the personal api key
+		// this is only available when using a PersonalApiKey
 		flagValue, err = c.featureFlagsPoller.GetFeatureFlag(flagConfig)
 	} else {
 		// if there's no poller, get the feature flag from the decide endpoint
+		c.debugf("getting feature flag from decide endpoint")
 		flagValue, err = c.getFeatureFlagFromDecide(flagConfig.Key, flagConfig.DistinctId, flagConfig.Groups, flagConfig.PersonProperties, flagConfig.GroupProperties)
 	}
 
@@ -347,8 +349,12 @@ func (c *client) GetAllFlags(flagConfig FeatureFlagPayloadNoKey) (map[string]int
 	var err error
 
 	if c.featureFlagsPoller != nil {
+		// get feature flags from the poller, which uses the personal api key
+		// this is only available when using a PersonalApiKey
 		flagsValue, err = c.featureFlagsPoller.GetAllFlags(flagConfig)
 	} else {
+		// if there's no poller, get the feature flags from the decide endpoint
+		c.debugf("getting all feature flags from decide endpoint")
 		flagsValue, err = c.getAllFeatureFlagsFromDecide(flagConfig.DistinctId, flagConfig.Groups, flagConfig.PersonProperties, flagConfig.GroupProperties)
 	}
 


### PR DESCRIPTION
Does what it says on the tin.  I made the following changes:

- Fallback logic in `GetFeatureFlag` and `GetAllFlags` that falls back to using the `/decide` endpoint for fetching feature flags if there's no PersonalApiKey provided
- Tests for this new behavior

Potential TODOs:
- Log the fallback?
- improve error messages with missing token to tell the users they can fall back?

Other things:
- Doc update associated with these changes: https://github.com/PostHog/posthog.com/pull/9121