### PR TITLE
feat(flags): make the `SendFeatureFlags` parameter more declarative and ergonomic

### DIFF
--- a/capture.go
+++ b/capture.go
@@ -49,7 +49,7 @@ type Capture struct {
 	Timestamp        time.Time
 	Properties       Properties
 	Groups           Groups
-	SendFeatureFlags interface{} // Can be bool or *SendFeatureFlagsOptions
+	SendFeatureFlags any // Can be bool or *SendFeatureFlagsOptions
 }
 
 func (msg Capture) internal() {
@@ -83,10 +83,10 @@ type CaptureInApi struct {
 	LibraryVersion string    `json:"library_version"`
 	Timestamp      time.Time `json:"timestamp"`
 
-	DistinctId       string      `json:"distinct_id"`
-	Event            string      `json:"event"`
-	Properties       Properties  `json:"properties"`
-	SendFeatureFlags interface{} `json:"send_feature_flags"`
+	DistinctId       string     `json:"distinct_id"`
+	Event            string     `json:"event"`
+	Properties       Properties `json:"properties"`
+	SendFeatureFlags any        `json:"send_feature_flags"`
 }
 
 func (msg Capture) APIfy() APIMessage {

--- a/examples/capture.go
+++ b/examples/capture.go
@@ -70,7 +70,7 @@ func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoin
 					"version":     "1.0.0",
 					"platform":    "macos", // :)
 				},
-				SendFeatureFlags: true,
+				SendFeatureFlags: posthog.SendFeatureFlags(true),
 			}); err != nil {
 				fmt.Println("error:", err)
 				return
@@ -121,7 +121,7 @@ func TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpo
 				Event:      "Purchase",
 				DistinctId: "123456",
 				Properties: map[string]interface{}{
-					"amount": 99.99,
+					"amount":   99.99,
 					"currency": "USD",
 				},
 				SendFeatureFlags: &posthog.SendFeatureFlagsOptions{

--- a/examples/capture.go
+++ b/examples/capture.go
@@ -78,3 +78,63 @@ func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoin
 		}
 	}
 }
+
+func TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpoint string) {
+	client, _ := posthog.NewWithConfig(projectAPIKey, posthog.Config{
+		Interval:       30 * time.Second,
+		BatchSize:      100,
+		Verbose:        true,
+		PersonalApiKey: personalAPIKey,
+		Endpoint:       endpoint,
+	})
+	defer client.Close()
+
+	done := time.After(3 * time.Second)
+	tick := time.Tick(50 * time.Millisecond)
+
+	for {
+		select {
+		case <-done:
+			fmt.Println("exiting")
+			return
+
+		case <-tick:
+			// Example 1: Using the new SendFeatureFlagsOptions with person properties
+			if err := client.Enqueue(posthog.Capture{
+				Event:      "Download",
+				DistinctId: "123456",
+				Properties: map[string]interface{}{
+					"application": "PostHog Go",
+					"version":     "1.0.0",
+					"platform":    "macos",
+				},
+				SendFeatureFlags: &posthog.SendFeatureFlagsOptions{
+					PersonProperties: posthog.NewProperties().Set("plan", "premium").Set("beta_user", true),
+				},
+			}); err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+
+			// Example 2: Using SendFeatureFlagsOptions with local-only evaluation
+			if err := client.Enqueue(posthog.Capture{
+				Event:      "Purchase",
+				DistinctId: "123456",
+				Properties: map[string]interface{}{
+					"amount": 99.99,
+					"currency": "USD",
+				},
+				SendFeatureFlags: &posthog.SendFeatureFlagsOptions{
+					OnlyEvaluateLocally: true,
+					PersonProperties:    posthog.NewProperties().Set("plan", "premium"),
+					GroupProperties: map[string]posthog.Properties{
+						"company": posthog.NewProperties().Set("name", "PostHog").Set("plan", "enterprise"),
+					},
+				},
+			}); err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+		}
+	}
+}

--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -49,7 +49,8 @@ func TestMatchPropertyInvalidOperator(t *testing.T) {
 		t.Error("Should not match")
 	}
 
