### PR TITLE
chore: sign release workflow commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,23 +114,28 @@ jobs:
           echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "New version: $NEW_VERSION"
 
-      - name: Commit version bump
-        id: commit-version-bump
-        env:
-          NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}
+      - name: Check for version bump changes
+        id: check-changes
         run: |
-          git add -A
-          if git diff --staged --quiet; then
+          if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release v$NEW_VERSION [version bump] [skip ci]"
-            git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Commit version bump
+        id: commit-version-bump
+        if: steps.check-changes.outputs.committed == 'true'
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: "chore: release v${{ steps.apply-changesets.outputs.new-version }} [version bump] [skip ci]"
+          repo: ${{ github.repository }}
+          branch: main
+        env:
+          GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
       - name: Create GitHub release
-        if: steps.commit-version-bump.outputs.committed == 'true'
+        if: steps.check-changes.outputs.committed == 'true'
         env:
           GH_TOKEN: ${{ steps.releaser.outputs.token }}
           NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
       - name: Create GitHub release
-        if: steps.check-changes.outputs.committed == 'true'
+        if: steps.commit-version-bump.outputs.commit-hash != ''
         env:
           GH_TOKEN: ${{ steps.releaser.outputs.token }}
           NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}


### PR DESCRIPTION
## :bulb: Motivation and Context

Release workflows commit version bump changes during automated releases. Raw `git commit` / `git push` can fail in repositories that require verified commit signatures, so the workflow should use `planetscale/ghcommit-action`, matching other SDK release workflows.

## :green_heart: How did you test it?

- Parsed the updated workflow YAML successfully.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
