### PR TITLE
fix(flags): Pass project API key in remote_config requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.2
+
+* Fix: Pass project API key in remote_config requests
+* [Full Changelog](https://github.com/PostHog/posthog-go/compare/v1.6.1...v1.6.2)
+
 ## 1.6.1
 
 * [Full Changelog](https://github.com/PostHog/posthog-go/compare/v1.6.0...v1.6.1)

--- a/posthog.go
+++ b/posthog.go
@@ -711,7 +711,7 @@ func (c *client) getFeatureVariantsWithOptions(distinctId string, groups Groups,
 }
 
 func (c *client) makeRemoteConfigRequest(flagKey string) (string, error) {
-	remoteConfigEndpoint := fmt.Sprintf("api/projects/@current/feature_flags/%s/remote_config/", flagKey)
+	remoteConfigEndpoint := fmt.Sprintf("api/projects/@current/feature_flags/%s/remote_config?token=%s", flagKey, c.key)
 	url, err := url.Parse(c.Endpoint + "/" + remoteConfigEndpoint)
 	if err != nil {
 		return "", fmt.Errorf("creating url: %v", err)

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@ package posthog
 import "flag"
 
 // Version of the client.
-const Version = "1.6.1"
+const Version = "1.6.2"
 
 // make tests easier by using a constant version
 func getVersion() string {


### PR DESCRIPTION
Fixes the remote_config endpoint to include the project API key as a token parameter for deterministic project routing, matching the implementation in other server-side SDKs.

- Add token parameter to remote_config URL construction
- Add test to verify the token parameter is included in requests

See https://github.com/PostHog/posthog/issues/35303 for the problem.
Port of PostHog Python implementation: https://github.com/PostHog/posthog-python/pull/303
