### PR TITLE
feat: add `locally_evaluated` property to `$feature_flag_called`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `locally_evaluated` property to `$feature_flag_called` events, indicating whether the flag was evaluated locally or via the remote `/flags` endpoint.
+
 ## 1.11.2 - 2026-03-26
 
 * [Full Changelog](https://github.com/PostHog/posthog-go/compare/v1.11.1...v1.11.2)

--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -710,9 +711,28 @@ func TestGetFeatureFlag(t *testing.T) {
 
 	defer server.Close()
 
+	var capturedEvent *CaptureInApi
+	var mu sync.Mutex
+	eventCaptured := make(chan struct{}, 1)
+
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
 		PersonalApiKey: "some very secret key",
 		Endpoint:       server.URL,
+		BatchSize:      1,
+		Callback: testCallback{
+			func(m APIMessage) {
+				if capture, ok := m.(CaptureInApi); ok {
+					mu.Lock()
+					capturedEvent = &capture
+					mu.Unlock()
+					select {
+					case eventCaptured <- struct{}{}:
+					default:
+					}
+				}
+			},
+			func(m APIMessage, e error) {},
+		},
 	})
 	defer client.Close()
 
@@ -725,6 +745,97 @@ func TestGetFeatureFlag(t *testing.T) {
 
 	if variant != "variant-1" {
 		t.Error("Should match")
+	}
+
+	select {
+	case <-eventCaptured:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for captured event")
+	}
+
+	mu.Lock()
+	lastEvent := capturedEvent
+	mu.Unlock()
+
+	if lastEvent == nil || lastEvent.Event != "$feature_flag_called" {
+		t.Errorf("Expected a $feature_flag_called event, got: %v", lastEvent)
+	}
+
+	if lastEvent != nil {
+		if lastEvent.Properties["$feature_flag"] != "test-get-feature" {
+			t.Errorf("Expected feature flag key 'test-get-feature', got: %v", lastEvent.Properties["$feature_flag"])
+		}
+		if lastEvent.Properties["$feature_flag_response"] != "variant-1" {
+			t.Errorf("Expected feature flag response 'variant-1', got: %v", lastEvent.Properties["$feature_flag_response"])
+		}
+		if lastEvent.Properties["locally_evaluated"] != false {
+			t.Errorf("Expected locally_evaluated to be false (test-get-feature is only in /flags response), got: %v", lastEvent.Properties["locally_evaluated"])
+		}
+	}
+}
+
+func TestGetFeatureFlagLocallyEvaluated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/flags") {
+			w.Write([]byte(fixture("test-flags-v3.json")))
+		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
+		}
+	}))
+	defer server.Close()
+
+	var capturedEvent *CaptureInApi
+	var mu sync.Mutex
+	eventCaptured := make(chan struct{}, 1)
+
+	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
+		PersonalApiKey: "some very secret key",
+		Endpoint:       server.URL,
+		BatchSize:      1,
+		Callback: testCallback{
+			func(m APIMessage) {
+				if capture, ok := m.(CaptureInApi); ok {
+					mu.Lock()
+					capturedEvent = &capture
+					mu.Unlock()
+					select {
+					case eventCaptured <- struct{}{}:
+					default:
+					}
+				}
+			},
+			func(m APIMessage, e error) {},
+		},
+	})
+	defer client.Close()
+
+	value, err := client.GetFeatureFlag(FeatureFlagPayload{
+		Key:              "simple-flag",
+		DistinctId:       "distinct_id",
+		PersonProperties: NewProperties().Set("region", "USA"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != true {
+		t.Errorf("Expected simple-flag to evaluate to true, got: %v", value)
+	}
+
+	select {
+	case <-eventCaptured:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for captured event")
+	}
+
+	mu.Lock()
+	lastEvent := capturedEvent
+	mu.Unlock()
+
+	if lastEvent == nil || lastEvent.Event != "$feature_flag_called" {
+		t.Fatalf("Expected a $feature_flag_called event, got: %v", lastEvent)
+	}
+	if lastEvent.Properties["locally_evaluated"] != true {
+		t.Errorf("Expected locally_evaluated to be true for local evaluation, got: %v", lastEvent.Properties["locally_evaluated"])
 	}
 }
 

--- a/featureflags.go
+++ b/featureflags.go
@@ -532,10 +532,11 @@ func (poller *FeatureFlagsPoller) fetchNewFeatureFlags() {
 	})
 }
 
