### PR TITLE
feat(flags): implement get_feature_flag endpoint in SDK compliance adapter

### DIFF
--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -333,6 +333,13 @@ func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Sanitize user-controlled fields before they enter the SDK. The SDK
+	// logs flag keys downstream (e.g. featureflags.go's local-eval Warnf),
+	// which CodeQL flags as go/log-injection. Stripping CR/LF here breaks
+	// the data flow at the adapter boundary.
+	req.Key = sanitizeForLog(req.Key)
+	req.DistinctID = sanitizeForLog(req.DistinctID)
+
 	state.mu.Lock()
 	client := state.client
 	state.mu.Unlock()

--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -382,12 +382,14 @@ func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
 		OnlyEvaluateLocally: !forceRemote,
 	})
 	if err != nil {
-		log.Printf("Error evaluating feature flag %s for %s: %v", req.Key, req.DistinctID, err)
+		// Avoid logging user-controlled fields (req.Key, req.DistinctID) to prevent log injection.
+		log.Printf("Error evaluating feature flag: %v", err)
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	log.Printf("Feature flag %s for %s: %v", req.Key, req.DistinctID, value)
+	// Avoid logging user-controlled fields (req.Key, req.DistinctID, value) to prevent log injection.
+	log.Printf("Evaluated feature flag")
 
 	jsonResponse(w, map[string]interface{}{
 		"success": true,

--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -100,9 +100,10 @@ var state = &AdapterState{
 
 // HealthResponse represents /health endpoint response
 type HealthResponse struct {
-	SDKName        string `json:"sdk_name"`
-	SDKVersion     string `json:"sdk_version"`
-	AdapterVersion string `json:"adapter_version"`
+	SDKName        string   `json:"sdk_name"`
+	SDKVersion     string   `json:"sdk_version"`
+	AdapterVersion string   `json:"adapter_version"`
+	Capabilities   []string `json:"capabilities"`
 }
 
 // InitRequest represents /init endpoint request
@@ -143,6 +144,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 		SDKName:        "posthog-go",
 		SDKVersion:     posthog.Version,
 		AdapterVersion: VERSION,
+		Capabilities:   []string{"capture_v0", "encoding_gzip"},
 	}
 	jsonResponse(w, response)
 }

--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -124,6 +124,17 @@ type CaptureRequest struct {
 	Timestamp  *string                `json:"timestamp,omitempty"`
 }
 
+// FeatureFlagRequest represents /get_feature_flag endpoint request
+type FeatureFlagRequest struct {
+	Key              string                            `json:"key"`
+	DistinctID       string                            `json:"distinct_id"`
+	PersonProperties map[string]interface{}            `json:"person_properties,omitempty"`
+	Groups           map[string]interface{}            `json:"groups,omitempty"`
+	GroupProperties  map[string]map[string]interface{} `json:"group_properties,omitempty"`
+	DisableGeoIP     *bool                             `json:"disable_geoip,omitempty"`
+	ForceRemote      *bool                             `json:"force_remote,omitempty"`
+}
+
 // StateResponse represents /state endpoint response
 type StateResponse struct {
 	PendingEvents       int           `json:"pending_events"`
@@ -305,6 +316,91 @@ func stateHandler(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, response)
 }
 
+func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
+	var req FeatureFlagRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.Key == "" {
+		jsonError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	if req.DistinctID == "" {
+		jsonError(w, http.StatusBadRequest, "distinct_id is required")
+		return
+	}
+
+	state.mu.Lock()
+	client := state.client
+	state.mu.Unlock()
+
+	if client == nil {
+		jsonError(w, http.StatusBadRequest, "SDK not initialized")
+		return
+	}
+
+	// force_remote defaults to true
+	forceRemote := true
+	if req.ForceRemote != nil {
+		forceRemote = *req.ForceRemote
+	}
+
+	// Note: posthog-go's DisableGeoIP is a client-level config (Config.DisableGeoIP),
+	// not a per-call option on FeatureFlagPayload. We accept the field on the request
+	// for compatibility with the harness contract but do not honor it per-call. The
+	// SDK default (when DisableGeoIP is nil) is to disable geoip on flag requests,
+	// which matches the test harness's expected `geoip_disable: true` assertion.
+	_ = req.DisableGeoIP
+
+	// Convert groups/properties to SDK types
+	var groups posthog.Groups
+	if req.Groups != nil {
+		groups = posthog.Groups(req.Groups)
+	}
+
+	var personProperties posthog.Properties
+	if req.PersonProperties != nil {
+		personProperties = posthog.Properties(req.PersonProperties)
+	}
+
+	var groupProperties map[string]posthog.Properties
+	if req.GroupProperties != nil {
+		groupProperties = make(map[string]posthog.Properties, len(req.GroupProperties))
+		for k, v := range req.GroupProperties {
+			groupProperties[k] = posthog.Properties(v)
+		}
+	}
+
+	value, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
+		Key:                 req.Key,
+		DistinctId:          req.DistinctID,
+		Groups:              groups,
+		PersonProperties:    personProperties,
+		GroupProperties:     groupProperties,
+		OnlyEvaluateLocally: !forceRemote,
+	})
+	if err != nil {
+		log.Printf("Error evaluating feature flag %s for %s: %v", req.Key, req.DistinctID, err)
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	log.Printf("Feature flag %s for %s: %v", req.Key, req.DistinctID, value)
+
+	jsonResponse(w, map[string]interface{}{
+		"success": true,
+		"value":   value,
+	})
+}
+
+func jsonError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
 func resetHandler(w http.ResponseWriter, r *http.Request) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
@@ -336,6 +432,7 @@ func main() {
 	http.HandleFunc("/flush", flushHandler)
 	http.HandleFunc("/state", stateHandler)
 	http.HandleFunc("/reset", resetHandler)
+	http.HandleFunc("/get_feature_flag", featureFlagHandler)
 
 	log.Printf("Starting PostHog Go SDK adapter on port %s", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))

--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -383,7 +384,9 @@ func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		// Avoid logging user-controlled fields (req.Key, req.DistinctID) to prevent log injection.
-		log.Printf("Error evaluating feature flag: %v", err)
+		// The error message itself can wrap upstream user-controlled input (e.g. flag keys
+		// quoted in error strings), so strip CR/LF before logging to defang log injection.
+		log.Printf("Error evaluating feature flag: %s", sanitizeForLog(err.Error()))
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -395,6 +398,13 @@ func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
 		"success": true,
 		"value":   value,
 	})
