### PR TITLE
fix: Add v prefix to release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
         run: |
           release_date=$(date +%Y-%m-%d)
-          echo -e "## $NEW_VERSION - $release_date\n\n* [Full Changelog](https://github.com/PostHog/posthog-go/compare/${CURRENT_VERSION}...${NEW_VERSION})\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+          echo -e "## $NEW_VERSION - $release_date\n\n* [Full Changelog](https://github.com/PostHog/posthog-go/compare/v${CURRENT_VERSION}...v${NEW_VERSION})\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
 
       - name: Commit version bump
         id: commit-version-bump
@@ -166,8 +166,10 @@ jobs:
           NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
           COMMIT_HASH: ${{ steps.commit-version-bump.outputs.commit-hash }}
         run: |
+          # Go modules require semantic version tags to use a v prefix (for example, v1.2.3):
+          # https://go.dev/ref/mod#versions
           gh api "repos/$GITHUB_REPOSITORY/git/refs" \
-            -f "ref=refs/tags/${NEW_VERSION}" \
+            -f "ref=refs/tags/v${NEW_VERSION}" \
             -f "sha=${COMMIT_HASH}"
 
       - name: Create GitHub release
@@ -177,7 +179,7 @@ jobs:
           NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
         run: |
           CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
-          gh release create "${NEW_VERSION}" --title "${NEW_VERSION}" --notes "$CHANGELOG_ENTRY"
+          gh release create "v${NEW_VERSION}" --title "${NEW_VERSION}" --notes "$CHANGELOG_ENTRY"
 
       # Notify in case of a failure
       - name: Send failure event to PostHog


### PR DESCRIPTION
## :bulb: Motivation and Context
Git tags for Go modules must use a `v` prefix (for example, `v1.2.3`) to be recognized as semantic versions by Go tooling. The release workflow was creating unprefixed tags, which made recent releases unavailable via the Go module proxy.

Fixes #194.

## :green_heart: How did you test it?
- Ran a static workflow check to confirm tag creation uses `refs/tags/v${NEW_VERSION}`.
- Confirmed the GitHub release is still created with an unprefixed title.
- Ran `git diff --check`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added a version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
