### PR TITLE
feat: Allows stringt to be Numeric if the format is correct

### DIFF
--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -199,6 +199,26 @@ func TestMatchPropertyNumber(t *testing.T) {
 	}
 }
 
+func TestMatchPropertyStringAsNumber(t *testing.T) {
+	property := FlagProperty{
+		Key:      "Number",
+		Value:    "5",
+		Operator: "gt",
+	}
+
+	properties := NewProperties().Set("Number", "7")
+
+	isMatch, err := matchProperty(property, properties)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !isMatch {
+		t.Error("Value is not a match")
+	}
+}
+
 func TestMatchPropertyRegex(t *testing.T) {
 
 	shouldMatch := []interface{}{"value.com", "value2.com"}

--- a/featureflags.go
+++ b/featureflags.go
@@ -804,6 +804,7 @@ func validateOrderable(firstValue interface{}, secondValue interface{}) (float64
 
 func interfaceToFloat(val interface{}) (float64, error) {
 	var i float64
+	var err error
 	switch t := val.(type) {
 	case int:
 		i = float64(t)
@@ -827,6 +828,13 @@ func interfaceToFloat(val interface{}) (float64, error) {
 		i = float64(t)
 	case uint64:
 		i = float64(t)
+	case string:
+		i, err = strconv.ParseFloat(t, 64)
+		if err != nil {
+			// If parsing fails, return an error
+			errMessage := fmt.Sprintf("string '%s' is not orderable", t)
+			return 0.0, errors.New(errMessage)
+		}
 	default:
 		errMessage := "argument not orderable"
 		return 0.0, errors.New(errMessage)

--- a/featureflags_test.go
+++ b/featureflags_test.go
@@ -1,6 +1,7 @@
 package posthog
 
 import (
+	"fmt"
 	"math"
 	"testing"
 )
@@ -20,6 +21,29 @@ func TestCalculateHash(t *testing.T) {
 			if math.Abs(got-tt.want) > 0.000001 {
 				t.Logf("got: %.16f, want: %f", got, tt.want)
 				t.Fail()
+			}
+		})
+	}
+}
+
+func TestArgumentConversion(t *testing.T) {
+	for _, tt := range []struct {
+		input    interface{}
+		expected float64
+		error    bool
+	}{
+		{42, 42.0, false},
+		{3.14, 3.14, false},
+		{"123.456", 123.456, false},
+		{"not_a_number", 0.0, true}, // This should fail
+	} {
+		t.Run(fmt.Sprintf("Converting %v...", tt.input), func(t *testing.T) {
+			result, err := interfaceToFloat(tt.input)
+			if tt.error != (err != nil) {
+				t.Errorf("Expected error: %v, got: %v", tt.error, err)
+			}
+			if !tt.error && result != tt.expected {
+				t.Errorf("Expected: %f, got: %f", tt.expected, result)
 			}
 		})
 	}

--- a/featureflags_test.go
+++ b/featureflags_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 )
 
 func TestCalculateHash(t *testing.T) {
@@ -26,7 +27,7 @@ func TestCalculateHash(t *testing.T) {
 	}
 }
 
-func TestArgumentConversion(t *testing.T) {
+func TestArgumentOrderableConversion(t *testing.T) {
 	for _, tt := range []struct {
 		input    interface{}
 		expected float64
@@ -46,5 +47,83 @@ func TestArgumentConversion(t *testing.T) {
 				t.Errorf("Expected: %f, got: %f", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestArgumentDateTimeConversion(t *testing.T) {
+	now := time.Now().UTC()
+	for _, tt := range []struct {
+		input    interface{}
+		expected time.Time
+		error    bool
+	}{
+		{now, now, false},
+		{"2024-02-01T01:33:00Z", time.Date(2024, 2, 1, 1, 33, 0, 0, time.UTC), false},
+		{"2024-02-01", time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), false},
+		{"none", time.Time{}, true},
+	} {
+		t.Run(fmt.Sprintf("Converting %v...", tt.input), func(t *testing.T) {
+			result, err := convertToDateTime(tt.input)
+			if tt.error != (err != nil) {
+				t.Errorf("Expected error: %v, got: %v", tt.error, err)
+			}
+			if !tt.error && result != tt.expected {
+				t.Errorf("Expected: %v, got: %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMatchPropertyDate(t *testing.T) {
+	shouldMatchA := []interface{}{"2022-04-30T00:00:00+00:00", "2022-04-30T00:00:00+02:00", time.Date(2022, 3, 20, 20, 34, 58, 651387237, time.UTC)}
+	shouldNotMatchA := NewProperties().Set("key", "2022-05-30T00:00:00+00:00")
+	propertyA := FlagProperty{
+		Key:      "key",
+		Value:    "2022-05-01",
+		Operator: "is_date_before",
+		Type:     "person",
+	}
+	for _, val := range shouldMatchA {
+		isMatch, err := matchProperty(propertyA, NewProperties().Set("key", val))
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !isMatch {
+			t.Error(("Value is not a match"))
+		}
+	}
+	isMatchA, errA := matchProperty(propertyA, shouldNotMatchA)
+	if errA != nil {
+		t.Error(errA)
+	}
+	if isMatchA {
+		t.Error("Value is not a match")
+	}
+
+	shouldMatchB := []interface{}{"2022-05-30T00:00:00+00:00", time.Date(2022, 5, 30, 20, 34, 58, 651387237, time.UTC)}
+	shouldNotMatchB := NewProperties().Set("key", "2022-04-29T00:00:00+00:00")
+	propertyB := FlagProperty{
+		Key:      "key",
+		Value:    "2022-05-01T00:00:00+00:00",
+		Operator: "is_date_after",
+		Type:     "person",
+	}
+	for _, val := range shouldMatchB {
+		isMatch, err := matchProperty(propertyB, NewProperties().Set("key", val))
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !isMatch {
+			t.Error(("Value is not a match"))
+		}
+	}
+	isMatchB, errB := matchProperty(propertyB, shouldNotMatchB)
+	if errB != nil {
+		t.Error(errB)
+	}
+	if isMatchB {
+		t.Error("Value is not a match")
 	}
 }


### PR DESCRIPTION
Numeric values were not evaluated **ever** locally as the posthog saves the values in the `Conditions` as `string`. By allowing the conversion, they will be able to be evaluated locally