-func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) (interface{}, error) {
+func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) (interface{}, bool, error) {
 	flag, err := poller.getFeatureFlag(flagConfig)
 
 	var result interface{}
+	locallyEvaluated := false
 
 	if flag.Key != "" {
 		result, err = poller.computeFlagLocally(
@@ -547,6 +548,9 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 			flagConfig.GroupProperties,
 			poller.getCohorts(),
 		)
+		if err == nil && result != nil {
+			locallyEvaluated = true
+		}
 	}
 
 	if err != nil {
@@ -556,11 +560,11 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 	if (err != nil || result == nil) && !flagConfig.OnlyEvaluateLocally {
 		result, err = poller.getFeatureFlagVariant(flagConfig.Key, flagConfig.DistinctId, flagConfig.DeviceId, flagConfig.Groups, flagConfig.PersonProperties, flagConfig.GroupProperties)
 		if err != nil {
-			return nil, err
+			return nil, locallyEvaluated, err
 		}
 	}
 
-	return result, err
+	return result, locallyEvaluated, err
 }
 
 func (poller *FeatureFlagsPoller) GetFeatureFlagPayload(flagConfig FeatureFlagPayload) (string, error) {
@@ -602,9 +606,10 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagPayload(flagConfig FeatureFlagPa
 // flagValueAndPayload holds the result of a single flag evaluation that returns
 // both the flag value and its payload, avoiding the need for double evaluation.
 type flagValueAndPayload struct {
-	value   interface{}
-	payload string
-	err     error
+	value            interface{}
+	payload          string
+	err              error
+	locallyEvaluated bool
 }
 
 // GetFeatureFlagWithPayload evaluates a feature flag once and returns both its value
@@ -640,12 +645,15 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagWithPayload(flagConfig FeatureFl
 		}
 	}
 
+	locallyEvaluated := err == nil && result != nil
+
 	// Fall back to remote evaluation if local didn't produce a result
 	if (err != nil || result == nil) && !flagConfig.OnlyEvaluateLocally {
 		flagsResponse, remoteErr := poller.getFeatureFlagVariants(flagConfig.DistinctId, flagConfig.DeviceId, flagConfig.Groups, flagConfig.PersonProperties, flagConfig.GroupProperties)
 		if remoteErr != nil {
 			return flagValueAndPayload{value: nil, err: remoteErr}
 		}
+		locallyEvaluated = false
 		// Clear local eval error — we successfully made a remote request
 		err = nil
 		if flagsResponse != nil {
@@ -663,7 +671,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagWithPayload(flagConfig FeatureFl
 		}
 	}
 
-	return flagValueAndPayload{value: result, payload: payload, err: err}
+	return flagValueAndPayload{value: result, payload: payload, err: err, locallyEvaluated: locallyEvaluated}
 }
 
 func (poller *FeatureFlagsPoller) getFeatureFlag(flagConfig FeatureFlagPayload) (FeatureFlag, error) {

--- a/featureflags.go
+++ b/featureflags.go
@@ -548,9 +548,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 			flagConfig.GroupProperties,
 			poller.getCohorts(),
 		)
-		if err == nil && result != nil {
-			locallyEvaluated = true
-		}
+		locallyEvaluated = err == nil && result != nil
 	}
 
 	if err != nil {

--- a/posthog.go
+++ b/posthog.go
@@ -508,11 +508,13 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 	var payloadStr string
 	var variantStr string
 	var hasPayload, hasVariant bool
+	var locallyEvaluated bool
 
 	if c.featureFlagsPoller != nil {
 		// Evaluate flag once to get both value and payload (avoids double evaluation)
 		combined := c.featureFlagsPoller.GetFeatureFlagWithPayload(flagConfig)
 		flagValue = combined.value
+		locallyEvaluated = combined.locallyEvaluated
 		err = combined.err
 		evalResult.Value = flagValue
 		evalResult.Err = err
@@ -527,6 +529,7 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 	} else {
 		// if there's no poller, get the feature flag from the flags endpoint
 		c.debugf("getting feature flag from flags endpoint")
+		locallyEvaluated = false
 		remoteResult := c.getFeatureFlagFromRemote(flagConfig.Key, flagConfig.DistinctId, flagConfig.DeviceId, flagConfig.Groups,
 			flagConfig.PersonProperties, flagConfig.GroupProperties)
 		evalResult = *remoteResult
@@ -560,7 +563,8 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 	if *flagConfig.SendFeatureFlagEvents && !c.distinctIdsFeatureFlagsReported.Contains(cacheKey) {
 		var properties = NewProperties().
 			Set("$feature_flag", flagConfig.Key).
-			Set("$feature_flag_response", flagValue)
+			Set("$feature_flag_response", flagValue).
+			Set("locally_evaluated", locallyEvaluated)
 
 		if flagConfig.DeviceId != nil {
 			properties.Set("$device_id", *flagConfig.DeviceId)

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -1581,6 +1581,9 @@ func TestGetFeatureFlagWithNoPersonalApiKey(t *testing.T) {
 		if lastEvent.Properties["$feature_flag_response"] != expectedValue {
 			t.Errorf("Expected feature flag response %v, got: %v", expectedValue, lastEvent.Properties["$feature_flag_response"])
 		}
+		if lastEvent.Properties["locally_evaluated"] != false {
+			t.Errorf("Expected locally_evaluated to be false for remote evaluation, got: %v", lastEvent.Properties["locally_evaluated"])
+		}
 	}
 
 	// Test a bunch of GetFeatureFlag scenarios


### PR DESCRIPTION
## :bulb: Motivation and Context

Bring this in line with other SDKs by setting a `locally_evaluated` property on `$feature_flag_called` events to indicate whether the flag was evaluated locally.


## :green_heart: How did you test it?

New unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
