### PR TITLE
fix: Change default endpoint to us.i.posthog.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ go run *.go
 # Set your PostHog API keys and endpoint (optional)
 export POSTHOG_PROJECT_API_KEY="your-project-api-key"
 export POSTHOG_PERSONAL_API_KEY="your-personal-api-key"
-export POSTHOG_ENDPOINT="https://app.posthog.com"  # Optional, defaults to http://localhost:8000
+export POSTHOG_ENDPOINT="https://us.i.posthog.com"  # Optional, defaults to http://localhost:8000
 
 # Run all examples
 go run examples/*.go

--- a/config.go
+++ b/config.go
@@ -148,7 +148,7 @@ const (
 
 	// DefaultEndpoint constant sets the default endpoint to which client instances send
 	// messages if none was explicitly set.
-	DefaultEndpoint = "https://app.posthog.com"
+	DefaultEndpoint = "https://us.i.posthog.com"
 
 	// DefaultInterval constant sets the default flush interval used by client instances if
 	// none was explicitly set.

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,7 +63,7 @@ The examples will automatically load configuration from a `.env` file if it exis
 # PostHog API Configuration
 POSTHOG_PROJECT_API_KEY=phc_your_project_api_key_here
 POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
-POSTHOG_ENDPOINT=https://app.posthog.com
+POSTHOG_ENDPOINT=https://us.i.posthog.com
 ```
 
 **Note**: Environment variables take precedence over .env file values, so you can override specific settings when needed.


### PR DESCRIPTION
## :bulb: Motivation and Context

The Go SDK default endpoint was still set to `https://app.posthog.com`, while other PostHog SDKs default to the US ingest host.

This updates the SDK default to `https://us.i.posthog.com` and aligns the related README examples with the new default.

## :green_heart: How did you test it?

- Ran `go test -run 'TestConfig|TestMakeConfigDefaultsWhitespaceEndpoint' ./...`
- Confirmed `DefaultEndpoint` now points to `https://us.i.posthog.com`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`
