### PR TITLE
refactor: Consolidate decide code

### DIFF
--- a/decide.go
+++ b/decide.go
@@ -11,6 +11,20 @@ import (
 	"time"
 )
 
+type DecideRequestData struct {
+	ApiKey           string                `json:"api_key"`
+	DistinctId       string                `json:"distinct_id"`
+	Groups           Groups                `json:"groups"`
+	PersonProperties Properties            `json:"person_properties"`
+	GroupProperties  map[string]Properties `json:"group_properties"`
+}
+
+type DecideResponse struct {
+	FeatureFlags        map[string]interface{} `json:"featureFlags"`
+	FeatureFlagPayloads map[string]string      `json:"featureFlagPayloads"`
+	QuotaLimited        *[]string              `json:"quota_limited"`
+}
+
 // decider defines the interface for making decide requests
 type decider interface {
 	makeDecideRequest(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (*DecideResponse, error)

--- a/decide.go
+++ b/decide.go
@@ -1,0 +1,96 @@
+package posthog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// decider defines the interface for making decide requests
+type decider interface {
+	makeDecideRequest(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (*DecideResponse, error)
+}
+
+// decideClient implements the decider interface
+type decideClient struct {
+	apiKey                    string
+	endpoint                  string
+	http                      http.Client
+	featureFlagRequestTimeout time.Duration
+	errorf                    func(format string, args ...interface{})
+}
+
+// newDecideClient creates a new decideClient
+func newDecideClient(apiKey string, endpoint string, httpClient http.Client, featureFlagRequestTimeout time.Duration, errorf func(format string, args ...interface{})) *decideClient {
+	return &decideClient{
+		apiKey:                    apiKey,
+		endpoint:                  endpoint,
+		http:                      httpClient,
+		featureFlagRequestTimeout: featureFlagRequestTimeout,
+		errorf:                    errorf,
+	}
+}
+
+// makeDecideRequest makes a request to the decide endpoint and deserializes the response
+// into a DecideResponse struct.
+func (d *decideClient) makeDecideRequest(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (*DecideResponse, error) {
+	requestData := DecideRequestData{
+		ApiKey:           d.apiKey,
+		DistinctId:       distinctId,
+		Groups:           groups,
+		PersonProperties: personProperties,
+		GroupProperties:  groupProperties,
+	}
+
+	requestDataBytes, err := json.Marshal(requestData)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal decide endpoint request data: %v", err)
+	}
+
+	decideEndpoint := "decide/?v=3"
+	url, err := url.Parse(d.endpoint + "/" + decideEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("creating url: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", url.String(), bytes.NewReader(requestDataBytes))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "posthog-go/"+Version)
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), d.featureFlagRequestTimeout)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	res, err := d.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code from /decide/: %d", res.StatusCode)
+	}
+
+	resBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from /decide/: %v", err)
+	}
+
+	var decideResponse DecideResponse
+	err = json.Unmarshal(resBody, &decideResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response from /decide/: %v", err)
+	}
+
+	return &decideResponse, nil
+}

--- a/decide.go
+++ b/decide.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -81,7 +81,7 @@ func (d *decideClient) makeDecideRequest(distinctId string, groups Groups, perso
 		return nil, fmt.Errorf("unexpected status code from /decide/: %d", res.StatusCode)
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response from /decide/: %v", err)
 	}

--- a/featureflags.go
+++ b/featureflags.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -202,7 +202,7 @@ func (poller *FeatureFlagsPoller) fetchNewFeatureFlags() {
 	}
 
 	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		poller.Errorf("Unable to fetch feature flags: %s", err)
 		return

--- a/featureflags.go
+++ b/featureflags.go
@@ -865,17 +865,6 @@ func (poller *FeatureFlagsPoller) GetFeatureFlags() ([]FeatureFlag, error) {
 	return poller.featureFlags, nil
 }
 
