### PR TITLE
Add some development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ make dependencies
 
 # Run tests and build
 make build
+
+# Just run tests
+make test
 ```
 
 ## Testing Locally

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Please see the main [PostHog docs](https://posthog.com/docs).
 
 Specifically, the [Go integration](https://posthog.com/docs/integrations/go-integration) details.
 
-# Quickstart
+## Quickstart
 
 Install posthog to your gopath
+
 ```bash
 $ go get github.com/posthog/posthog-go
 ```
 
 Go 🦔!
+
 ```go
 package main
 
@@ -86,7 +88,20 @@ func main() {
         // Do something differently for this user
     }
 }
+```
 
+## Development
+
+Make sure you have Go installed (macOS: `brew install go`, Linx / Windows: https://go.dev/doc/install).
+
+To build the project:
+
+```bash
+# Install dependencies
+make dependencies
+
+# Run tests and build
+make build
 ```
 
 ## Testing Locally
@@ -104,6 +119,49 @@ require github.com/google/uuid v1.3.0 // indirect
 
 replace github.com/posthog/posthog-go => /path-to-your-local/posthog-go
 ```
+
+## Examples
+
+Check out the [examples](examples/README.md) for more detailed examples of how to use the PostHog Go client.
+
+## Running the examples
+
+The examples demonstrate different features of the PostHog Go client. To run all examples:
+
+```bash
+# Set your PostHog API keys and endpoint (optional)
+export POSTHOG_PROJECT_API_KEY="your-project-api-key"
+export POSTHOG_PERSONAL_API_KEY="your-personal-api-key"
+export POSTHOG_ENDPOINT="https://app.posthog.com"  # Optional, defaults to http://localhost:8000
+
+# Run all examples
+go run examples/*.go
+```
+
+This will run:
+- Feature flags example
+- Capture events example
+- Capture events with feature flag options example
+
+### Prerequisites
+
+Before running the examples, you'll need to:
+
+1. Have a PostHog instance running (default: http://localhost:8000)
+   - You can modify the endpoint by setting the `POSTHOG_ENDPOINT` environment variable
+   - If not set, it defaults to "http://localhost:8000"
+
+2. Set up the following feature flags in your PostHog instance:
+   - `multivariate-test` (a multivariate flag)
+   - `simple-test` (a simple boolean flag)
+   - `multivariate-simple-test` (a multivariate flag)
+   - `my_secret_flag_value` (a remote config flag with string payload)
+   - `my_secret_flag_json_object_value` (a remote config flag with JSON object payload)
+   - `my_secret_flag_json_array_value` (a remote config flag with JSON array payload)
+
+3. Set your PostHog API keys as environment variables:
+   - `POSTHOG_PROJECT_API_KEY`: Your project API key (starts with `phc_...`)
+   - `POSTHOG_PERSONAL_API_KEY`: Your personal API key (starts with `phx_...`)
 
 ## Questions?
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,39 @@
+# PostHog Go Examples
+
+The examples demonstrate different features of the PostHog Go client.
+
 ## Running the examples
 
-1. `go run *.go`
+```bash
+# Set your PostHog API keys
+export POSTHOG_PROJECT_API_KEY="your-project-api-key"
+export POSTHOG_PERSONAL_API_KEY="your-personal-api-key"
+
+# Run all examples
+go run *.go
+```
+
+This will run:
+
+- Feature flags example
+- Capture events example
+- Capture events with feature flag options example
+
+### Prerequisites
+
+Before running the examples, you'll need to:
+
+1. Have a PostHog instance running (default: http://localhost:8000)
+   - You can modify the endpoint in the example code if your instance is running elsewhere
+
+2. Set up the following feature flags in your PostHog instance:
+   - `multivariate-test` (a multivariate flag)
+   - `simple-test` (a simple boolean flag)
+   - `multivariate-simple-test` (a multivariate flag)
+   - `my_secret_flag_value` (a remote config flag with string payload)
+   - `my_secret_flag_json_object_value` (a remote config flag with JSON object payload)
+   - `my_secret_flag_json_array_value` (a remote config flag with JSON array payload)
+
+3. Set your PostHog API keys as environment variables:
+   - `POSTHOG_PROJECT_API_KEY`: Your project API key (starts with `phc_...`)
+   - `POSTHOG_PERSONAL_API_KEY`: Your personal API key (starts with `phx_...`)

--- a/examples/capture.go
+++ b/examples/capture.go
@@ -7,12 +7,12 @@ import (
 	"github.com/posthog/posthog-go"
 )
 
-func TestCapture() {
-	// Tests against "Testing" project in app.posthog.com
-	client, _ := posthog.NewWithConfig("phc_X8B6bhR1QgQKP1WdpFLN82LxLxgZ7WPXDgJyRyvIpib", posthog.Config{
+func TestCapture(projectAPIKey, endpoint string) {
+	client, _ := posthog.NewWithConfig(projectAPIKey, posthog.Config{
 		Interval:  30 * time.Second,
 		BatchSize: 100,
 		Verbose:   true,
+		Endpoint:  endpoint,
 	})
 	defer client.Close()
 
@@ -42,12 +42,13 @@ func TestCapture() {
 	}
 }
 
-func TestCaptureWithSendFeatureFlagOption() {
-	client, _ := posthog.NewWithConfig("phc_X8B6bhR1QgQKP1WdpFLN82LxLxgZ7WPXDgJyRyvIpib", posthog.Config{
+func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoint string) {
+	client, _ := posthog.NewWithConfig(projectAPIKey, posthog.Config{
 		Interval:       30 * time.Second,
 		BatchSize:      100,
 		Verbose:        true,
-		PersonalApiKey: "a secret key",
+		PersonalApiKey: personalAPIKey,
+		Endpoint:       endpoint,
 	})
 	defer client.Close()
 

--- a/examples/featureflags.go
+++ b/examples/featureflags.go
@@ -8,13 +8,13 @@ import (
 	"github.com/posthog/posthog-go"
 )
 
-func TestIsFeatureEnabled() {
-	client, _ := posthog.NewWithConfig("phc_36WfBWNJEQcYotMZ7Ui7EWzqKLbIo2LWJFG5fIg1EER", posthog.Config{
+func TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint string) {
+	client, _ := posthog.NewWithConfig(projectAPIKey, posthog.Config{
 		Interval:                           30 * time.Second,
 		BatchSize:                          100,
 		Verbose:                            true,
-		PersonalApiKey:                     "phx_DvugINPCOSM3Ko929TaeywnUlRC5FeF4X7KV60IgyXWGTLw",
-		Endpoint:                           "http://localhost:8000",
+		PersonalApiKey:                     personalAPIKey,
+		Endpoint:                           endpoint,
 		DefaultFeatureFlagsPollingInterval: 5 * time.Second,
 		FeatureFlagRequestTimeout:          3 * time.Second,
 	})

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,7 +1,40 @@
 package main
 
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var (
+	projectAPIKey  = os.Getenv("POSTHOG_PROJECT_API_KEY")
+	personalAPIKey = os.Getenv("POSTHOG_PERSONAL_API_KEY")
+	endpoint       = os.Getenv("POSTHOG_ENDPOINT")
+)
+
+func init() {
+	if endpoint == "" {
+		endpoint = "http://localhost:8000"
+	}
+}
+
+func promptForInput(prompt string) string {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	return strings.TrimSpace(input)
+}
+
 func main() {
-	TestCapture()
-	TestCaptureWithSendFeatureFlagOption()
-	TestIsFeatureEnabled()
+	if projectAPIKey == "" {
+		projectAPIKey = promptForInput("Enter your PostHog project API key (starts with phc_): ")
+	}
+	if personalAPIKey == "" {
+		personalAPIKey = promptForInput("Enter your PostHog personal API key (starts with phx_): ")
+	}
+
+	TestCapture(projectAPIKey, endpoint)
+	TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoint)
+	TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint)
 }


### PR DESCRIPTION
And improve how we run the examples. They now can read project (and personal) api keys from env vars. If not present, they'll prompt for them.