### PR TITLE
fix: trim whitespace from API keys and endpoint config

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package posthog
 import (
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -177,9 +178,16 @@ const (
 	DefaultMaxEnqueuedRequests = 1000
 )
 
+func (c *Config) normalize() {
+	c.Endpoint = strings.TrimSpace(c.Endpoint)
+	c.PersonalApiKey = strings.TrimSpace(c.PersonalApiKey)
+}
+
 // Validate verifies that fields that don't have zero-values are set to valid values,
 // returns an error describing the problem if a field was invalid.
 func (c *Config) Validate() error {
+	c.normalize()
+
 	if c.Interval < 0 {
 		return ConfigError{
 			Reason: "negative time intervals are not supported",
@@ -226,6 +234,8 @@ func (c *Config) Validate() error {
 // Given a config object as argument the function will set all zero-values to
 // their defaults and return the modified object.
 func makeConfig(c Config) Config {
+	c.normalize()
+
 	if len(c.Endpoint) == 0 {
 		c.Endpoint = DefaultEndpoint
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -15,6 +15,22 @@ func TestConfigZeroValue(t *testing.T) {
 	}
 }
 
+func TestConfigValidateTrimsWhitespaceSensitiveFields(t *testing.T) {
+	c := Config{
+		Endpoint:       " \nhttps://app.posthog.com\t ",
+		PersonalApiKey: " \ttest-personal-key\n ",
+	}
+
+	require.NoError(t, c.Validate())
+	require.Equal(t, "https://app.posthog.com", c.Endpoint)
+	require.Equal(t, "test-personal-key", c.PersonalApiKey)
+}
+
+func TestMakeConfigDefaultsWhitespaceEndpoint(t *testing.T) {
+	got := makeConfig(Config{Endpoint: " \n\t "})
+	require.Equal(t, DefaultEndpoint, got.Endpoint)
+}
+
 func TestConfigInvalidInterval(t *testing.T) {
 	c := Config{
 		Interval: -1 * time.Second,

--- a/feature_flags_flags_test.go
+++ b/feature_flags_flags_test.go
@@ -882,3 +882,60 @@ func TestGetFeatureFlagResultPropagatesRemoteAPIErrors(t *testing.T) {
 		t.Errorf("Expected result to be nil, got: %v", result)
 	}
 }
+
+func TestWhitespacePersonalAPIKeySkipsPollerAndUsesRemoteFlags(t *testing.T) {
+	var mu sync.Mutex
+	definitionsCalls := 0
+	flagsCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/flags/definitions":
+			mu.Lock()
+			definitionsCalls++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"flags": [], "group_type_mapping": {}}`))
+		case "/flags", "/flags/":
+			mu.Lock()
+			flagsCalls++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"featureFlags": {"any-flag": true}, "featureFlagPayloads": {}}`))
+		default:
+			t.Errorf("Unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewWithConfig("test-api-key", Config{
+		Endpoint:       server.URL,
+		PersonalApiKey: " \n\t ",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	defer client.Close()
+
+	result, err := client.GetFeatureFlagResult(FeatureFlagPayload{
+		Key:                   "any-flag",
+		DistinctId:            "some-distinct-id",
+		SendFeatureFlagEvents: Ptr(false),
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if result == nil || !result.Enabled {
+		t.Fatalf("Expected enabled flag result, got: %#v", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if definitionsCalls != 0 {
+		t.Fatalf("Expected poller to be skipped, got %d /flags/definitions call(s)", definitionsCalls)
+	}
+	if flagsCalls != 1 {
+		t.Fatalf("Expected one /flags call, got %d", flagsCalls)
+	}
+}

--- a/posthog.go
+++ b/posthog.go
@@ -187,6 +187,10 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 	}
 
 	config = makeConfig(config)
+	apiKey = strings.TrimSpace(apiKey)
+	if len(apiKey) == 0 {
+		config.Logger.Errorf("posthog apiKey is empty after trimming whitespace; check your project API key")
+	}
 	reportedCache, err := lru.New[flagUser, struct{}](CACHE_DEFAULT_SIZE)
 	if err != nil && config.Logger != nil {
 		config.Logger.Errorf("Error creating cache for reported flags: %v", err)

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -85,6 +85,96 @@ func (l testLogger) Errorf(format string, args ...interface{}) {
 	}
 }
 
+func TestNewWithConfig_LogsErrorForBlankAPIKeyAfterTrim(t *testing.T) {
+	var logged string
+
+	client, err := NewWithConfig(" \n\t ", Config{
+		Logger: testLogger{
+			logf: t.Logf,
+			errorf: func(format string, args ...interface{}) {
+				logged = fmt.Sprintf(format, args...)
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	defer client.Close()
+
+	require.Contains(t, logged, "apiKey is empty after trimming whitespace")
+}
+
+func TestNewWithConfig_TrimsWhitespaceSensitiveInputsInRequests(t *testing.T) {
+	var (
+		mu                sync.Mutex
+		batchAPIKey       string
+		remoteConfigToken string
+		remoteConfigAuth  string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/flags/definitions"):
+			if got := r.Header.Get("Authorization"); got != "Bearer test-personal-key" {
+				t.Errorf("Expected Authorization header 'Bearer test-personal-key', got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"flags": [], "group_type_mapping": {}}`))
+		case r.URL.Path == "/batch/":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("Failed to read batch body: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			var payload struct {
+				ApiKey string `json:"api_key"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Errorf("Failed to parse batch body: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			mu.Lock()
+			batchAPIKey = payload.ApiKey
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/remote_config"):
+			mu.Lock()
+			remoteConfigToken = r.URL.Query().Get("token")
+			remoteConfigAuth = r.Header.Get("Authorization")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`"ok"`))
+		default:
+			t.Errorf("Unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewWithConfig(" \n test-api-key\t ", Config{
+		PersonalApiKey: " \ttest-personal-key\n ",
+		Endpoint:       " \n" + server.URL + "\t ",
+		BatchSize:      1,
+	})
+	require.NoError(t, err)
+
+	payload, err := client.GetRemoteConfigPayload("test-flag")
+	require.NoError(t, err)
+	require.Equal(t, "ok", payload)
+
+	require.NoError(t, client.Enqueue(Capture{DistinctId: "test-user", Event: "test-event"}))
+	require.NoError(t, client.Close())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "test-api-key", batchAPIKey)
+	require.Equal(t, "test-api-key", remoteConfigToken)
+	require.Equal(t, "Bearer test-personal-key", remoteConfigAuth)
+}
+
 var _ Message = (*testErrorMessage)(nil)
 
 // Instances of this type are used to force message validation errors in unit


### PR DESCRIPTION
## :bulb: Motivation and Context
This fixes a hard-to-debug configuration issue where project API keys, personal API keys, or endpoints could be passed with surrounding spaces or line breaks. In those cases the SDK could send invalid tokens or use a broken endpoint while the API still returned 200s, making the root cause difficult to spot

Relates to https://github.com/PostHog/posthog-js/issues/3424
I want to port this fix across SDKs


## :green_heart: How did you test it?
- `go test ./... -run 'TestConfigValidateTrimsWhitespaceSensitiveFields|TestMakeConfigDefaultsWhitespaceEndpoint|TestNewWithConfig_LogsErrorForBlankAPIKeyAfterTrim|TestNewWithConfig_TrimsWhitespaceSensitiveInputsInRequests|TestWhitespacePersonalAPIKeySkipsPollerAndUsesRemoteFlags'`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
