### PR TITLE
feat: support custom properties on exception events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,3 @@
-### New Features
-
-* **Custom properties on exceptions**: `Exception` now has a `Properties` field for attaching arbitrary key/value metadata to a captured exception. Custom keys are flattened into the event's `properties` object alongside the built-in ones. Reserved keys (`$lib`, `$lib_version`, `distinct_id`, `$exception_list`, `$exception_fingerprint`, `$geoip_disable`, system context) are preserved — colliding custom keys are ignored.
-* **slog custom properties**: `NewSlogCaptureHandler` accepts a new `WithPropertiesFn` option that returns custom properties per `slog.Record`. A ready-made `SlogAttrsAsProperties` helper copies every slog attribute onto the event — the common case is a one-liner.
-
-```go
-client.Enqueue(posthog.Exception{
-    DistinctId: "user-123",
-    Timestamp:  time.Now(),
-    Properties: posthog.Properties{
-        "environment": "production",
-        "retry_count": 3,
-    },
-    ExceptionList: []posthog.ExceptionItem{
-        {Type: "Payment failed", Value: "Card declined"},
-    },
-})
-
-logger := slog.New(posthog.NewSlogCaptureHandler(baseHandler, client,
-    posthog.WithPropertiesFn(posthog.SlogAttrsAsProperties),
-))
-logger.Error("Payment failed", "payment_id", "pay_123", "amount", 99.99)
-```
-
 ## 1.11.3 - 2026-04-14
 
 * [Full Changelog](https://github.com/PostHog/posthog-go/compare/v1.11.2...v1.11.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+### New Features
+
+* **Custom properties on exceptions**: `Exception` now has a `Properties` field for attaching arbitrary key/value metadata to a captured exception. Custom keys are flattened into the event's `properties` object alongside the built-in ones. Reserved keys (`$lib`, `$lib_version`, `distinct_id`, `$exception_list`, `$exception_fingerprint`, `$geoip_disable`, system context) are preserved — colliding custom keys are ignored.
+* **slog custom properties**: `NewSlogCaptureHandler` accepts a new `WithPropertiesFn` option that returns custom properties per `slog.Record`. A ready-made `SlogAttrsAsProperties` helper copies every slog attribute onto the event — the common case is a one-liner.
+
+```go
+client.Enqueue(posthog.Exception{
+    DistinctId: "user-123",
+    Timestamp:  time.Now(),
+    Properties: posthog.Properties{
+        "environment": "production",
+        "retry_count": 3,
+    },
+    ExceptionList: []posthog.ExceptionItem{
+        {Type: "Payment failed", Value: "Card declined"},
+    },
+})
+
+logger := slog.New(posthog.NewSlogCaptureHandler(baseHandler, client,
+    posthog.WithPropertiesFn(posthog.SlogAttrsAsProperties),
+))
+logger.Error("Payment failed", "payment_id", "pay_123", "amount", 99.99)
+```
+
 ## 1.11.3 - 2026-04-14
 
 * [Full Changelog](https://github.com/PostHog/posthog-go/compare/v1.11.2...v1.11.3)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ func main() {
       "Error Description",
     ))
 
+    // Capture an error with custom properties
+    client.Enqueue(posthog.Exception{
+      DistinctId: "distinct-id",
+      Timestamp:  time.Now(),
+      Properties: posthog.Properties{
+        "environment": "production",
+        "retry_count": 3,
+      },
+      ExceptionList: []posthog.ExceptionItem{
+        {Type: "Error title", Value: "Error Description"},
+      },
+    })
+
     // Create a logger which automatically captures warning logs and above
     baseLogHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
     logger := slog.New(posthog.NewSlogCaptureHandler(baseLogHandler, client,
@@ -84,6 +97,15 @@ func main() {
       }),
     })
     logger.Warn("Log that something broke", "error", fmt.Errorf("this is a dummy scenario"))
