### PR TITLE
Better error for feature flags fetch without errors. Adds missing format string verbs to poller Errorf.

### DIFF
--- a/featureflags.go
+++ b/featureflags.go
@@ -174,19 +174,23 @@ func (poller *FeatureFlagsPoller) fetchNewFeatureFlags() {
 	res, cancel, err := poller.localEvaluationFlags(headers)
 	defer cancel()
 	if err != nil || res.StatusCode != http.StatusOK {
-		poller.Errorf("Unable to fetch feature flags", err)
+		if err != nil {
+			poller.Errorf("Unable to fetch feature flags: %s", err)
+		} else {
+			poller.Errorf("Unable to fetch feature flags, status: %s", res.Status)
+		}
 		return
 	}
 	defer res.Body.Close()
 	resBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		poller.Errorf("Unable to fetch feature flags", err)
+		poller.Errorf("Unable to fetch feature flags: %s", err)
 		return
 	}
 	featureFlagsResponse := FeatureFlagsResponse{}
 	err = json.Unmarshal([]byte(resBody), &featureFlagsResponse)
 	if err != nil {
-		poller.Errorf("Unable to unmarshal response from api/feature_flag/local_evaluation", err)
+		poller.Errorf("Unable to unmarshal response from api/feature_flag/local_evaluation: %s", err)
 		return
 	}
 	newFlags := []FeatureFlag{}


### PR DESCRIPTION
We get error responses from the API with no details about why (e.g. rate limiting) and we'd like to see that HTTP response payload appear in the error log rather than what's currently displayed:

```
ERROR: Unable to fetch feature flags%!(EXTRA <nil>)
```

Also, there were several invocations of `poller.Errorf` that were missing the Go format string verb (`%s`).