### PR TITLE
fix: Do not convert string variant results into bool

### DIFF
--- a/featureflags.go
+++ b/featureflags.go
@@ -1009,10 +1009,8 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariant(featureFlag FeatureFlag,
 		}
 
 		for flagKey, flagValue := range featureFlagVariants.FeatureFlags {
-			flagValueString := fmt.Sprintf("%v", flagValue)
-			if key == flagKey && flagValueString != "false" {
-				result = flagValueString
-				break
+			if key == flagKey {
+				return flagValue, nil
 			}
 		}
 		return result, nil

--- a/posthog.go
+++ b/posthog.go
@@ -287,12 +287,6 @@ func (c *client) IsFeatureEnabled(flagConfig FeatureFlagPayload) (interface{}, e
 		return nil, err
 	}
 
-	if result == "false" {
-		result = false
-	} else if result == "true" {
-		result = true
-	}
-
 	return result, nil
 }
 

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -842,7 +842,7 @@ func TestIsFeatureEnabled(t *testing.T) {
 				DistinctId: "user789",
 			},
 			mockResponse:   `{"featureFlags": {"test-flag": "true"}}`,
-			expectedResult: true,
+			expectedResult: "true",
 		},
 		{
 			name: "Feature flag is a string 'false'",
@@ -851,7 +851,7 @@ func TestIsFeatureEnabled(t *testing.T) {
 				DistinctId: "user101",
 			},
 			mockResponse:   `{"featureFlags": {"test-flag": "false"}}`,
-			expectedResult: false,
+			expectedResult: "false",
 		},
 		{
 			name: "Feature flag is a variant string",


### PR DESCRIPTION
The words "true" and "false" are valid variant keys. It's incorrect to convert them to `true` and `false`. This could result in a case where `isEnabled` returns `false` when in fact, it's `true` but the variant selected is named "false".

This PR fixes the bug by not converting flag values from `string` to `bool`. There's also a new test to confirm this change.

The PR also makes the examples read from env vars for the project api key, personal api key, and endpoint. Makes it easier to switch between local dev and prod.

I documented these changes in the respective READMEs.