### PR TITLE
fix: GetFeatureFlagPayload returns no error on no-match with OnlyEvaluateLocally

### DIFF
--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -323,6 +323,39 @@ func TestFeatureFlagsDontFallbackToFlagsWhenOnlyLocalEvaluationIsTrue(t *testing
 	}
 }
 
+func TestGetFeatureFlagPayloadNoMatchReturnsNoError(t *testing.T) {
+	// Regression test for: GetFeatureFlagPayload with OnlyEvaluateLocally=true should
+	// return ("", nil) on no match, consistent with IsFeatureEnabled returning (false, nil).
+	// Uses a flag with 0% rollout so it evaluates locally but never matches.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			w.Write([]byte(fixture("feature_flag/test-compute-inactive-flags-locally.json")))
+		}
+	}))
+	defer server.Close()
+
+	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
+		PersonalApiKey: "some very secret key",
+		Endpoint:       server.URL,
+	})
+	defer client.Close()
+
+	payload, err := client.GetFeatureFlagPayload(
+		FeatureFlagPayload{
+			Key:                 "disabled-feature",
+			DistinctId:          "some-distinct-id",
+			OnlyEvaluateLocally: true,
+		},
+	)
+
+	if err != nil {
+		t.Errorf("Expected no error on no-match with OnlyEvaluateLocally, got: %v", err)
+	}
+	if payload != "" {
+		t.Errorf("Expected empty payload on no-match, got: %v", payload)
+	}
+}
+
 func TestFeatureFlagDefaultsDontHinderEvaluation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/flags") {

--- a/featureflags.go
+++ b/featureflags.go
@@ -596,7 +596,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagPayload(flagConfig FeatureFlagPa
 		return result, nil
 	}
 
-	return "", errors.New("unable to compute flag locally")
+	return "", err
 }
 
 // flagValueAndPayload holds the result of a single flag evaluation that returns


### PR DESCRIPTION
## Motivation and Context

Fixes #76.

When `OnlyEvaluateLocally: true` and the flag exists but the user doesn't match, `GetFeatureFlagPayload` was returning `("", error)` with the message `"unable to compute flag locally"`. This is inconsistent with `GetFeatureFlag` and `IsFeatureEnabled` which return `(nil, nil)` and `(false, nil)` respectively in the same scenario.

The fix passes through `err` at the final return instead of always constructing a new error, matching the pattern already used by `GetFeatureFlag`.

## How did you test it?

Added regression test `TestGetFeatureFlagPayloadNoMatchReturnsNoError` using a fixture with a 0% rollout flag and `OnlyEvaluateLocally: true`, asserting `("", nil)` is returned. All existing feature flag tests continue to pass.

## Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.