+
+    // Optionally forward all slog attributes as event properties
+    loggerWithProps := slog.New(posthog.NewSlogCaptureHandler(baseLogHandler, client,
+      posthog.WithDistinctIDFn(func(ctx context.Context, r slog.Record) string {
+        return "my-user-id"
+      }),
+      posthog.WithPropertiesFn(posthog.SlogAttrsAsProperties),
+    ))
+    loggerWithProps.Error("Payment failed", "payment_id", "pay_123", "amount", 99.99)
 
     // Capture event with calculated uuid to deduplicate repeated events.
     // The library github.com/google/uuid is used

--- a/error_tracking.go
+++ b/error_tracking.go
@@ -1,6 +1,7 @@
 package posthog
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -15,9 +16,9 @@ type Exception struct {
 
 	DistinctId   string
 	Timestamp    time.Time
+	Properties   Properties
 	DisableGeoIP bool
 
-	// Typed properties that end up in the API "properties" object:
 	ExceptionList        []ExceptionItem
 	ExceptionFingerprint *string
 }
@@ -72,6 +73,43 @@ type ExceptionInApiProperties struct {
 	DisableGeoIP         bool            `json:"$geoip_disable,omitempty"`
 	ExceptionList        []ExceptionItem `json:"$exception_list"`
 	ExceptionFingerprint *string         `json:"$exception_fingerprint,omitempty"`
+
+	// Custom is flattened into the wire "properties" on marshal.
+	// Typed fields win on collision.
+	Custom Properties `json:"-"`
+}
+
+// MarshalJSON lets users add extra keys (via Custom) to the event's
+// JSON output next to the built-in ones like $lib and distinct_id.
+// If a custom key clashes with a built-in, we keep ours and drop theirs.
+func (p ExceptionInApiProperties) MarshalJSON() ([]byte, error) {
+	type alias ExceptionInApiProperties
+	typedBytes, err := json.Marshal(alias(p))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(p.Custom) == 0 {
+		return typedBytes, nil
+	}
+
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(typedBytes, &merged); err != nil {
+		return nil, err
+	}
+
+	for k, v := range p.Custom {
+		if _, exists := merged[k]; exists {
+			continue
+		}
+		vb, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		merged[k] = vb
+	}
+
+	return json.Marshal(merged)
 }
 
 func (msg Exception) internal() { panic(unimplementedError) }
@@ -137,6 +175,7 @@ func (msg Exception) APIfy() APIMessage {
 			DisableGeoIP:         msg.DisableGeoIP,
 			ExceptionList:        msg.ExceptionList,
 			ExceptionFingerprint: msg.ExceptionFingerprint,
+			Custom:               msg.Properties,
 		},
 	}
 }

--- a/error_tracking_slog.go
+++ b/error_tracking_slog.go
@@ -69,6 +69,7 @@ func (h *SlogCaptureHandler) Handle(ctx context.Context, r slog.Record) error {
 			},
 		},
 		ExceptionFingerprint: h.cfg.fingerprint(ctx, r),
+		Properties:           h.cfg.properties(ctx, r),
 	}
 	_ = h.client.Enqueue(ex) // ignore enqueue error to keep logging safe
 
@@ -89,6 +90,23 @@ func (h *SlogCaptureHandler) WithGroup(name string) slog.Handler {
 		client: h.client,
 		cfg:    h.cfg,
 	}
+}
+
+// SlogAttrsAsProperties is a convenience implementation of the fn passed to
+// WithPropertiesFn. It copies every slog.Record attribute into a Properties
+// map, so log fields flow onto the captured exception event verbatim.
+//
+// Usage: posthog.WithPropertiesFn(posthog.SlogAttrsAsProperties)
+//
+// Note: this ships all attrs to PostHog — make sure none contain sensitive
+// data, or write a filtering fn instead.
+func SlogAttrsAsProperties(_ context.Context, r slog.Record) Properties {
+	props := NewProperties()
+	r.Attrs(func(a slog.Attr) bool {
+		props.Set(a.Key, a.Value.Any())
+		return true
+	})
+	return props
 }
 
 // DescriptionExtractor defines the interface for extracting a human-readable

