### PR TITLE
Wrap map mutations with mutex lock

### DIFF
--- a/util.go
+++ b/util.go
@@ -7,7 +7,7 @@ import (
 type SizeLimitedMap struct {
 	ids  map[string][]string
 	size int
-	mu   sync.Mutex
+	mu   sync.RWMutex
 }
 
 func newSizeLimitedMap(size int) *SizeLimitedMap {
@@ -35,6 +35,9 @@ func (sizeLimitedMap *SizeLimitedMap) add(key string, element string) {
 }
 
 func (sizeLimitedMap *SizeLimitedMap) contains(key string, element string) bool {
+	sizeLimitedMap.mu.RLock()
+	defer sizeLimitedMap.mu.RUnlock()
+
 	if val, ok := sizeLimitedMap.ids[key]; ok {
 		for _, v := range val {
 			if v == element {
@@ -47,5 +50,8 @@ func (sizeLimitedMap *SizeLimitedMap) contains(key string, element string) bool 
 }
 
 func (sizeLimitedMap *SizeLimitedMap) count() int {
+	sizeLimitedMap.mu.RLock()
+	defer sizeLimitedMap.mu.RUnlock()
+
 	return len(sizeLimitedMap.ids)
 }

--- a/util.go
+++ b/util.go
@@ -1,8 +1,13 @@
 package posthog
 
+import (
+	"sync"
+)
+
 type SizeLimitedMap struct {
 	ids  map[string][]string
 	size int
+	mu   sync.Mutex
 }
 
 func newSizeLimitedMap(size int) *SizeLimitedMap {
@@ -15,6 +20,8 @@ func newSizeLimitedMap(size int) *SizeLimitedMap {
 }
 
 func (sizeLimitedMap *SizeLimitedMap) add(key string, element string) {
+	sizeLimitedMap.mu.Lock()
+	defer sizeLimitedMap.mu.Unlock()
 
 	if len(sizeLimitedMap.ids) >= sizeLimitedMap.size {
 		sizeLimitedMap.ids = map[string][]string{}

--- a/util.go
+++ b/util.go
@@ -7,7 +7,7 @@ import (
 type SizeLimitedMap struct {
 	ids  map[string][]string
 	size int
-	mu   sync.RWMutex
+	mu   sync.Mutex
 }
 
 func newSizeLimitedMap(size int) *SizeLimitedMap {
@@ -35,8 +35,8 @@ func (sizeLimitedMap *SizeLimitedMap) add(key string, element string) {
 }
 
 func (sizeLimitedMap *SizeLimitedMap) contains(key string, element string) bool {
-	sizeLimitedMap.mu.RLock()
-	defer sizeLimitedMap.mu.RUnlock()
+	sizeLimitedMap.mu.Lock()
+	defer sizeLimitedMap.mu.Unlock()
 
 	if val, ok := sizeLimitedMap.ids[key]; ok {
 		for _, v := range val {
@@ -50,8 +50,8 @@ func (sizeLimitedMap *SizeLimitedMap) contains(key string, element string) bool 
 }
 
 func (sizeLimitedMap *SizeLimitedMap) count() int {
-	sizeLimitedMap.mu.RLock()
-	defer sizeLimitedMap.mu.RUnlock()
+	sizeLimitedMap.mu.Lock()
+	defer sizeLimitedMap.mu.Unlock()
 
 	return len(sizeLimitedMap.ids)
 }


### PR DESCRIPTION
Fixes #80 by wrapping the `add` method with a mutex lock.

Considered:
- sync.Map: felt this was a little overkill for such a simple utility.
- sync.RWMutex: it is assumed read and write frequencies are approximately the same sync.Mutex have a simpler algorithm.