### PR TITLE
chore: Bump Go version in CI to 1.21 to align with `go.mod`

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,10 +9,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Check out source code
         uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PostHog Go
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/posthog/posthog-go.svg)](https://pkg.go.dev/github.com/posthog/posthog-go)
+![min. Go Version](https://img.shields.io/github/go-mod/go-version/PostHog/posthog-go?label=min.%20Go%20version%20)
 
 Please see the main [PostHog docs](https://posthog.com/docs).
 


### PR DESCRIPTION
## Context

This PR bumps the Golang version in the CI to [version 1.21](https://tip.golang.org/doc/go1.21). This way the version is aligned with the version defined in the `go.mod` file ([code](https://github.com/PostHog/posthog-go/blob/master/go.mod)). Additionally it will unblock [this PR](https://github.com/PostHog/posthog-go/pull/120) as it depends on features introduced in `Go 1.21`.

Both version 1.19 and version 1.21 are deprecated:

<img width="737" height="505" alt="Scherm­afbeelding 2025-08-26 om 18 00 53" src="https://github.com/user-attachments/assets/c46b49c5-4a7c-4cfc-a6b2-f940192b6c44" />

_([source](https://endoflife.date/go))_

However I figured that bumping the version to the lowest required version (albeit EOL) to unblock other work, will keep the library usable for the widest possible audience.
