### PR TITLE
fix: Ignore new `flag` filter type in local evaluation

### DIFF
--- a/featureflags.go
+++ b/featureflags.go
@@ -78,7 +78,7 @@ type FlagProperty struct {
 	Key      string      `json:"key"`
 	Operator string      `json:"operator"`
 	Value    interface{} `json:"value"`
-	Type     string      `json:"type"`
+	Type     string      `json:"type"` // Supported types: "person", "group", "cohort", "flag" (flag dependencies not implemented in local evaluation)
 	Negation bool        `json:"negation"`
 }
 
@@ -519,6 +519,10 @@ func isConditionMatch(
 		for _, prop := range condition.Properties {
 			if prop.Type == "cohort" {
 				isMatch, err = matchCohort(prop, properties, cohorts)
+			} else if prop.Type == "flag" {
+				// Flag dependencies are not supported in local evaluation yet
+				// Skip this condition to allow other conditions to be evaluated
+				continue
 			} else {
 				isMatch, err = matchProperty(prop, properties)
 			}

--- a/fixtures/feature_flag/test-flag-with-dependencies.json
+++ b/fixtures/feature_flag/test-flag-with-dependencies.json
@@ -1,0 +1,37 @@
+{
+  "flags": [
+    {
+      "id": 1,
+      "name": "Test Flag with Dependencies",
+      "key": "flag-with-dependencies",
+      "is_simple_flag": false,
+      "active": true,
+      "filters": {
+        "groups": [
+          {
+            "properties": [
+              {
+                "key": "beta-feature",
+                "type": "flag",
+                "value": true,
+                "operator": "exact",
+                "negation": false
+              },
+              {
+                "key": "email",
+                "type": "person",
+                "value": "@example.com",
+                "operator": "icontains",
+                "negation": false
+              }
+            ],
+            "rollout_percentage": 100
+          }
+        ],
+        "multivariate": null,
+        "payloads": {}
+      }
+    }
+  ],
+  "group_type_mapping": {}
+}


### PR DESCRIPTION
Add support for the new "flag" filter type to prevent serialization errors during local feature flag evaluation. Flag dependencies are not yet implemented in local evaluation, so these conditions are skipped to allow other conditions to be evaluated properly.