### PR TITLE
feat(flags): switch local evaluation endpoint to /flags/definitions

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -203,7 +203,7 @@ func BenchmarkFeatureFlagLocalEvaluation(b *testing.B) {
 	// Setup server that returns actual flag definitions
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation"):
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
 			w.Write([]byte(fixture("test-api-feature-flag.json")))
 		case strings.HasPrefix(r.URL.Path, "/batch"):
 			io.Copy(io.Discard, r.Body)

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -133,7 +133,7 @@ func TestConcurrentFeatureFlagEvaluation(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		// Return proper format for both local evaluation and flags endpoints
-		if r.URL.Path == "/api/feature_flag/local_evaluation" {
+		if r.URL.Path == "/flags/definitions" {
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"flags": []map[string]interface{}{
 					{

--- a/feature_flags_dependencies_test.go
+++ b/feature_flags_dependencies_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestFlagDependenciesSimpleChain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(`{
 				"flags": [
 					{
@@ -109,7 +109,7 @@ func TestFlagDependenciesSimpleChain(t *testing.T) {
 
 func TestFlagDependenciesCircularDependency(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(`{
 				"flags": [
 					{
@@ -193,7 +193,7 @@ func TestFlagDependenciesCircularDependency(t *testing.T) {
 
 func TestFlagDependenciesMissingFlag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(`{
 				"flags": [
 					{
@@ -246,7 +246,7 @@ func TestFlagDependenciesMissingFlag(t *testing.T) {
 
 func TestFlagDependenciesComplexChain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(`{
 				"flags": [
 					{
@@ -355,7 +355,7 @@ func TestFlagDependenciesComplexChain(t *testing.T) {
 
 func TestFlagDependenciesMixedConditions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(`{
 				"flags": [
 					{
@@ -440,7 +440,7 @@ func TestFlagDependenciesMixedConditions(t *testing.T) {
 
 func TestFlagDependenciesMalformedChain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(`{
 				"flags": [
 					{
@@ -508,7 +508,7 @@ func TestFlagDependenciesMalformedChain(t *testing.T) {
 // This test is equivalent to the EvaluatesMultiLevelMultivariateDependencyChain test in the .NET SDK
 func TestMultiLevelMultivariateDependencyChain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(`{
 				"flags": [
 					{

--- a/feature_flags_flags_test.go
+++ b/feature_flags_flags_test.go
@@ -82,7 +82,7 @@ func TestFlags(t *testing.T) {
 	for _, test := range tests {
 		test := test // Capture loop variable for Go 1.21 compatibility
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				w.Write([]byte(fixture(test.fixture)))
 			}
 		}))
@@ -211,7 +211,7 @@ func TestFlags(t *testing.T) {
 
 func TestFeatureFlagCalledIncludesDeviceId(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v4.json")))
 		}
 	}))
@@ -366,7 +366,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 
 	t.Run("API error sets $feature_flag_error with status code", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(`{"error": "Internal Server Error"}`))
 			}
@@ -432,7 +432,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 
 func TestFlagsV4(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v4.json")))
 		}
 	}))
@@ -553,7 +553,7 @@ func TestGetFeatureFlagResult(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				w.Write([]byte(fixture(test.fixture)))
 			}
 		}))
@@ -729,7 +729,7 @@ func TestGetFeatureFlagResult(t *testing.T) {
 
 func TestGetFeatureFlagResultGetPayloadAs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v4.json")))
 		}
 	}))
@@ -778,7 +778,7 @@ func TestGetFeatureFlagResultGetPayloadAs(t *testing.T) {
 
 func TestGetFeatureFlagResultReturnsErrorForNonExistentFlag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			// Return empty flags - the requested flag won't exist
 			w.Write([]byte(`{"flags": [], "group_type_mapping": {}}`))
 		}
@@ -812,7 +812,7 @@ func TestGetFeatureFlagResultReturnsErrorForNonExistentFlag(t *testing.T) {
 
 func TestGetFeatureFlagResultPropagatesLocalEvaluationErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}))
@@ -851,7 +851,7 @@ func TestGetFeatureFlagResultPropagatesLocalEvaluationErrors(t *testing.T) {
 
 func TestGetFeatureFlagResultPropagatesRemoteAPIErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(`{"error": "Internal Server Error"}`))
 		}

--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -22,9 +22,9 @@ import (
 
 func TestFlagPersonProperty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
 		}
 	}))
@@ -64,7 +64,7 @@ func TestFlagPersonProperty(t *testing.T) {
 
 func TestFlagGroup(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			decoder := json.NewDecoder(r.Body)
 			decoder.DisallowUnknownFields()
 			var reqBody FlagsRequestData
@@ -98,7 +98,7 @@ func TestFlagGroup(t *testing.T) {
 				t.Errorf("Expected groupProperties to be map[company:map[name:Project Name 1]], got %s", reqBody.GroupProperties)
 			}
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-flag-group-properties.json")))
 		} else if strings.HasPrefix(r.URL.Path, "/batch/") {
 			// Ignore batch requests
@@ -182,9 +182,9 @@ func TestFlagGroupProperty(t *testing.T) {
 
 func TestComplexDefinition(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-complex-definition.json"))) // Don't return anything for local eval
 		}
 	}))
@@ -220,9 +220,9 @@ func TestComplexDefinition(t *testing.T) {
 
 func TestFallbackToFlags(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte("{}")) // Don't return anything for local eval
 		}
 	}))
@@ -249,9 +249,9 @@ func TestFallbackToFlags(t *testing.T) {
 
 func TestFeatureFlagsDontFallbackToFlagsWhenOnlyLocalEvaluationIsTrue(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte("test-flags-v3.json"))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-feature-flags-dont-fallback-to-decide-when-only-local-evaluation-is-true.json")))
 		}
 	}))
@@ -326,9 +326,9 @@ func TestFeatureFlagsDontFallbackToFlagsWhenOnlyLocalEvaluationIsTrue(t *testing
 
 func TestFeatureFlagDefaultsDontHinderEvaluation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-false.json")))
 		}
 	}))
@@ -435,9 +435,9 @@ func TestFeatureFlagNullComeIntoPlayOnlyWhenFlagsErrorsOut(t *testing.T) {
 
 func TestExperienceContinuityOverride(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-simple-flag.json")))
 		}
 	}))
@@ -475,9 +475,9 @@ func TestExperienceContinuityOverride(t *testing.T) {
 
 func TestGetAllFlags(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-multiple-flags.json")))
 		}
 	}))
@@ -501,9 +501,9 @@ func TestGetAllFlags(t *testing.T) {
 
 func TestGetAllFlagsEmptyLocal(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte("{}"))
 		}
 	}))
@@ -529,9 +529,9 @@ func TestGetAllFlagsEmptyLocal(t *testing.T) {
 
 func TestGetAllFlagsNoRemoteFallback(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-multiple-flags-valid.json")))
 		}
 	}))
@@ -555,9 +555,9 @@ func TestGetAllFlagsNoRemoteFallback(t *testing.T) {
 
 func TestGetAllFlagsOnlyLocalEvaluationSet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-get-all-flags-with-fallback-but-only-local-evaluation-set.json")))
 		}
 	}))
@@ -582,9 +582,9 @@ func TestGetAllFlagsOnlyLocalEvaluationSet(t *testing.T) {
 
 func TestComputeInactiveFlagsLocally(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-compute-inactive-flags-locally.json")))
 		}
 	}))
@@ -606,9 +606,9 @@ func TestComputeInactiveFlagsLocally(t *testing.T) {
 	}
 
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-compute-inactive-flags-locally-2.json")))
 		}
 	}))
@@ -632,7 +632,7 @@ func TestComputeInactiveFlagsLocally(t *testing.T) {
 
 func TestFeatureFlagWithDependencies(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-flag-with-dependencies.json")))
 		}
 	}))
@@ -702,9 +702,9 @@ func TestFeatureEnabledSimpleIsTrueWhenRolloutUndefined(t *testing.T) {
 
 func TestGetFeatureFlag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
 		}
 	}))
@@ -776,9 +776,9 @@ func TestGetFeatureFlag(t *testing.T) {
 
 func TestGetFeatureFlagLocallyEvaluated(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
 		}
 	}))
@@ -841,9 +841,9 @@ func TestGetFeatureFlagLocallyEvaluated(t *testing.T) {
 
 func TestGetFeatureFlagPayload(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
 		}
 	}))
@@ -897,9 +897,9 @@ func TestGetRemoteConfigPayload(t *testing.T) {
 func TestFlagWithVariantOverrides(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-variant-override.json")))
 		}
 	}))
@@ -961,9 +961,9 @@ func TestFlagWithVariantOverrides(t *testing.T) {
 
 func TestFlagWithClashingVariantOverrides(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-variant-override-clashing.json")))
 		}
 	}))
@@ -1027,9 +1027,9 @@ func TestFlagWithClashingVariantOverrides(t *testing.T) {
 
 func TestFlagWithInvalidVariantOverrides(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-variant-override-invalid.json")))
 		}
 	}))
@@ -1091,9 +1091,9 @@ func TestFlagWithInvalidVariantOverrides(t *testing.T) {
 
 func TestConditionsEvaluatedInOrder(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-condition-order.json")))
 		}
 	}))
@@ -1162,9 +1162,9 @@ func TestConditionsEvaluatedInOrder(t *testing.T) {
 
 func TestCaptureIsCalled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
 		}
 	}))
@@ -4280,7 +4280,7 @@ func TestMultivariateFlagConsistencyPayload(t *testing.T) {
 
 func TestFlagsFetchFail(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.WriteHeader(http.StatusInternalServerError)
 		} else if strings.HasPrefix(r.URL.Path, "/batch/") {
 			// ignore batch requests
@@ -4307,10 +4307,10 @@ func TestFlagsFetchFail(t *testing.T) {
 
 func TestFlagWithTimeoutExceeded(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			time.Sleep(1 * time.Second)
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-flag-group-properties.json")))
 		} else if strings.HasPrefix(r.URL.Path, "/batch/") {
 			// Ignore batch requests
@@ -4390,9 +4390,9 @@ func TestFlagDefinitionsWithTimeoutExceeded(t *testing.T) {
 	var buf bytes.Buffer
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			// Sleep longer than client timeout (100ms) to trigger timeout
 			time.Sleep(1 * time.Second)
 			w.Write([]byte(fixture("feature_flag/test-flag-group-properties.json")))
@@ -4486,7 +4486,7 @@ func TestFetchFlagsFails(t *testing.T) {
 // Check link: https://github.com/PostHog/posthog/blob/0bb3ed063c37f5be280e4283a0d2a6a6683a9534/rust/feature-flags/src/api/request_handler.rs#L1412
 func TestFeatureFlagWithOverrides(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-group-props.json")))
 		} else if strings.HasPrefix(r.URL.Path, "/batch/") {
 			// ignore
@@ -4567,7 +4567,7 @@ func TestFeatureFlagWithOverrides(t *testing.T) {
 
 func TestFeatureFlagDistinctIDOverride(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-distinct-id-local.json")))
 		} else if strings.HasPrefix(r.URL.Path, "/batch/") {
 			// ignore
@@ -4630,7 +4630,7 @@ func TestFeatureFlagDistinctIDOverride(t *testing.T) {
 
 func TestFeatureFlagDeviceIDBucketingLocalEvaluation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-device-id-bucketing.json")))
 		} else if strings.HasPrefix(r.URL.Path, "/batch/") {
 			// ignore
@@ -4664,7 +4664,7 @@ func TestFeatureFlagDeviceIDBucketingLocalEvaluation(t *testing.T) {
 
 func TestFeatureFlagWithFalseVariant(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("feature_flag/test-false-variant.json")))
 		} else if strings.HasPrefix(r.URL.Path, "/batch/") {
 			// ignore
@@ -5059,11 +5059,11 @@ func TestFallbackToAPIWhenFlagHasStaticCohortInMultiCondition(t *testing.T) {
 
 	var flagsAPICalled bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			// Return API response indicating user is in the static cohort
 			flagsAPICalled = true
 			w.Write([]byte(`{"featureFlags": {"multi-condition-flag": "set-1"}}`))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			// Return local evaluation data WITHOUT cohort 999 (making it a static cohort)
 			w.Write([]byte(`{
 				"flags": [
@@ -5147,11 +5147,11 @@ func TestGetFeatureFlagPayloadFallbackToAPIWhenFlagHasStaticCohort(t *testing.T)
 
 	var flagsAPICalled bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			// Return API response with payload
 			flagsAPICalled = true
 			w.Write([]byte(`{"featureFlags": {"flag-with-cohort": "variant-a"}, "featureFlagPayloads": {"flag-with-cohort": "{\"message\": \"from-api\"}"}}`))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			// Return local evaluation data WITHOUT cohort 999 (making it a static cohort)
 			w.Write([]byte(`{
 				"flags": [
@@ -5218,7 +5218,7 @@ func TestGetFeatureFlagPayloadFallbackToAPIWhenFlagHasStaticCohort(t *testing.T)
 
 func TestDateBeforeOperatorAbsolute(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			response := `{
 				"flags": [
 					{

--- a/featureflags.go
+++ b/featureflags.go
@@ -384,7 +384,7 @@ func newFeatureFlagsPoller(
 	decider decider,
 	disableGeoIP bool,
 ) (*FeatureFlagsPoller, error) {
-	localEvaluationEndpoint := "/api/feature_flag/local_evaluation"
+	localEvaluationEndpoint := "/flags/definitions"
 	localEvalURL, err := url.Parse(endpoint + localEvaluationEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("creating local evaluation URL - %w", err)

--- a/featureflags_etag_test.go
+++ b/featureflags_etag_test.go
@@ -14,7 +14,7 @@ import (
 func newTestPoller(t *testing.T, serverURL string) *FeatureFlagsPoller {
 	t.Helper()
 
-	localEvalURL, err := url.Parse(serverURL + "/api/feature_flag/local_evaluation")
+	localEvalURL, err := url.Parse(serverURL + "/flags/definitions")
 	if err != nil {
 		t.Fatalf("Failed to parse URL: %v", err)
 	}
@@ -33,7 +33,7 @@ func newTestPoller(t *testing.T, serverURL string) *FeatureFlagsPoller {
 func TestETagSupportForLocalEvaluation(t *testing.T) {
 	t.Run("stores ETag from initial response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				w.Header().Set("ETag", `"abc123"`)
 				w.Write([]byte(`{
 					"flags": [{"key": "test-flag", "active": true, "filters": {"groups": []}}],
@@ -63,7 +63,7 @@ func TestETagSupportForLocalEvaluation(t *testing.T) {
 		var receivedIfNoneMatch string
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				requestCount++
 				receivedIfNoneMatch = r.Header.Get("If-None-Match")
 
@@ -105,7 +105,7 @@ func TestETagSupportForLocalEvaluation(t *testing.T) {
 		var requestCount int
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				requestCount++
 
 				if requestCount == 1 {
@@ -147,7 +147,7 @@ func TestETagSupportForLocalEvaluation(t *testing.T) {
 		var requestCount int
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				requestCount++
 
 				if requestCount == 1 {
@@ -206,7 +206,7 @@ func TestETagSupportForLocalEvaluation(t *testing.T) {
 		var requestCount int
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				requestCount++
 
 				if requestCount == 1 {
@@ -260,7 +260,7 @@ func TestETagSupportForLocalEvaluation(t *testing.T) {
 		var requestCount int
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				requestCount++
 
 				if requestCount == 1 {
@@ -315,7 +315,7 @@ func TestETagSupportForLocalEvaluation(t *testing.T) {
 		var requestCount int
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				requestCount++
 
 				if requestCount == 1 {
@@ -373,7 +373,7 @@ func TestETagSupportForLocalEvaluation(t *testing.T) {
 		var firstRequestIfNoneMatch string
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				firstRequestIfNoneMatch = r.Header.Get("If-None-Match")
 				w.Header().Set("ETag", `"abc123"`)
 				w.Write([]byte(`{

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -121,7 +121,7 @@ var (
 
 	testTransportFeatureFlagsOK = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		var body string
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			body = fixture("feature_flag/test-simple-flag.json")
 		}
 		return &http.Response{
@@ -1138,7 +1138,7 @@ func TestDeviceIdInFlagsRequest(t *testing.T) {
 	t.Run("GetFeatureFlag passes device_id when provided", func(t *testing.T) {
 		var requestData FlagsRequestData
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				body, _ := io.ReadAll(r.Body)
 				json.Unmarshal(body, &requestData)
 				w.Write([]byte(`{"featureFlags": {"test-flag": true}}`))
@@ -1171,7 +1171,7 @@ func TestDeviceIdInFlagsRequest(t *testing.T) {
 	t.Run("GetFeatureFlag omits device_id when nil", func(t *testing.T) {
 		var receivedBody string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				body, _ := io.ReadAll(r.Body)
 				receivedBody = string(body)
 				w.Write([]byte(`{"featureFlags": {"test-flag": true}}`))
@@ -1200,7 +1200,7 @@ func TestDeviceIdInFlagsRequest(t *testing.T) {
 	t.Run("GetAllFlags passes device_id when provided", func(t *testing.T) {
 		var requestData FlagsRequestData
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				body, _ := io.ReadAll(r.Body)
 				json.Unmarshal(body, &requestData)
 				w.Write([]byte(`{"featureFlags": {"test-flag": true}}`))
@@ -1232,7 +1232,7 @@ func TestDeviceIdInFlagsRequest(t *testing.T) {
 	t.Run("GetFeatureFlagPayload passes device_id when provided", func(t *testing.T) {
 		var requestData FlagsRequestData
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				body, _ := io.ReadAll(r.Body)
 				json.Unmarshal(body, &requestData)
 				w.Write([]byte(`{"featureFlags": {"test-flag": true}, "featureFlagPayloads": {"test-flag": "payload-value"}}`))
@@ -1267,14 +1267,14 @@ func TestDeviceIdInFlagsRequest(t *testing.T) {
 		received := make(chan struct{})
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
-			case strings.HasPrefix(r.URL.Path, "/flags"):
+			case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
 				body, _ := io.ReadAll(r.Body)
 				if err := json.Unmarshal(body, &requestData); err != nil {
 					t.Errorf("Failed to parse request body: %v", err)
 				}
 				close(received)
 				w.Write([]byte(`{"featureFlags": {"test-flag": true}}`))
-			case strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation"):
+			case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"flags":[]}`))
 			case strings.HasPrefix(r.URL.Path, "/batch"):
@@ -1322,7 +1322,7 @@ func TestDeviceIdInFlagsRequest(t *testing.T) {
 
 func TestGetFeatureFlagPayloadWithNoPersonalApiKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
 		} else if !strings.HasPrefix(r.URL.Path, "/batch") {
 			t.Errorf("client called an endpoint it shouldn't have: %s", r.URL.Path)
@@ -1508,7 +1508,7 @@ func TestGetFeatureFlagPayloadWithNoPersonalApiKey(t *testing.T) {
 
 func TestGetFeatureFlagWithNoPersonalApiKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
 		} else if !strings.HasPrefix(r.URL.Path, "/batch") {
 			t.Errorf("client called an endpoint it shouldn't have: %s", r.URL.Path)
@@ -1875,7 +1875,7 @@ func TestGetAllFeatureFlagsWithNoPersonalApiKey(t *testing.T) {
 
 func TestGetFeatureFlagPayloadWithPersonalKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			t.Fatal("expected local evaluations endpoint to be called")
 		}
 		w.Write([]byte(fixture("test-api-feature-flag.json")))
@@ -1905,13 +1905,13 @@ func TestGetFeatureFlagPayloadWithPersonalKey(t *testing.T) {
 func TestGetFeatureFlagPayloadWithPersonalKey_LocalComputationFailure(t *testing.T) {
 	apiCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if apiCalls == 0 && strings.HasPrefix(r.URL.Path, "/flags") {
+		if apiCalls == 0 && (r.URL.Path == "/flags" || r.URL.Path == "/flags/") {
 			t.Fatal("expected local evaluations endpoint to be called first")
-		} else if apiCalls == 1 && strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if apiCalls == 1 && strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			t.Fatal("expected flags endpoint to be called second")
 		}
 
-		if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("test-api-feature-flag.json")))
 		} else {
 			w.Write([]byte(fixture("test-flags-v3.json")))
@@ -1974,9 +1974,9 @@ func TestSimpleFlagCalculation(t *testing.T) {
 
 func TestComplexFlag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte(fixture("test-api-feature-flag.json")))
 		} else if !strings.HasPrefix(r.URL.Path, "/batch") {
 			t.Errorf("client called an endpoint it shouldn't have")
@@ -2026,9 +2026,9 @@ func TestComplexFlag(t *testing.T) {
 
 func TestMultiVariateFlag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte("{}"))
 		} else if !strings.HasPrefix(r.URL.Path, "/batch") {
 			t.Errorf("client called an endpoint it shouldn't have")
@@ -2078,9 +2078,9 @@ func TestMultiVariateFlag(t *testing.T) {
 
 func TestDisabledFlag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags") {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 			w.Write([]byte("{}"))
 		} else if !strings.HasPrefix(r.URL.Path, "/batch") {
 			t.Errorf("client called an endpoint it shouldn't have")
@@ -2316,7 +2316,7 @@ func TestSendFeatureFlagsHelperMethods(t *testing.T) {
 func TestFeatureFlagQuotaLimits(t *testing.T) {
 	t.Run("flags endpoint quota limited", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/flags") {
+			if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{
 					"featureFlags": {"test-flag": true},
@@ -2370,14 +2370,14 @@ func TestFeatureFlagQuotaLimits(t *testing.T) {
 
 	t.Run("local evaluation endpoint quota limited", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
 				w.WriteHeader(http.StatusPaymentRequired)
 				w.Write([]byte(`{
 					"type": "quota_limited",
 					"detail": "You have exceeded your feature flag request quota",
 					"code": "payment_required"
 				}`))
-			} else if strings.HasPrefix(r.URL.Path, "/flags") {
+			} else if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
 				// Mock the flags endpoint as well since it's used as fallback
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{
@@ -2436,7 +2436,7 @@ func TestClient_GetRemoteConfigPayload_IncludesTokenParameter(t *testing.T) {
 		var remoteConfigCalled bool
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Handle the initial feature flag definitions request
-			if strings.Contains(r.URL.Path, "/api/feature_flag/local_evaluation") {
+			if strings.Contains(r.URL.Path, "/flags/definitions") {
 				w.Header().Set("Content-Type", "application/json")
 				w.Write([]byte(`{"flags": [], "group_type_mapping": {}}`))
 				return

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -177,7 +177,7 @@ func (b *MockServerBuilder) Build() *httptest.Server {
 				w.Write([]byte(b.config.BatchResponse))
 			}
 
-		case strings.HasPrefix(r.URL.Path, "/flags"):
+		case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
 			if b.config.FlagsHandler != nil {
 				b.config.FlagsHandler(w, r)
 				return
@@ -187,7 +187,7 @@ func (b *MockServerBuilder) Build() *httptest.Server {
 				w.Write([]byte(b.config.FlagsResponse))
 			}
 
-		case strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation"):
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
 			if b.config.LocalEvalHandler != nil {
 				b.config.LocalEvalHandler(w, r)
 				return


### PR DESCRIPTION
## Motivation and Context

The Rust feature flags definitions fleet now serves 100% of `/api/feature_flag/local_evaluation` traffic in all environments. This switches the SDK's default polling URL from the legacy Django path to the Rust endpoint's native path (`/flags/definitions`).

The old `/api/feature_flag/local_evaluation` path remains registered as a route alias on the Rust service, so older SDK versions continue to work.

Replaces #179 which was incorrectly opened against `master`.

## How did you test it?

- Updated all test mock HTTP servers to match the new path
- Fixed `/flags` prefix collision in test handlers (use exact path match so `/flags` doesn't swallow `/flags/definitions`)
- Fixed operator precedence bug in `TestGetFeatureFlagPayloadWithPersonalKey_LocalComputationFailure`
- `go build ./...` passes