--- a/error_tracking_slog_options.go
+++ b/error_tracking_slog_options.go
@@ -36,6 +36,11 @@ type captureConfig struct {
 	// record for fields like "err" or "error" and uses the extracted
 	// error message as the description.
 	descriptionExtractor DescriptionExtractor
+
+	// properties optionally returns custom properties to attach to the
+	// captured exception event. Returning nil attaches no extra properties.
+	// User-supplied keys override the built-in ones (e.g. "$lib", "distinct_id").
+	properties func(ctx context.Context, r slog.Record) Properties
 }
 
 func defaultCaptureConfig() captureConfig {
@@ -54,6 +59,9 @@ func defaultCaptureConfig() captureConfig {
 		descriptionExtractor: ErrorExtractor{
 			ErrorKeys: []string{"err", "error"},
 			Fallback:  "<no linked error>",
+		},
+		properties: func(ctx context.Context, r slog.Record) Properties {
+			return nil
 		},
 	}
 }
@@ -86,4 +94,12 @@ func WithStackTraceExtractor(extractor StackTraceExtractor) SlogOption {
 
 func WithDescriptionExtractor(extractor DescriptionExtractor) SlogOption {
 	return func(c *captureConfig) { c.descriptionExtractor = extractor }
+}
+
+func WithPropertiesFn(fn func(ctx context.Context, r slog.Record) Properties) SlogOption {
+	return func(c *captureConfig) {
+		if fn != nil {
+			c.properties = fn
+		}
+	}
 }

--- a/error_tracking_slog_test.go
+++ b/error_tracking_slog_test.go
@@ -178,3 +178,58 @@ func TestErrorExtractor_ExtractDescription(t *testing.T) {
 		})
 	}
 }
+
+func TestSlogCaptureHandler_WithPropertiesFn(t *testing.T) {
+	next := &fakeNextSlogHandler{isEnabled: true}
+	client := &fakeEnqueueClient{}
+	ctx := context.Background()
+
+	handler := NewSlogCaptureHandler(next, client,
+		WithMinCaptureLevel(slog.LevelWarn),
+		WithDistinctIDFn(func(_ context.Context, _ slog.Record) string {
+			return "test-user"
+		}),
+		WithPropertiesFn(func(_ context.Context, r slog.Record) Properties {
+			props := NewProperties()
+			r.Attrs(func(a slog.Attr) bool {
+				props.Set(a.Key, a.Value.Any())
+				return true
+			})
+			return props
+		}),
+	)
+
+	record := createLogRecord(slog.LevelError, "test error",
+		slog.String("environment", "production"),
+		slog.Int("retry_count", 3),
+	)
+
+	if err := handler.Handle(ctx, record); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+
+	if len(client.enqueuedMsgs) != 1 {
+		t.Fatalf("expected 1 enqueued message, got %d", len(client.enqueuedMsgs))
+	}
+
+	exception, ok := client.enqueuedMsgs[0].(Exception)
+	if !ok {
+		t.Fatalf("expected Exception, got %T", client.enqueuedMsgs[0])
+	}
+
+	if exception.Properties == nil {
+		t.Fatal("expected Properties to be set")
+	}
+
+	expectedProps := map[string]interface{}{
+		"environment": "production",
+		"retry_count": int64(3),
+	}
+
+	for key, expected := range expectedProps {
+		if exception.Properties[key] != expected {
+			t.Errorf("property %s: expected %v (type %T), got %v (type %T)",
+				key, expected, expected, exception.Properties[key], exception.Properties[key])
+		}
+	}
+}

--- a/error_tracking_test.go
+++ b/error_tracking_test.go
@@ -1,6 +1,7 @@
 package posthog
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -114,5 +115,157 @@ func TestException_Validate(t *testing.T) {
 				t.Errorf("expected error:\n%v \ngot:\n%v", tc.expectedError, err)
 			}
 		})
