### PR TITLE
Run Go CI on main pushes

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -5,6 +5,9 @@ permissions:
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   merge_group:
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,9 @@ name: Unit Tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   merge_group:
 
 jobs:


### PR DESCRIPTION
## :bulb: Motivation and Context
Ensure the Go SDK's PR formatting and unit test workflows also run after changes land on `main`, so regressions introduced by merges are caught on the default branch.

## :green_heart: How did you test it?
Validated the workflow YAML parses and that both workflows now include `push` for the `main` branch.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
