### PR TITLE
docs: add dedicated contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for your interest in improving the PostHog Go SDK.
+
+## Development setup
+
+Make sure you have Go installed (macOS: `brew install go`, Linux / Windows: https://go.dev/doc/install).
+
+From the repository root:
+
+```bash
+# Install dependencies
+make dependencies
+
+# Run tests and build
+make build
+
+# Just run tests
+make test
+```
+
+## Testing local changes in another app
+
+You can run your Go app against a local build of `posthog-go` by updating your app's `go.mod`, for example:
+
+```go
+module example/posthog-go-app
+
+go 1.22.5
+
+require github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103
+
+require github.com/google/uuid v1.3.0 // indirect
+
+replace github.com/posthog/posthog-go => /path-to-your-local/posthog-go
+```
+
+## Pull requests
+
+Please keep changes focused and make sure the relevant tests pass before opening a PR.

--- a/README.md
+++ b/README.md
@@ -132,38 +132,9 @@ func main() {
 }
 ```
 
-## Development
+## Contributing
 
-Make sure you have Go installed (macOS: `brew install go`, Linx / Windows: https://go.dev/doc/install).
-
-To build the project:
-
-```bash
-# Install dependencies
-make dependencies
-
-# Run tests and build
-make build
-
-# Just run tests
-make test
-```
-
-## Testing Locally
-
-You can run your Go app against a local build of `posthog-go` by making the following change to your `go.mod` file for whichever your app, e.g.
-
-```Go
-module example/posthog-go-app
-
-go 1.22.5
-
-require github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103
-
-require github.com/google/uuid v1.3.0 // indirect
-
-replace github.com/posthog/posthog-go => /path-to-your-local/posthog-go
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, build, and test instructions.
 
 ## Examples
 

--- a/sdk_compliance_adapter/CONTRIBUTING.md
+++ b/sdk_compliance_adapter/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+This package contains the PostHog Go SDK compliance adapter used with the PostHog SDK Test Harness.
+
+## Running tests
+
+Tests run automatically in CI via GitHub Actions.
+
+### Locally with Docker Compose
+
+Run the full compliance suite from the `sdk_compliance_adapter` directory:
+
+```bash
+docker-compose up --build --abort-on-container-exit
+```
+
+This will:
+
+1. Build the Go SDK adapter
+2. Pull the test harness image
+3. Run all compliance tests
+4. Show the results
+
+### Manually with Docker
+
+```bash
+# Create network
+docker network create test-network
+
+# Build and run adapter
+docker build -f sdk_compliance_adapter/Dockerfile -t posthog-go-adapter .
+docker run -d --name sdk-adapter --network test-network -p 8080:8080 posthog-go-adapter
+
+# Run test harness
+docker run --rm \
+  --name test-harness \
+  --network test-network \
+  ghcr.io/posthog/sdk-test-harness:latest \
+  run --adapter-url http://sdk-adapter:8080 --mock-url http://test-harness:8081
+
+# Cleanup
+docker stop sdk-adapter && docker rm sdk-adapter
+docker network rm test-network
+```

--- a/sdk_compliance_adapter/README.md
+++ b/sdk_compliance_adapter/README.md
@@ -2,44 +2,9 @@
 
 This adapter wraps the posthog-go SDK for compliance testing with the [PostHog SDK Test Harness](https://github.com/PostHog/posthog-sdk-test-harness).
 
-## Running Tests
+## Contributing
 
-Tests run automatically in CI via GitHub Actions. See the test harness repo for details.
-
-### Locally with Docker Compose
-
-```bash
-# From the posthog-go/sdk_compliance_adapter directory
-docker-compose up --build --abort-on-container-exit
-```
-
-This will:
-1. Build the Go SDK adapter
-2. Pull the test harness image
-3. Run all compliance tests
-4. Show results
-
-### Manually with Docker
-
-```bash
-# Create network
-docker network create test-network
-
-# Build and run adapter
-docker build -f sdk_compliance_adapter/Dockerfile -t posthog-go-adapter .
-docker run -d --name sdk-adapter --network test-network -p 8080:8080 posthog-go-adapter
-
-# Run test harness
-docker run --rm \
-  --name test-harness \
-  --network test-network \
-  ghcr.io/posthog/sdk-test-harness:latest \
-  run --adapter-url http://sdk-adapter:8080 --mock-url http://test-harness:8081
-
-# Cleanup
-docker stop sdk-adapter && docker rm sdk-adapter
-docker network rm test-network
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local build and compliance test instructions.
 
 ## Implementation
 


### PR DESCRIPTION
## :bulb: Motivation and Context

This repo had contributor-facing development instructions split between the root README and the SDK compliance adapter README.

This PR moves that guidance into dedicated `CONTRIBUTING.md` files so contributors have a consistent place to find local setup and compliance adapter instructions.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Checked the updated markdown links and file locations

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`