+	}
+}
+
+func TestException_APIfy_WithCustomProperties(t *testing.T) {
+	now := time.Now()
+	exList := []ExceptionItem{{Type: "Error", Value: "Something went wrong"}}
+
+	fingerprintStr := "custom-fingerprint"
+
+	tests := map[string]struct {
+		exception       Exception
+		expectKeys      map[string]interface{}
+		forbiddenValues []string
+	}{
+		"basic without custom properties": {
+			exception: Exception{DistinctId: "user-123", Timestamp: now, ExceptionList: exList},
+			expectKeys: map[string]interface{}{
+				"$lib":         SDKName,
+				"$lib_version": getVersion(),
+				"distinct_id":  "user-123",
+			},
+		},
+		"with custom properties and fingerprint": {
+			exception: Exception{
+				DistinctId:           "user-123",
+				Timestamp:            now,
+				ExceptionFingerprint: &fingerprintStr,
+				Properties:           NewProperties().Set("environment", "production").Set("retry_count", 3),
+				ExceptionList:        exList,
+			},
+			expectKeys: map[string]interface{}{
+				"$lib":                   SDKName,
+				"$lib_version":           getVersion(),
+				"distinct_id":            "user-123",
+				"$exception_fingerprint": "custom-fingerprint",
+				"environment":            "production",
+				"retry_count":            float64(3),
+			},
+		},
+		"typed fields win on collision with custom": {
+			exception: Exception{
+				DistinctId:    "user-123",
+				Timestamp:     now,
+				Properties:    NewProperties().Set("$lib", "custom-lib").Set("distinct_id", "custom-id"),
+				ExceptionList: exList,
+			},
+			expectKeys: map[string]interface{}{
+				"$lib":        SDKName,
+				"distinct_id": "user-123",
+			},
+			forbiddenValues: []string{"custom-lib", "custom-id"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			apiMsg, ok := tc.exception.APIfy().(ExceptionInApi)
+			if !ok {
+				t.Fatalf("expected ExceptionInApi, got %T", tc.exception.APIfy())
+			}
+
+			jsonBytes, err := json.Marshal(apiMsg)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+
+			var wire map[string]interface{}
+			if err := json.Unmarshal(jsonBytes, &wire); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			props, ok := wire["properties"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("properties field missing or wrong type")
+			}
+
+			for k, want := range tc.expectKeys {
+				if got := props[k]; !reflect.DeepEqual(got, want) {
+					t.Errorf("property %q: expected %v (%T), got %v (%T)", k, want, want, got, got)
+				}
+			}
+
+			for _, forbidden := range tc.forbiddenValues {
+				for k, v := range props {
+					if s, ok := v.(string); ok && s == forbidden {
+						t.Errorf("forbidden value %q leaked into property %q", forbidden, k)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestException_JSONSerialization(t *testing.T) {
+	fingerprint := "custom-fingerprint-123"
+	exception := Exception{
+		Type:                 "exception",
+		Uuid:                 "01963f1a-3c12-7b21-8a1d-3f6d1cf49b8e",
+		DistinctId:           "user-123",
+		Timestamp:            time.Date(2024, 11, 17, 10, 30, 0, 0, time.UTC),
+		Properties:           NewProperties().Set("environment", "production").Set("custom_key", "custom_value"),
+		DisableGeoIP:         true,
+		ExceptionFingerprint: &fingerprint,
+		ExceptionList:        []ExceptionItem{{Type: "RuntimeError", Value: "Database connection failed"}},
+	}
+
+	jsonBytes, err := json.Marshal(exception.APIfy())
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &result); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	props, ok := result["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("properties field missing or wrong type")
+	}
+
+	tests := []struct {
+		obj      map[string]interface{}
+		field    string
+		expected interface{}
+	}{
+		{result, "type", "exception"},
+		{result, "uuid", "01963f1a-3c12-7b21-8a1d-3f6d1cf49b8e"},
+		{result, "event", "$exception"},
+		{result, "library", SDKName},
+		{result, "library_version", getVersion()},
+		{props, "$lib", SDKName},
+		{props, "$lib_version", getVersion()},
+		{props, "distinct_id", "user-123"},
+		{props, "$geoip_disable", true},
+		{props, "$exception_fingerprint", "custom-fingerprint-123"},
+		{props, "environment", "production"},
+		{props, "custom_key", "custom_value"},
+	}
+
+	for _, tc := range tests {
+		if tc.obj[tc.field] != tc.expected {
+			t.Errorf("%s: expected %v, got %v", tc.field, tc.expected, tc.obj[tc.field])
+		}
+	}
+
+	exList, ok := props["$exception_list"].([]interface{})
+	if !ok {
+		t.Errorf("$exception_list: expected []interface{}, got %T", props["$exception_list"])
+	}
+	if len(exList) == 0 {
+		t.Errorf("$exception_list: expected non-empty list, got empty")
 	}
 }

--- a/examples/error_tracking.go
+++ b/examples/error_tracking.go
@@ -38,6 +38,22 @@ func TestErrorTrackingThroughEnqueueing(projectAPIKey, endpoint string) {
 				fmt.Println("error:", err)
 				return
 			}
+
+			exceptionWithProps := posthog.Exception{
+				DistinctId: "distinct-id",
+				Timestamp:  time.Now(),
+				Properties: posthog.Properties{
+					"environment": "production",
+					"retry_count": 3,
+				},
+				ExceptionList: []posthog.ExceptionItem{
+					{Type: "Enqueued error with custom props", Value: "Error Description"},
+				},
+			}
+			if err := client.Enqueue(exceptionWithProps); err != nil {
+				fmt.Println("error:", err)
+				return
+			}
 		}
 	}
 }
@@ -57,6 +73,7 @@ func TestErrorTrackingThroughLogHandler(projectAPIKey, endpoint string) {
 			// for demo purposes, real applications should likely pull this value from the context.
 			return "my-user-id"
 		}),
+		posthog.WithPropertiesFn(posthog.SlogAttrsAsProperties),
 	))
 
 	done := time.After(3 * time.Second)
