### PR TITLE
feat: Add SDK parity for date operators and inconclusive evaluation

### DIFF
--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -307,6 +307,265 @@ func TestMatchPropertyContains(t *testing.T) {
 	}
 }
 
+func TestMatchPropertyDateComparison(t *testing.T) {
+	t.Run("RFC3339 dates", func(t *testing.T) {
+		// Test is_date_before
+		property := FlagProperty{
+			Key:      "created_at",
+			Value:    "2024-12-31T23:59:59Z",
+			Operator: "is_date_before",
+		}
+
+		// Should match: 2024-06-15 is before 2024-12-31
+		isMatch, err := matchProperty(property, NewProperties().Set("created_at", "2024-06-15T10:00:00Z"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: 2025-01-01 is after 2024-12-31
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01T00:00:00Z"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test is_date_after
+		property.Operator = "is_date_after"
+
+		// Should match: 2025-01-01 is after 2024-12-31
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01T00:00:00Z"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: 2024-06-15 is before 2024-12-31
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-06-15T10:00:00Z"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+	})
+
+	t.Run("ISO 8601 date formats", func(t *testing.T) {
+		// Test date-only format (YYYY-MM-DD)
+		property := FlagProperty{
+			Key:      "created_at",
+			Value:    "2024-12-31",
+			Operator: "is_date_before",
+		}
+
+		// Should match: 2024-06-15 is before 2024-12-31
+		isMatch, err := matchProperty(property, NewProperties().Set("created_at", "2024-06-15"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: 2025-01-01 is after 2024-12-31
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test datetime without timezone (YYYY-MM-DDTHH:MM:SS)
+		property.Value = "2024-12-31T23:59:59"
+
+		// Should match: 2024-06-15T10:00:00 is before 2024-12-31T23:59:59
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-06-15T10:00:00"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: 2025-01-01T00:00:00 is after 2024-12-31T23:59:59
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01T00:00:00"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test is_date_after with date-only format
+		property.Operator = "is_date_after"
+		property.Value = "2024-06-15"
+
+		// Should match: 2025-01-01 is after 2024-06-15
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: 2024-01-01 is before 2024-06-15
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-01-01"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test mixing formats (RFC3339 value with date-only property)
+		property.Value = "2024-06-15"
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01T00:00:00Z"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Test mixing formats (date-only value with datetime property)
+		property.Value = "2024-06-15T12:00:00"
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+	})
+
+	t.Run("ISO 8601 fractional seconds and timezone offsets", func(t *testing.T) {
+		// Test fractional seconds with Z timezone
+		property := FlagProperty{
+			Key:      "created_at",
+			Value:    "2024-12-31T23:59:59.999Z",
+			Operator: "is_date_before",
+		}
+
+		// Should match: earlier fractional time
+		isMatch, err := matchProperty(property, NewProperties().Set("created_at", "2024-06-15T10:30:00.123Z"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: later time
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01T00:00:00.001Z"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test timezone offsets (positive)
+		property.Value = "2024-06-15T10:00:00+05:30"
+
+		// Should match: earlier time with different timezone
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-06-15T03:00:00Z"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: later time
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-06-15T12:00:00+05:30"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test timezone offsets (negative)
+		property.Value = "2024-06-15T10:00:00-08:00"
+
+		// Should match: earlier time
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-06-15T08:00:00-08:00"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Test combined fractional seconds + timezone offset
+		property.Value = "2024-12-31T23:59:59.999+01:00"
+
+		// Should match: earlier fractional time with timezone
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-12-31T22:59:59.998+01:00"))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: later time
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2025-01-01T00:00:00.000+01:00"))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test various fractional second precisions
+		testCases := []struct {
+			name     string
+			dateStr  string
+			expected bool
+		}{
+			{"1 digit fractional", "2024-01-15T10:30:00.1Z", true},
+			{"2 digit fractional", "2024-01-15T10:30:00.12Z", true},
+			{"3 digit fractional", "2024-01-15T10:30:00.123Z", true},
+			{"6 digit fractional", "2024-01-15T10:30:00.123456Z", true},
+			{"9 digit fractional", "2024-01-15T10:30:00.123456789Z", true},
+			{"fractional with +00:00", "2024-01-15T10:30:00.123+00:00", true},
+		}
+
+		property.Operator = "is_date_after"
+		property.Value = "2024-01-01T00:00:00Z"
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				isMatch, err := matchProperty(property, NewProperties().Set("created_at", tc.dateStr))
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, isMatch, "Failed for date: %s", tc.dateStr)
+			})
+		}
+
+		// Test mixing fractional seconds with non-fractional
+		property.Value = "2024-06-15T10:30:00Z"
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-06-15T10:30:00.999Z"))
+		require.NoError(t, err)
+		require.True(t, isMatch) // .999 is after :00 (operator is still is_date_after)
+
+		// Test +00:00 equivalent to Z
+		property.Value = "2024-06-15T10:30:00+00:00"
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "2024-06-15T10:30:00Z"))
+		require.NoError(t, err)
+		require.False(t, isMatch) // Equal times, not after
+	})
+
+	t.Run("Relative dates", func(t *testing.T) {
+		now := time.Now()
+
+		// Test is_date_after with relative date
+		property := FlagProperty{
+			Key:      "created_at",
+			Value:    "-7d", // 7 days ago
+			Operator: "is_date_after",
+		}
+
+		// Should match: 3 days ago is after 7 days ago
+		threeDaysAgo := now.AddDate(0, 0, -3).Format(time.RFC3339)
+		isMatch, err := matchProperty(property, NewProperties().Set("created_at", threeDaysAgo))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+
+		// Should not match: 10 days ago is before 7 days ago
+		tenDaysAgo := now.AddDate(0, 0, -10).Format(time.RFC3339)
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", tenDaysAgo))
+		require.NoError(t, err)
+		require.False(t, isMatch)
+
+		// Test is_date_before with relative date
+		property.Operator = "is_date_before"
+
+		// Should match: 10 days ago is before 7 days ago
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", tenDaysAgo))
+		require.NoError(t, err)
+		require.True(t, isMatch)
+	})
+
+	t.Run("Various relative date formats", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			relativeDate string
+			shouldParse  bool
+		}{
+			{"1 hour", "1h", true},
+			{"7 days", "7d", true},
+			{"2 weeks", "2w", true},
+			{"3 months", "3m", true},
+			{"1 year", "1y", true},
+			{"large number rejected", "10000d", false},
+			{"invalid format", "invalid", false},
+			{"no number", "d", false},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := parseRelativeDate(tc.relativeDate)
+				if tc.shouldParse {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("Error handling", func(t *testing.T) {
+		property := FlagProperty{
+			Key:      "created_at",
+			Value:    "2024-12-31T23:59:59Z",
+			Operator: "is_date_before",
+		}
+
+		// Test with non-string value
+		isMatch, err := matchProperty(property, NewProperties().Set("created_at", 12345))
+		require.Error(t, err)
+		require.False(t, isMatch)
+
+		// Test with invalid date format
+		isMatch, err = matchProperty(property, NewProperties().Set("created_at", "invalid-date"))
+		require.Error(t, err)
+		require.False(t, isMatch)
+	})
+}
+
 func TestFlagPersonProperty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/flags") {
@@ -6116,4 +6375,59 @@ func TestGetFeatureFlagPayloadFallbackToAPIWhenFlagHasStaticCohort(t *testing.T)
 	if result != expectedPayload {
 		t.Errorf("Expected payload '%s' from API, got '%s'", expectedPayload, result)
 	}
+}
+
+func TestDateBeforeOperatorAbsolute(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			response := `{
+				"flags": [
+					{
+						"id": 1,
+						"key": "test-flag",
+						"active": true,
+						"filters": {
+							"groups": [
+								{
+									"properties": [
+										{
+											"key": "created_at",
+											"value": "2024-12-31T23:59:59Z",
+											"operator": "is_date_before",
+											"type": "person"
+										}
+									],
+									"rollout_percentage": 100
+								}
+							]
+						}
+					}
+				],
+				"group_type_mapping": {},
+				"cohorts": {}
+			}`
+			w.Write([]byte(response))
+		}
+	}))
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-api-key", Config{
+		PersonalApiKey: "test-personal-key",
+		Endpoint:       server.URL,
+	})
+	defer client.Close()
+
+	// Person has created_at "2024-01-01T00:00:00Z" which is before "2024-12-31T23:59:59Z"
+	result, err := client.GetFeatureFlag(
+		FeatureFlagPayload{
+			Key:                   "test-flag",
+			DistinctId:            "user-123",
+			PersonProperties:      NewProperties().Set("created_at", "2024-01-01T00:00:00Z"),
+			OnlyEvaluateLocally:   true,
+			SendFeatureFlagEvents: nil,
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, true, result)
 }


### PR DESCRIPTION
- Fixed bug where inconclusive feature flag evaluations returned `false` instead of `nil`: When local evaluation couldn't determine a flag's value due to missing properties, it returned `false` (with an error), potentially causing flags to appear disabled when they should be inconclusive. Now properly returns `nil` with an error.
- Added date comparison support for local feature flag evaluation: Implemented `is_date_before` and `is_date_after` operators for property matching, supporting both absolute dates (most common ISO 8601 timestamps) and relative dates (e.g., -7d, 2w, 3m, 1y)