### PR TITLE
chore: add manual release workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: Version bump to apply
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: read
@@ -20,8 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     # Run when PR with 'release' label is merged to main, or when manually triggered
     if: |
-      github.event.pull_request.merged == true
-       && contains(github.event.pull_request.labels.*.name, 'release')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'release'))
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
       bump-type: ${{ steps.check.outputs.bump-type }}
@@ -37,8 +49,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Determine bump type from PR labels
-          if ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}; then
+          # Determine bump type from workflow input or PR labels
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "bump-type=${{ inputs.bump_type }}" >> "$GITHUB_OUTPUT"
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "Manual release requested with bump type '${{ inputs.bump_type }}'"
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}; then
             echo "bump-type=major" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
           elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-minor') }}; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,19 +48,24 @@ jobs:
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BUMP_TYPE: ${{ inputs.bump_type }}
+          HAS_BUMP_MAJOR: ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}
+          HAS_BUMP_MINOR: ${{ contains(github.event.pull_request.labels.*.name, 'bump-minor') }}
+          HAS_BUMP_PATCH: ${{ contains(github.event.pull_request.labels.*.name, 'bump-patch') }}
         run: |
           # Determine bump type from workflow input or PR labels
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "bump-type=${{ inputs.bump_type }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "bump-type=$INPUT_BUMP_TYPE" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
-            echo "Manual release requested with bump type '${{ inputs.bump_type }}'"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}; then
+            echo "Manual release requested with bump type '$INPUT_BUMP_TYPE'"
+          elif [ "$HAS_BUMP_MAJOR" = "true" ]; then
             echo "bump-type=major" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-minor') }}; then
+          elif [ "$HAS_BUMP_MINOR" = "true" ]; then
             echo "bump-type=minor" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-patch') }}; then
+          elif [ "$HAS_BUMP_PATCH" = "true" ]; then
             echo "bump-type=patch" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
           fi
@@ -157,10 +162,11 @@ jobs:
         if: steps.commit-version-bump.outputs.commit-hash != ''
         env:
           GH_TOKEN: ${{ steps.releaser.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
           COMMIT_HASH: ${{ steps.commit-version-bump.outputs.commit-hash }}
         run: |
-          gh api "repos/${{ github.repository }}/git/refs" \
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
             -f "ref=refs/tags/v${NEW_VERSION}" \
             -f "sha=${COMMIT_HASH}"
 
@@ -208,8 +214,10 @@ jobs:
         id: check-rejection
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          RESPONSE=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals)
+          RESPONSE=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/approvals")
           REJECTED=$(echo "$RESPONSE" | jq '[.[] | select(.state == "rejected")] | length')
           if [ "$REJECTED" -gt 0 ]; then
             echo "was_rejected=true" >> "$GITHUB_OUTPUT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,17 +1,16 @@
 # Releasing
 
-Releases are semi-automated via GitHub Actions. When a PR with the `release` and a version bump label is merged to `main`, the release workflow is triggered.
+Releases are semi-automated via GitHub Actions. When a PR with the `release` and a version bump label is merged to `main`, the release workflow is triggered. You can also trigger the `Release` workflow manually from GitHub Actions and choose the bump type.
 
 You'll need an approval from a PostHog engineer. If you're an employee, you can see the request in the [#approvals-client-libraries](https://app.slack.com/client/TSS5W8YQZ/C0A3UEVDDNF) channel.
 
 ## Release Process
 
-1. **Create your PR** with the changes you want to release
-2. **Add the `release` label** to the PR
-3. **Add a version bump label** that should be either `bump-patch`, `bump-minor` or `bump-major`
-4. **Merge the PR** to `main`
+1. Either:
+   - **Create your PR** with the changes you want to release, add the `release` label, add exactly one version bump label (`bump-patch`, `bump-minor`, or `bump-major`), and **merge the PR** to `main`, or
+   - open the `Release` workflow in GitHub Actions, click **Run workflow**, and choose `patch`, `minor`, or `major`
 
-Once merged, the following happens automatically:
+Once the workflow is triggered, the following happens automatically:
 
 1. A Slack notification is sent to the client libraries channel requesting approval
 2. A maintainer approves the release in the GitHub `Release` environment


### PR DESCRIPTION
## :bulb: Motivation and Context

The release workflow can currently run only from a merged PR with release labels. Adding `workflow_dispatch` makes it possible to trigger a release manually from GitHub Actions when needed.

This also updates `RELEASING.md` to document the manual path and the required bump type selection.

## :green_heart: How did you test it?

- Reviewed the workflow logic change
- Validated `.github/workflows/release.yml` parses as YAML

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`