-	if _, ok := err.(*InconclusiveMatchError); !ok {
+	var inconclusiveErr *InconclusiveMatchError
+	if !errors.As(err, &inconclusiveErr) {
 		t.Error("Error type is not a match")
 	}
 

--- a/featureflags.go
+++ b/featureflags.go
@@ -880,7 +880,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlags() ([]FeatureFlag, error) {
 }
 
 func (poller *FeatureFlagsPoller) localEvaluationFlags(headers http.Header) (*http.Response, context.CancelFunc, error) {
-	u := *poller.localEvalUrl
+	u := url.URL(*poller.localEvalUrl)
 	searchParams := u.Query()
 	searchParams.Add("token", poller.projectApiKey)
 	searchParams.Add("send_cohorts", "true")

--- a/featureflags.go
+++ b/featureflags.go
@@ -877,8 +877,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlags() ([]FeatureFlag, error) {
 }
 
 func (poller *FeatureFlagsPoller) localEvaluationFlags(headers http.Header) (*http.Response, context.CancelFunc, error) {
-	var u url.URL
-	u = *poller.localEvalUrl
+	u := *poller.localEvalUrl
 	searchParams := u.Query()
 	searchParams.Add("token", poller.projectApiKey)
 	searchParams.Add("send_cohorts", "true")
@@ -950,7 +949,7 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariantsLocalOnly(distinctId str
 			groupProperties,
 			cohorts,
 		)
-		
+
 		// Skip flags that can't be evaluated locally (e.g., experience continuity flags)
 		if err != nil {
 			if _, ok := err.(*InconclusiveMatchError); ok {

--- a/featureflags.go
+++ b/featureflags.go
@@ -478,7 +478,8 @@ func (poller *FeatureFlagsPoller) matchFeatureFlagProperties(
 	for _, condition := range sortedConditions {
 		isMatch, err := poller.isConditionMatch(flag, distinctId, condition, properties, cohorts)
 		if err != nil {
-			if _, ok := err.(*InconclusiveMatchError); ok {
+			var inconclusiveErr *InconclusiveMatchError
+			if errors.As(err, &inconclusiveErr) {
 				isInconclusive = true
 			} else {
 				return nil, err
@@ -574,7 +575,8 @@ func matchPropertyGroup(propertyGroup PropertyGroup, properties Properties, coho
 					Values: getSafeProp[[]any](prop, "values"),
 				}, properties, cohorts)
 				if err != nil {
-					if _, ok := err.(*InconclusiveMatchError); ok {
+					var inconclusiveErr *InconclusiveMatchError
+					if errors.As(err, &inconclusiveErr) {
 						errorMatchingLocally = true
 					} else {
 						return false, err
@@ -609,7 +611,8 @@ func matchPropertyGroup(propertyGroup PropertyGroup, properties Properties, coho
 				}
 
 				if err != nil {
-					if _, ok := err.(*InconclusiveMatchError); ok {
+					var inconclusiveErr *InconclusiveMatchError
+					if errors.As(err, &inconclusiveErr) {
 						errorMatchingLocally = true
 					} else {
 						return false, err
@@ -952,7 +955,8 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariantsLocalOnly(distinctId str
 
 		// Skip flags that can't be evaluated locally (e.g., experience continuity flags)
 		if err != nil {
-			if _, ok := err.(*InconclusiveMatchError); ok {
+			var inconclusiveErr *InconclusiveMatchError
+			if errors.As(err, &inconclusiveErr) {
 				continue
 			}
 			return nil, err

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -231,7 +231,7 @@ func ExampleCapture() {
 			"version":     "1.0.0",
 			"platform":    "macos", // :)
 		},
-		SendFeatureFlags: false,
+		SendFeatureFlags: SendFeatureFlags(false),
 	})
 
 	fmt.Printf("%s\n", <-body)
@@ -283,7 +283,7 @@ func TestCaptureNoProperties(t *testing.T) {
 	client.Enqueue(Capture{
 		Event:            "Download",
 		DistinctId:       "123456",
-		SendFeatureFlags: false,
+		SendFeatureFlags: SendFeatureFlags(false),
 	})
 }
 
@@ -338,7 +338,7 @@ func TestEnqueue(t *testing.T) {
 					"version":     "1.0.0",
 					"platform":    "macos", // :)
 				},
-				SendFeatureFlags: false,
+				SendFeatureFlags: SendFeatureFlags(false),
 			},
 			&f,
 		},
@@ -353,7 +353,7 @@ func TestEnqueue(t *testing.T) {
 					"version":     "1.0.0",
 					"platform":    "macos", // :)
 				},
-				SendFeatureFlags: false,
+				SendFeatureFlags: SendFeatureFlags(false),
 			},
 			&tv,
 		},
@@ -395,7 +395,7 @@ func TestEnqueue(t *testing.T) {
 					"version":     "1.0.0",
 					"platform":    "macos", // :)
 				},
-				SendFeatureFlags: false,
+				SendFeatureFlags: SendFeatureFlags(false),
 			},
 			&tv,
 		},
@@ -480,7 +480,7 @@ func TestCaptureWithInterval(t *testing.T) {
 			"version":     "1.0.0",
 			"platform":    "macos", // :)
 		},
-		SendFeatureFlags: false,
+		SendFeatureFlags: SendFeatureFlags(false),
 	})
 
 	// Will flush in 100 milliseconds
@@ -516,7 +516,7 @@ func TestCaptureWithTimestamp(t *testing.T) {
 			"version":     "1.0.0",
 			"platform":    "macos", // :)
 		},
-		SendFeatureFlags: false,
+		SendFeatureFlags: SendFeatureFlags(false),
 		Timestamp:        time.Date(2015, time.July, 10, 23, 0, 0, 0, time.UTC),
 	})
 
@@ -549,7 +549,7 @@ func TestCaptureWithDefaultProperties(t *testing.T) {
 			"version":     "1.0.0",
 			"platform":    "macos", // :)
 		},
-		SendFeatureFlags: false,
+		SendFeatureFlags: SendFeatureFlags(false),
 		Timestamp:        time.Date(2015, time.July, 10, 23, 0, 0, 0, time.UTC),
 	})
 
@@ -581,7 +581,7 @@ func TestCaptureMany(t *testing.T) {
 				"application": "PostHog Go",
 				"version":     i,
 			},
-			SendFeatureFlags: false,
+			SendFeatureFlags: SendFeatureFlags(false),
 		})
 	}
 
@@ -1755,7 +1755,7 @@ func TestCaptureSendFlags(t *testing.T) {
 	err := client.Enqueue(Capture{
 		Event:            "Download",
 		DistinctId:       "123456",
-		SendFeatureFlags: true,
+		SendFeatureFlags: SendFeatureFlags(true),
 	})
 
 	if err != nil {
@@ -1838,7 +1838,7 @@ func TestCaptureSendFeatureFlagsOptions(t *testing.T) {
 		err := client.Enqueue(Capture{
 			Event:            "test_event",
 			DistinctId:       "test_user",
-			SendFeatureFlags: true,
+			SendFeatureFlags: SendFeatureFlags(true),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -1847,7 +1847,7 @@ func TestCaptureSendFeatureFlagsOptions(t *testing.T) {
 		err = client.Enqueue(Capture{
 			Event:            "test_event",
 			DistinctId:       "test_user",
-			SendFeatureFlags: false,
+			SendFeatureFlags: SendFeatureFlags(false),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -1857,14 +1857,14 @@ func TestCaptureSendFeatureFlagsOptions(t *testing.T) {
 
 func TestSendFeatureFlagsHelperMethods(t *testing.T) {
 	t.Run("shouldSendFeatureFlags with bool true", func(t *testing.T) {
-		capture := Capture{SendFeatureFlags: true}
+		capture := Capture{SendFeatureFlags: SendFeatureFlags(true)}
 		if !capture.shouldSendFeatureFlags() {
 			t.Error("Expected shouldSendFeatureFlags to return true for bool true")
 		}
 	})
 
 	t.Run("shouldSendFeatureFlags with bool false", func(t *testing.T) {
-		capture := Capture{SendFeatureFlags: false}
+		capture := Capture{SendFeatureFlags: SendFeatureFlags(false)}
 		if capture.shouldSendFeatureFlags() {
 			t.Error("Expected shouldSendFeatureFlags to return false for bool false")
 		}
@@ -1885,7 +1885,7 @@ func TestSendFeatureFlagsHelperMethods(t *testing.T) {
 	})
 
 	t.Run("getFeatureFlagsOptions with bool", func(t *testing.T) {
-		capture := Capture{SendFeatureFlags: true}
+		capture := Capture{SendFeatureFlags: SendFeatureFlags(true)}
 		if capture.getFeatureFlagsOptions() != nil {
 			t.Error("Expected getFeatureFlagsOptions to return nil for bool")
 		}

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@ package posthog
 import "flag"
 
 // Version of the client.
-const Version = "1.5.15"
+const Version = "1.6.0"
 
 // make tests easier by using a constant version
 func getVersion() string {


### PR DESCRIPTION
### Problem
  The current `SendFeatureFlags` boolean parameter provides limited control over feature flag evaluation behavior. Users couldn't specify evaluation preferences or custom properties per capture event.

### Solution
 Modified `SendFeatureFlags` to accept either:
 - `bool` (existing behavior, fully backward compatible)
 - `*SendFeatureFlagsOptions` struct with granular control:
```go
   type SendFeatureFlagsOptions struct {
       OnlyEvaluateLocally bool              // Force local vs remote evaluation
       PersonProperties    Properties        // Custom properties for this event
       GroupProperties     map[string]Properties  // Custom group properties
   }
```

### Benefits
  - Declarative control: Explicitly specify local vs remote evaluation per event
  - Custom properties: Supply event-specific properties without affecting global state
  - Backward compatible: Existing boolean usage unchanged
  - Type-safe: Go's type system ensures compile-time safety for the new options

 #### Usage Examples

```go
  // Traditional usage (unchanged)
  client.Enqueue(posthog.Capture{
      Event:            "Download",
      DistinctId:       "user123",
      SendFeatureFlags: true,
  })

  // New declarative usage with custom properties
  client.Enqueue(posthog.Capture{
      Event:      "Purchase",
      DistinctId: "user123",
      SendFeatureFlags: &posthog.SendFeatureFlagsOptions{
          PersonProperties: posthog.NewProperties().Set("plan", "premium"),
      },
  })

  // Force local-only evaluation
  client.Enqueue(posthog.Capture{
      Event:      "Signup",
      DistinctId: "user123",
      SendFeatureFlags: &posthog.SendFeatureFlagsOptions{
          OnlyEvaluateLocally: true,
          PersonProperties:    posthog.NewProperties().Set("beta_user", true),
          GroupProperties: map[string]posthog.Properties{
              "company": posthog.NewProperties().Set("name", "Acme Corp"),
          },
      },
  })
```

  This brings the Go SDK in line with the enhanced Node.js SDK functionality from https://github.com/PostHog/posthog-js-lite/pull/566.