@@ -71,6 +88,8 @@ func TestErrorTrackingThroughLogHandler(projectAPIKey, endpoint string) {
 		case <-tick:
 			log.Warn("Log that something broke",
 				"error", fmt.Errorf("this is a dummy scenario"),
+				"retry_count", 3,
+				"endpoint", "/api/v1/users",
 			)
 		}
 	}


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds a Properties field to Exception, plus a SlogAttrsAsProperties helper and WithPropertiesFn option for the slog capture handler. 

Closes #132 

* **Custom properties on exceptions**: `Exception` now has a `Properties` field for attaching arbitrary key/value metadata to a captured exception. Custom keys are flattened into the event's `properties` object alongside the built-in ones. Reserved keys (`$lib`, `$lib_version`, `distinct_id`, `$exception_list`, `$exception_fingerprint`, `$geoip_disable`, system context) are preserved — colliding custom keys are ignored.
* **slog custom properties**: `NewSlogCaptureHandler` accepts a new `WithPropertiesFn` option that returns custom properties per `slog.Record`. A ready-made `SlogAttrsAsProperties` helper copies every slog attribute onto the event — the common case is a one-liner.

```go
client.Enqueue(posthog.Exception{
    DistinctId: "user-123",
    Timestamp:  time.Now(),
    Properties: posthog.Properties{
        "environment": "production",
        "retry_count": 3,
    },
    ExceptionList: []posthog.ExceptionItem{
        {Type: "Payment failed", Value: "Card declined"},
    },
})

logger := slog.New(posthog.NewSlogCaptureHandler(baseHandler, client,
    posthog.WithPropertiesFn(posthog.SlogAttrsAsProperties),
))
logger.Error("Payment failed", "payment_id", "pay_123", "amount", 99.99)
```

## :green_heart: How did you test it?
Manually and with with tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