-func (poller *FeatureFlagsPoller) decide(requestData []byte, headers [][2]string) (*http.Response, context.CancelFunc, error) {
-	decideEndpoint := "decide/?v=3"
-
-	url, err := url.Parse(poller.Endpoint + "/" + decideEndpoint + "")
-	if err != nil {
-		poller.Errorf("creating url - %s", err)
-	}
-
-	return poller.request("POST", url, requestData, headers, poller.flagTimeout)
-}
-
 func (poller *FeatureFlagsPoller) localEvaluationFlags(headers [][2]string) (*http.Response, context.CancelFunc, error) {
 	localEvaluationEndpoint := "api/feature_flag/local_evaluation"
 

--- a/featureflags.go
+++ b/featureflags.go
@@ -95,20 +95,6 @@ type FeatureFlagsResponse struct {
 	Cohorts          map[string]PropertyGroup `json:"cohorts"`
 }
 
-type DecideRequestData struct {
-	ApiKey           string                `json:"api_key"`
-	DistinctId       string                `json:"distinct_id"`
-	Groups           Groups                `json:"groups"`
-	PersonProperties Properties            `json:"person_properties"`
-	GroupProperties  map[string]Properties `json:"group_properties"`
-}
-
-type DecideResponse struct {
-	FeatureFlags        map[string]interface{} `json:"featureFlags"`
-	FeatureFlagPayloads map[string]string      `json:"featureFlagPayloads"`
-	QuotaLimited        *[]string              `json:"quota_limited"`
-}
-
 type InconclusiveMatchError struct {
 	msg string
 }

--- a/featureflags.go
+++ b/featureflags.go
@@ -126,6 +126,7 @@ func newFeatureFlagsPoller(
 	pollingInterval time.Duration,
 	nextPollTick func() time.Duration,
 	flagTimeout time.Duration,
+	decider decider,
 ) *FeatureFlagsPoller {
 	if nextPollTick == nil {
 		nextPollTick = func() time.Duration { return pollingInterval }
@@ -143,7 +144,7 @@ func newFeatureFlagsPoller(
 		mutex:          sync.RWMutex{},
 		nextPollTick:   nextPollTick,
 		flagTimeout:    flagTimeout,
-		decider:        newDecideClient(projectApiKey, endpoint, httpClient, flagTimeout, errorf),
+		decider:        decider,
 	}
 
 	go poller.run()

--- a/featureflags.go
+++ b/featureflags.go
@@ -35,7 +35,6 @@ type FeatureFlagsPoller struct {
 	mutex          sync.RWMutex
 	nextPollTick   func() time.Duration
 	flagTimeout    time.Duration
-	client         *client
 	decider        decider
 }
 
@@ -132,20 +131,6 @@ func newFeatureFlagsPoller(
 		nextPollTick = func() time.Duration { return pollingInterval }
 	}
 
-	client := &client{
-		Config: Config{
-			PersonalApiKey:            personalApiKey,
-			Endpoint:                  endpoint,
-			FeatureFlagRequestTimeout: flagTimeout,
-		},
-		key:                             projectApiKey,
-		msgs:                            make(chan APIMessage, 100),
-		quit:                            make(chan struct{}),
-		shutdown:                        make(chan struct{}),
-		http:                            httpClient,
-		distinctIdsFeatureFlagsReported: newSizeLimitedMap(SIZE_DEFAULT),
-	}
-
 	poller := FeatureFlagsPoller{
 		loaded:         make(chan bool),
 		shutdown:       make(chan bool),
@@ -158,7 +143,6 @@ func newFeatureFlagsPoller(
 		mutex:          sync.RWMutex{},
 		nextPollTick:   nextPollTick,
 		flagTimeout:    flagTimeout,
-		client:         client,
 		decider:        newDecideClient(projectApiKey, endpoint, httpClient, flagTimeout, errorf),
 	}
 

--- a/posthog.go
+++ b/posthog.go
@@ -143,6 +143,7 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 			c.DefaultFeatureFlagsPollingInterval,
 			c.NextFeatureFlagsPollingTick,
 			c.FeatureFlagRequestTimeout,
+			c.decider,
 		)
 	}
 

--- a/posthog.go
+++ b/posthog.go
@@ -96,6 +96,9 @@ type client struct {
 	lastCapturedEvent *Capture
 	// Mutex to protect last captured event
 	lastEventMutex sync.RWMutex
+
+	// Decider for feature flag methods
+	decider decider
 }
 
 // Instantiate a new client that uses the write key passed as first argument to
@@ -117,8 +120,9 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 		return
 	}
 
+	config = makeConfig(config)
 	c := &client{
-		Config:                          makeConfig(config),
+		Config:                          config,
 		key:                             apiKey,
 		msgs:                            make(chan APIMessage, 100),
 		quit:                            make(chan struct{}),
@@ -126,6 +130,8 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 		http:                            makeHttpClient(config.Transport),
 		distinctIdsFeatureFlagsReported: newSizeLimitedMap(SIZE_DEFAULT),
 	}
+
+	c.decider = newDecideClient(apiKey, config.Endpoint, c.http, config.FeatureFlagRequestTimeout, c.Errorf)
 
 	if len(c.PersonalApiKey) > 0 {
 		c.featureFlagsPoller = newFeatureFlagsPoller(
@@ -359,6 +365,9 @@ func (c *client) GetRemoteConfigPayload(flagKey string) (string, error) {
 	return c.makeRemoteConfigRequest(flagKey)
 }
 
+// GetFeatureFlags returns all feature flag definitions used for local evaluation
+// This is only available when using a PersonalApiKey. Not to be confused with
+// GetAllFlags, which returns all flags and their values for a given user.
 func (c *client) GetFeatureFlags() ([]FeatureFlag, error) {
 	if c.featureFlagsPoller == nil {
 		errorMessage := "specifying a PersonalApiKey is required for using feature flags"
@@ -368,8 +377,11 @@ func (c *client) GetFeatureFlags() ([]FeatureFlag, error) {
 	return c.featureFlagsPoller.GetFeatureFlags()
 }
 
+// GetAllFlags returns all flags and their values for a given user
+// A flag value is either a boolean or a variant string (for multivariate flags)
+// This first attempts local evaluation if a poller exists, otherwise it falls
+// back to the decide endpoint
 func (c *client) GetAllFlags(flagConfig FeatureFlagPayloadNoKey) (map[string]interface{}, error) {
-
 	if err := flagConfig.validate(); err != nil {
 		return nil, err
 	}
@@ -628,58 +640,6 @@ func (c *client) getFeatureVariants(distinctId string, groups Groups, personProp
 	return featureVariants.FeatureFlags, nil
 }
 
-func (c *client) makeDecideRequest(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (*DecideResponse, error) {
-	requestData := DecideRequestData{
-		ApiKey:           c.key,
-		DistinctId:       distinctId,
-		Groups:           groups,
-		PersonProperties: personProperties,
-		GroupProperties:  groupProperties,
-	}
-
-	requestDataBytes, err := json.Marshal(requestData)
-	if err != nil {
-		return nil, fmt.Errorf("unable to marshal decide endpoint request data: %v", err)
-	}
-
-	decideEndpoint := "decide/?v=3"
-	url, err := url.Parse(c.Endpoint + "/" + decideEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("creating url: %v", err)
-	}
-
-	req, err := http.NewRequest("POST", url.String(), bytes.NewReader(requestDataBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %v", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "posthog-go/"+Version)
-
-	res, err := c.http.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %v", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code from /decide/: %d", res.StatusCode)
-	}
-
-	resBody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response from /decide/: %v", err)
-	}
-
-	var decideResponse DecideResponse
-	err = json.Unmarshal(resBody, &decideResponse)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing response from /decide/: %v", err)
-	}
-
-	return &decideResponse, nil
-}
-
 func (c *client) makeRemoteConfigRequest(flagKey string) (string, error) {
 	remoteConfigEndpoint := fmt.Sprintf("api/projects/@current/feature_flags/%s/remote_config/", flagKey)
 	url, err := url.Parse(c.Endpoint + "/" + remoteConfigEndpoint)
@@ -732,7 +692,7 @@ func (c *client) isFeatureFlagsQuotaLimited(decideResponse *DecideResponse) bool
 }
 
 func (c *client) getFeatureFlagFromDecide(key string, distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (interface{}, error) {
-	decideResponse, err := c.makeDecideRequest(distinctId, groups, personProperties, groupProperties)
+	decideResponse, err := c.decider.makeDecideRequest(distinctId, groups, personProperties, groupProperties)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +709,7 @@ func (c *client) getFeatureFlagFromDecide(key string, distinctId string, groups 
 }
 
 func (c *client) getFeatureFlagPayloadFromDecide(key string, distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (string, error) {
-	decideResponse, err := c.makeDecideRequest(distinctId, groups, personProperties, groupProperties)
+	decideResponse, err := c.decider.makeDecideRequest(distinctId, groups, personProperties, groupProperties)
 	if err != nil {
 		return "", err
 	}
@@ -766,7 +726,7 @@ func (c *client) getFeatureFlagPayloadFromDecide(key string, distinctId string, 
 }
 
 func (c *client) getAllFeatureFlagsFromDecide(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (map[string]interface{}, error) {
-	decideResponse, err := c.makeDecideRequest(distinctId, groups, personProperties, groupProperties)
+	decideResponse, err := c.decider.makeDecideRequest(distinctId, groups, personProperties, groupProperties)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There were two implementations of decide. That's not the end of the world, but I'm about to implement a new decide format (`/decide?v=4`) and I don't want to have to do it in two places.

So this adds a new file `decide.go` with a new interface `decider` and an implementation `decideClient` that both `Client` and `FeatureFlagsPoller` uses.