### PR TITLE
fix: change version from 2.0 to 1.2 (we are not on v2 yet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 2.0.1 - 2024-08-07
+## 1.2.1 - 2024-08-07
 
 1. The client will fall back to the `/decide` endpoint when evaluating feature flags if the user does not wish to provide a PersonalApiKey.  This fixes an issue where users were unable to use this SDK without providing a PersonalApiKey.  This fallback will make feature flag usage less performant, but will save users money by not making them pay for public API access.
 
-## 2.0.0 - 2022-08-15
+## 1.2.0 - 2022-08-15
 
 Breaking changes:
 

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@ package posthog
 import "flag"
 
 // Version of the client.
-const Version = "2.0.0"
+const Version = "1.2.1"
 
 // make tests easier by using a constant version
 func getVersion() string {


### PR DESCRIPTION
Golang requires a `v2` folder for major versions like `2.0.0`. We don't really want to do that yet since we are not any major versions ahead of 1.0 yet and have never really used SEMVER.

Let's just reset this to `v1.2.1`
