### PR TITLE
feat: add `locally_evaluated` property to `$feature_flag_called`

### DIFF
--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -1014,6 +1014,24 @@ func TestGetFeatureFlag(t *testing.T) {
 	if variant != "variant-1" {
 		t.Error("Should match")
 	}
+
+
+	lastEvent := client.GetLastCapturedEvent()
+	if lastEvent == nil || lastEvent.Event != "$feature_flag_called" {
+		t.Errorf("Expected a $feature_flag_called event, got: %v", lastEvent)
+	}
+
+	if lastEvent != nil {
+		if lastEvent.Properties["$feature_flag"] != "test-get-feature" {
+			t.Errorf("Expected feature flag key 'test-get-feature', got: %v", lastEvent.Properties["$feature_flag"])
+		}
+		if lastEvent.Properties["$feature_flag_response"] != "variant-1" {
+			t.Errorf("Expected feature flag response 'variant-1', got: %v", lastEvent.Properties["$feature_flag_response"])
+		}
+		if lastEvent.Properties["locally_evaluated"] != true {
+			t.Errorf("Expected locally_evaluated to be true for local evaluation, got: %v", lastEvent.Properties["locally_evaluated"])
+		}
+	}
 }
 
 func TestGetFeatureFlagPayload(t *testing.T) {

--- a/featureflags.go
+++ b/featureflags.go
@@ -370,10 +370,11 @@ func (poller *FeatureFlagsPoller) fetchNewFeatureFlags() {
 	}
 }
 
-func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) (interface{}, error) {
+func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) (interface{}, bool, error) {
 	flag, err := poller.getFeatureFlag(flagConfig)
 
 	var result interface{}
+	locallyEvaluated := false
 
 	if flag.Key != "" {
 		result, err = poller.computeFlagLocally(
@@ -384,6 +385,9 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 			flagConfig.GroupProperties,
 			poller.cohorts,
 		)
+		if err == nil && result != nil {
+			locallyEvaluated = true
+		}
 	}
 
 	if err != nil {
@@ -393,11 +397,11 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 	if (err != nil || result == nil) && !flagConfig.OnlyEvaluateLocally {
 		result, err = poller.getFeatureFlagVariant(flagConfig.Key, flagConfig.DistinctId, flagConfig.Groups, flagConfig.PersonProperties, flagConfig.GroupProperties)
 		if err != nil {
-			return nil, err
+			return nil, locallyEvaluated, err
 		}
 	}
 
-	return result, err
+	return result, locallyEvaluated, err
 }
 
 func (poller *FeatureFlagsPoller) GetFeatureFlagPayload(flagConfig FeatureFlagPayload) (string, error) {

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -1218,6 +1218,9 @@ func TestGetFeatureFlagWithNoPersonalApiKey(t *testing.T) {
 		if lastEvent.Properties["$feature_flag_response"] != expectedValue {
 			t.Errorf("Expected feature flag response %v, got: %v", expectedValue, lastEvent.Properties["$feature_flag_response"])
 		}
+		if lastEvent.Properties["locally_evaluated"] != false {
+			t.Errorf("Expected locally_evaluated to be false for remote evaluation, got: %v", lastEvent.Properties["locally_evaluated"])
+		}
 	}
 
 	// Test a bunch of GetFeatureFlag scenarios


### PR DESCRIPTION
Bring this in line with other SDKs by setting a `locally_evaluated` property on `$feature_flag_called` events to indicate whether the flag was evaluated locally.