+}
+
+// sanitizeForLog strips CR/LF characters from a string before logging, so
+// user-controlled input (e.g. error strings that quote upstream-supplied flag
+// keys) cannot inject forged log entries via newline characters.
+func sanitizeForLog(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", " ")
 }
 
 func jsonError(w http.ResponseWriter, status int, msg string) {


### PR DESCRIPTION
## Summary

- Adds a `POST /get_feature_flag` handler to the SDK compliance adapter that proxies to `client.GetFeatureFlag` and returns `{"success": true, "value": <result>}`. Enables the test harness's `feature_flags` suite to run against posthog-go.
- Declares `capabilities: ["capture_v0", "encoding_gzip"]` on `/health` so the harness can discover which suites this adapter supports (without it, all suites are skipped).

Mirrors the equivalent changes in posthog-python (#500, #501).

### Note on `disable_geoip`

In posthog-go, `DisableGeoIP` is a client-level `Config` field, not a per-call option on `FeatureFlagPayload`. The handler accepts the `disable_geoip` request field for harness compatibility but does not honor it per-call. The SDK's default (when `Config.DisableGeoIP` is nil) is to disable geoip on flag requests, which already satisfies the `geoip_disable: true` assertion in `request_with_person_properties_device_id`.

### Harness tests fails for fails

This is expected. Adding the adapter reveals drift in behavior across SDK's. Will follow up with PR's to fix this, but keeping this PR scoped to only adding the adapter to start running the tests. The harness tests are not required, so this won't block anything.

## Test plan

- [x] `go build ./...` in `sdk_compliance_adapter/` passes
- [x] Run posthog-sdk-test-harness `feature_flags` suite against the adapter and confirm output is as expected