### PR TITLE
chore: use v3 for create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Get GitHub App token
         id: releaser
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.GH_APP_POSTHOG_GO_RELEASER_APP_ID }}
           private-key: ${{ secrets.GH_APP_POSTHOG_GO_RELEASER_PRIVATE_KEY }} # Secrets available only inside the 'Release' environment, requires approval from a maintainer


### PR DESCRIPTION
## :bulb: Motivation and Context
This updates the release workflow to use the `v3` tag for `actions/create-github-app-token` instead of a pin to `v3.0.0`, so the workflow picks up the newer v3 input contract that accepts `client-id`.

https://github.com/PostHog/posthog-go/actions/runs/24553251098/job/71783575252

## :green_heart: How did you test it?
Verified the workflow change matches the action's current v3 usage and resolves the observed mismatch between `client-id` and the older pinned `v3.0.0` release.

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`