### PR TITLE
feat: add DisableGeoIP option

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -10,9 +10,10 @@ type Alias struct {
 	// the application, its value is always overwritten by the library.
 	Type string
 
-	Alias      string
-	DistinctId string
-	Timestamp  time.Time
+	Alias        string
+	DistinctId   string
+	Timestamp    time.Time
+	DisableGeoIP bool
 }
 
 func (msg Alias) internal() {
@@ -40,10 +41,11 @@ func (msg Alias) Validate() error {
 }
 
 type AliasInApiProperties struct {
-	DistinctId string `json:"distinct_id"`
-	Alias      string `json:"alias"`
-	Lib        string `json:"$lib"`
-	LibVersion string `json:"$lib_version"`
+	DistinctId   string `json:"distinct_id"`
+	Alias        string `json:"alias"`
+	Lib          string `json:"$lib"`
+	LibVersion   string `json:"$lib_version"`
+	DisableGeoIP bool   `json:"$geoip_disable,omitempty"`
 }
 
 type AliasInApi struct {
@@ -67,10 +69,11 @@ func (msg Alias) APIfy() APIMessage {
 		LibraryVersion: libraryVersion,
 		Timestamp:      msg.Timestamp,
 		Properties: AliasInApiProperties{
-			DistinctId: msg.DistinctId,
-			Alias:      msg.Alias,
-			Lib:        SDKName,
-			LibVersion: libraryVersion,
+			DistinctId:   msg.DistinctId,
+			Alias:        msg.Alias,
+			Lib:          SDKName,
+			LibVersion:   libraryVersion,
+			DisableGeoIP: msg.DisableGeoIP,
 		},
 	}
 

--- a/alias.go
+++ b/alias.go
@@ -58,19 +58,18 @@ type AliasInApi struct {
 }
 
 func (msg Alias) APIfy() APIMessage {
-	library := "posthog-go"
 	libraryVersion := getVersion()
 
 	apified := AliasInApi{
 		Type:           msg.Type,
 		Event:          "$create_alias",
-		Library:        library,
+		Library:        SDKName,
 		LibraryVersion: libraryVersion,
 		Timestamp:      msg.Timestamp,
 		Properties: AliasInApiProperties{
 			DistinctId: msg.DistinctId,
 			Alias:      msg.Alias,
-			Lib:        library,
+			Lib:        SDKName,
 			LibVersion: libraryVersion,
 		},
 	}

--- a/capture.go
+++ b/capture.go
@@ -58,10 +58,9 @@ type CaptureInApi struct {
 }
 
 func (msg Capture) APIfy() APIMessage {
-	library := "posthog-go"
 	libraryVersion := getVersion()
 
-	myProperties := Properties{}.Set("$lib", library).Set("$lib_version", libraryVersion)
+	myProperties := Properties{}.Set("$lib", SDKName).Set("$lib_version", libraryVersion)
 
 	if msg.Properties != nil {
 		for k, v := range msg.Properties {
@@ -76,7 +75,7 @@ func (msg Capture) APIfy() APIMessage {
 	apified := CaptureInApi{
 		Type:           msg.Type,
 		Uuid:           msg.Uuid,
-		Library:        library,
+		Library:        SDKName,
 		LibraryVersion: libraryVersion,
 		Timestamp:      msg.Timestamp,
 		DistinctId:     msg.DistinctId,

--- a/config.go
+++ b/config.go
@@ -23,6 +23,10 @@ type Config struct {
 	// Information on how to get a personal API key: https://posthog.com/docs/api/overview
 	PersonalApiKey string
 
+	// DisableGeoIP will disable GeoIP lookup for events
+	// and when fetching feature flags
+	DisableGeoIP bool
+
 	// The flushing interval of the client. Messages will be sent when they've
 	// been queued up to the maximum batch size or when the flushing interval
 	// timer triggers.
@@ -175,6 +179,12 @@ func makeConfig(c Config) Config {
 
 	if c.maxConcurrentRequests == 0 {
 		c.maxConcurrentRequests = 1000
+	}
+
+	if c.DisableGeoIP {
+		if c.DefaultEventProperties == nil {
+			c.DefaultEventProperties = NewProperties().Set(geoipDisableProperty, true)
+		}
 	}
 
 	return c

--- a/config.go
+++ b/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Instances of this type carry the different configuration options that may
+// Config carries the different configuration options that may
 // be set when instantiating a client.
 //
 // Each field's zero-value is either meaningful or interpreted as using the
@@ -101,25 +101,27 @@ func (c Config) GetDisableGeoIP() bool {
 	return c.DisableGeoIP == nil || *c.DisableGeoIP
 }
 
-const SdkName = "posthog-go"
+const (
+	SdkName = "posthog-go"
 
-// This constant sets the default endpoint to which client instances send
-// messages if none was explictly set.
-const DefaultEndpoint = "https://app.posthog.com"
+	// DefaultEndpoint constant sets the default endpoint to which client instances send
+	// messages if none was explicitly set.
+	DefaultEndpoint = "https://app.posthog.com"
 
-// This constant sets the default flush interval used by client instances if
-// none was explicitly set.
-const DefaultInterval = 5 * time.Second
+	// DefaultInterval constant sets the default flush interval used by client instances if
+	// none was explicitly set.
+	DefaultInterval = 5 * time.Second
 
-// Specifies the default interval at which to fetch new feature flags
-const DefaultFeatureFlagsPollingInterval = 5 * time.Minute
+	// DefaultFeatureFlagsPollingInterval the default interval at which to fetch new feature flags
+	DefaultFeatureFlagsPollingInterval = 5 * time.Minute
 
-// Specifies the default timeout for fetching feature flags
-const DefaultFeatureFlagRequestTimeout = 3 * time.Second
+	// DefaultFeatureFlagRequestTimeout the default timeout for fetching feature flags
+	DefaultFeatureFlagRequestTimeout = 3 * time.Second
 
-// This constant sets the default batch size used by client instances if none
-// was explicitly set.
-const DefaultBatchSize = 250
+	// DefaultBatchSize sets the default batch size used by client instances if none
+	// was explicitly set.
+	DefaultBatchSize = 250
+)
 
 // Verifies that fields that don't have zero-values are set to valid values,
 // returns an error describing the problem if a field was invalid.
@@ -186,7 +188,7 @@ func makeConfig(c Config) Config {
 		c.maxConcurrentRequests = 1000
 	}
 
-	if c.DisableGeoIP == nil || *c.DisableGeoIP {
+	if c.GetDisableGeoIP() {
 		if c.DefaultEventProperties == nil {
 			c.DefaultEventProperties = NewProperties()
 		}

--- a/config.go
+++ b/config.go
@@ -102,7 +102,7 @@ func (c Config) GetDisableGeoIP() bool {
 }
 
 const (
-	SdkName = "posthog-go"
+	SDKName = "posthog-go"
 
 	// DefaultEndpoint constant sets the default endpoint to which client instances send
 	// messages if none was explicitly set.

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package posthog
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
@@ -43,4 +44,17 @@ func TestConfigInvalidBatchSize(t *testing.T) {
 	} else if e.Field != "BatchSize" || e.Value.(int) != -1 {
 		t.Error("invalid field error reported:", e)
 	}
+}
+
+func TestConfigGetDisableGeoIP(t *testing.T) {
+	var (
+		c  Config
+		tv = true
+		fv = false
+	)
+	require.True(t, c.GetDisableGeoIP())
+	c.DisableGeoIP = &tv
+	require.True(t, c.GetDisableGeoIP())
+	c.DisableGeoIP = &fv
+	require.False(t, c.GetDisableGeoIP())
 }

--- a/featureflags.go
+++ b/featureflags.go
@@ -885,7 +885,7 @@ func (poller *FeatureFlagsPoller) request(method string, url *url.URL, requestDa
 
 	version := getVersion()
 
-	req.Header.Add("User-Agent", SdkName+"/"+version)
+	req.Header.Add("User-Agent", SDKName+"/"+version)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Content-Length", fmt.Sprintf("%d", len(requestData)))
 

--- a/fixtures/test-enqueue-alias.json
+++ b/fixtures/test-enqueue-alias.json
@@ -6,6 +6,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "alias": "A",

--- a/fixtures/test-enqueue-capture-with-disable-geoip.json
+++ b/fixtures/test-enqueue-capture-with-disable-geoip.json
@@ -1,0 +1,23 @@
+{
+  "api_key": "Csyjlnlun3OzyNJAafdlv",
+  "batch": [
+    {
+      "distinct_id": "123456",
+      "event": "Download",
+      "library": "posthog-go",
+      "library_version": "1.0.0",
+      "properties": {
+        "$geoip_disable": true,
+        "$lib": "posthog-go",
+        "$lib_version": "1.0.0",
+        "application": "PostHog Go",
+        "platform": "macos",
+        "version": "1.0.0"
+      },
+      "send_feature_flags": false,
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "capture",
+      "uuid": ""
+    }
+  ]
+}

--- a/fixtures/test-enqueue-capture-with-uuid.json
+++ b/fixtures/test-enqueue-capture-with-uuid.json
@@ -7,6 +7,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "application": "PostHog Go",

--- a/fixtures/test-enqueue-group-identify.json
+++ b/fixtures/test-enqueue-group-identify.json
@@ -7,6 +7,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$group_key": "id:5",
         "$group_set": {},
         "$group_type": "organization",

--- a/fixtures/test-enqueue-identify.json
+++ b/fixtures/test-enqueue-identify.json
@@ -10,6 +10,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0"
       },

--- a/fixtures/test-interval-capture.json
+++ b/fixtures/test-interval-capture.json
@@ -7,6 +7,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "application": "PostHog Go",

--- a/fixtures/test-many-capture.json
+++ b/fixtures/test-many-capture.json
@@ -7,6 +7,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "application": "PostHog Go",
@@ -23,6 +24,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "application": "PostHog Go",
@@ -39,6 +41,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "application": "PostHog Go",

--- a/fixtures/test-merge-capture.json
+++ b/fixtures/test-merge-capture.json
@@ -7,6 +7,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "application": "PostHog Go",

--- a/fixtures/test-timestamp-capture.json
+++ b/fixtures/test-timestamp-capture.json
@@ -7,6 +7,7 @@
       "library": "posthog-go",
       "library_version": "1.0.0",
       "properties": {
+        "$geoip_disable": true,
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
         "application": "PostHog Go",

--- a/flags.go
+++ b/flags.go
@@ -17,6 +17,7 @@ type FlagsRequestData struct {
 	Groups           Groups                `json:"groups"`
 	PersonProperties Properties            `json:"person_properties"`
 	GroupProperties  map[string]Properties `json:"group_properties"`
+	DisableGeoIP     bool                  `json:"geoip_disable"`
 }
 
 // FlagDetail represents a feature flag in v4 format
@@ -154,7 +155,8 @@ func (r *FlagsResponse) UnmarshalJSON(data []byte) error {
 
 // decider defines the interface for making flags requests
 type decider interface {
-	makeFlagsRequest(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (*FlagsResponse, error)
+	makeFlagsRequest(distinctId string, groups Groups, personProperties Properties,
+		groupProperties map[string]Properties, disableGeoIP bool) (*FlagsResponse, error)
 }
 
 // flagsClient implements the decider interface
@@ -167,7 +169,9 @@ type flagsClient struct {
 }
 
 // newFlagsClient creates a new flagsClient
-func newFlagsClient(apiKey string, endpoint string, httpClient http.Client, featureFlagRequestTimeout time.Duration, errorf func(format string, args ...interface{})) *flagsClient {
+func newFlagsClient(apiKey string, endpoint string, httpClient http.Client, featureFlagRequestTimeout time.Duration,
+	errorf func(format string, args ...interface{})) *flagsClient {
+
 	return &flagsClient{
 		apiKey:                    apiKey,
 		endpoint:                  endpoint,
@@ -179,13 +183,15 @@ func newFlagsClient(apiKey string, endpoint string, httpClient http.Client, feat
 
 // makeFlagsRequest makes a request to the flags endpoint and deserializes the response
 // into a FlagsResponse struct.
-func (d *flagsClient) makeFlagsRequest(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (*FlagsResponse, error) {
+func (d *flagsClient) makeFlagsRequest(distinctId string, groups Groups, personProperties Properties,
+	groupProperties map[string]Properties, disableGeoIP bool) (*FlagsResponse, error) {
 	requestData := FlagsRequestData{
 		ApiKey:           d.apiKey,
 		DistinctId:       distinctId,
 		Groups:           groups,
 		PersonProperties: personProperties,
 		GroupProperties:  groupProperties,
+		DisableGeoIP:     disableGeoIP,
 	}
 
 	requestDataBytes, err := json.Marshal(requestData)

--- a/flags.go
+++ b/flags.go
@@ -17,7 +17,7 @@ type FlagsRequestData struct {
 	Groups           Groups                `json:"groups"`
 	PersonProperties Properties            `json:"person_properties"`
 	GroupProperties  map[string]Properties `json:"group_properties"`
-	DisableGeoIP     bool                  `json:"geoip_disable"`
+	DisableGeoIP     bool                  `json:"geoip_disable,omitempty"`
 }
 
 // FlagDetail represents a feature flag in v4 format

--- a/group_identify.go
+++ b/group_identify.go
@@ -49,9 +49,7 @@ type GroupIdentifyInApi struct {
 }
 
 func (msg GroupIdentify) APIfy() APIMessage {
-	library := "posthog-go"
-
-	myProperties := Properties{}.Set("$lib", library).Set("$lib_version", getVersion())
+	myProperties := Properties{}.Set("$lib", SDKName).Set("$lib_version", getVersion())
 	myProperties.Set("$group_type", msg.Type).Set("$group_key", msg.Key).Set("$group_set", msg.Properties)
 
 	distinctId := fmt.Sprintf("$%s_%s", msg.Type, msg.Key)
@@ -61,7 +59,7 @@ func (msg GroupIdentify) APIfy() APIMessage {
 		Properties:     myProperties,
 		DistinctId:     distinctId,
 		Timestamp:      msg.Timestamp,
-		Library:        library,
+		Library:        SDKName,
 		LibraryVersion: getVersion(),
 	}
 

--- a/group_identify.go
+++ b/group_identify.go
@@ -9,9 +9,10 @@ type GroupIdentify struct {
 	Type string
 	Key  string
 
-	DistinctId string
-	Timestamp  time.Time
-	Properties Properties
+	DistinctId   string
+	Timestamp    time.Time
+	Properties   Properties
+	DisableGeoIP bool
 }
 
 func (msg GroupIdentify) internal() {
@@ -49,8 +50,16 @@ type GroupIdentifyInApi struct {
 }
 
 func (msg GroupIdentify) APIfy() APIMessage {
-	myProperties := Properties{}.Set("$lib", SDKName).Set("$lib_version", getVersion())
-	myProperties.Set("$group_type", msg.Type).Set("$group_key", msg.Key).Set("$group_set", msg.Properties)
+	myProperties := Properties{}.
+		Set("$lib", SDKName).
+		Set("$lib_version", getVersion()).
+		Set("$group_type", msg.Type).
+		Set("$group_key", msg.Key).
+		Set("$group_set", msg.Properties)
+
+	if msg.DisableGeoIP {
+		myProperties.Set(propertyGeoipDisable, true)
+	}
 
 	distinctId := fmt.Sprintf("$%s_%s", msg.Type, msg.Key)
 

--- a/identify.go
+++ b/identify.go
@@ -10,9 +10,10 @@ type Identify struct {
 	// the application, its value is always overwritten by the library.
 	Type string
 
-	DistinctId string
-	Timestamp  time.Time
-	Properties Properties
+	DistinctId   string
+	Timestamp    time.Time
+	Properties   Properties
+	DisableGeoIP bool
 }
 
 func (msg Identify) internal() {
@@ -45,6 +46,9 @@ type IdentifyInApi struct {
 
 func (msg Identify) APIfy() APIMessage {
 	myProperties := Properties{}.Set("$lib", SDKName).Set("$lib_version", getVersion())
+	if msg.DisableGeoIP {
+		myProperties.Set(propertyGeoipDisable, true)
+	}
 
 	apified := IdentifyInApi{
 		Type:           msg.Type,

--- a/identify.go
+++ b/identify.go
@@ -44,14 +44,12 @@ type IdentifyInApi struct {
 }
 
 func (msg Identify) APIfy() APIMessage {
-	library := "posthog-go"
-
-	myProperties := Properties{}.Set("$lib", library).Set("$lib_version", getVersion())
+	myProperties := Properties{}.Set("$lib", SDKName).Set("$lib_version", getVersion())
 
 	apified := IdentifyInApi{
 		Type:           msg.Type,
 		Event:          "$identify",
-		Library:        library,
+		Library:        SDKName,
 		LibraryVersion: getVersion(),
 		Timestamp:      msg.Timestamp,
 		DistinctId:     msg.DistinctId,

--- a/posthog.go
+++ b/posthog.go
@@ -218,15 +218,18 @@ func (c *client) Enqueue(msg Message) (err error) {
 	case Alias:
 		m.Type = "alias"
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
+		m.DisableGeoIP = c.GetDisableGeoIP()
 		msg = m
 
 	case Identify:
 		m.Type = "identify"
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
+		m.DisableGeoIP = c.GetDisableGeoIP()
 		msg = m
 
 	case GroupIdentify:
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
+		m.DisableGeoIP = c.GetDisableGeoIP()
 		msg = m
 
 	case Capture:

--- a/posthog.go
+++ b/posthog.go
@@ -155,6 +155,7 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 			c.NextFeatureFlagsPollingTick,
 			c.FeatureFlagRequestTimeout,
 			c.decider,
+			c.Config.DisableGeoIP,
 		)
 	}
 

--- a/posthog.go
+++ b/posthog.go
@@ -15,8 +15,12 @@ import (
 	"github.com/hashicorp/golang-lru/v2"
 )
 
-const unimplementedError = "not implemented"
-const CACHE_DEFAULT_SIZE = 300_000
+const (
+	unimplementedError = "not implemented"
+	CACHE_DEFAULT_SIZE = 300_000
+
+	propertyGeoipDisable = "$geoip_disable"
+)
 
 // This interface is the main API exposed by the posthog package.
 // Values that satsify this interface are returned by the client constructors
@@ -155,7 +159,7 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 			c.NextFeatureFlagsPollingTick,
 			c.FeatureFlagRequestTimeout,
 			c.decider,
-			c.Config.DisableGeoIP,
+			c.Config.GetDisableGeoIP(),
 		)
 	}
 
@@ -727,7 +731,7 @@ func (c *client) isFeatureFlagsQuotaLimited(flagsResponse *FlagsResponse) bool {
 }
 
 func (c *client) getFeatureFlagFromDecide(key string, distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (interface{}, *string, error) {
-	flagsResponse, err := c.decider.makeFlagsRequest(distinctId, groups, personProperties, groupProperties)
+	flagsResponse, err := c.decider.makeFlagsRequest(distinctId, groups, personProperties, groupProperties, c.GetDisableGeoIP())
 
 	if err != nil {
 		return nil, nil, err
@@ -750,7 +754,7 @@ func (c *client) getFeatureFlagFromDecide(key string, distinctId string, groups 
 }
 
 func (c *client) getFeatureFlagPayloadFromDecide(key string, distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (string, error) {
-	flagsResponse, err := c.decider.makeFlagsRequest(distinctId, groups, personProperties, groupProperties)
+	flagsResponse, err := c.decider.makeFlagsRequest(distinctId, groups, personProperties, groupProperties, c.GetDisableGeoIP())
 	if err != nil {
 		return "", err
 	}
@@ -767,7 +771,7 @@ func (c *client) getFeatureFlagPayloadFromDecide(key string, distinctId string, 
 }
 
 func (c *client) getAllFeatureFlagsFromDecide(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (map[string]interface{}, error) {
-	flagsResponse, err := c.decider.makeFlagsRequest(distinctId, groups, personProperties, groupProperties)
+	flagsResponse, err := c.decider.makeFlagsRequest(distinctId, groups, personProperties, groupProperties, c.GetDisableGeoIP())
 	if err != nil {
 		return nil, err
 	}

--- a/posthog.go
+++ b/posthog.go
@@ -524,7 +524,7 @@ func (c *client) upload(b []byte) error {
 
 	version := getVersion()
 
-	req.Header.Add("User-Agent", SdkName+"/"+version)
+	req.Header.Add("User-Agent", SDKName+"/"+version)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Content-Length", fmt.Sprintf("%d", len(b)))
 

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Helper type used to implement the io.Reader interface on function values.

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -269,7 +269,7 @@ func TestEnqueue(t *testing.T) {
 		"alias": {
 			strings.TrimSpace(fixture("test-enqueue-alias.json")),
 			Alias{Alias: "A", DistinctId: "B"},
-			&f,
+			&tv,
 		},
 
 		"identify": {
@@ -278,7 +278,15 @@ func TestEnqueue(t *testing.T) {
 				DistinctId: "B",
 				Properties: Properties{"email": "hey@posthog.com"},
 			},
-			&f,
+			&tv,
+		},
+		"identify-default-geoip": {
+			strings.TrimSpace(fixture("test-enqueue-identify.json")),
+			Identify{
+				DistinctId: "B",
+				Properties: Properties{"email": "hey@posthog.com"},
+			},
+			nil,
 		},
 
 		"groupIdentify": {
@@ -289,7 +297,7 @@ func TestEnqueue(t *testing.T) {
 				Key:        "id:5",
 				Properties: Properties{},
 			},
-			&f,
+			&tv,
 		},
 
 		"capture": {

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -217,6 +217,7 @@ func ExampleCapture() {
 	//       "library": "posthog-go",
 	//       "library_version": "1.0.0",
 	//       "properties": {
+	//         "$geoip_disable": true,
 	//         "$lib": "posthog-go",
 	//         "$lib_version": "1.0.0",
 	//         "application": "PostHog Go",


### PR DESCRIPTION
Bring the **DisableGeoIP** option to Go SDK.

This PR is backward incompatible, but posthog-python and doc compatible.

Since now the Go sets `$geoip_disable` by default on all capture events and `geoip_disable` on feature flag requests.

With few tweeks, this is based on https://github.com/PostHog/posthog-go/pull/83/files #83  and @jackhopner contribution.

#31 has been assimilated