### PR TITLE
fix: reject leading-zero semver values in local evaluation

### DIFF
--- a/.changeset/strict-semver-leading-zeros.md
+++ b/.changeset/strict-semver-leading-zeros.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Reject semver values with leading zeros in local flag evaluation. Per semver 2.0.0 §2, numeric identifiers must not include leading zeros — values like `1.07.3` are not valid semver and should not match targeting conditions. Both override values and flag values are now validated; invalid inputs surface an `InconclusiveMatchError` so the condition does not match.

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -638,10 +638,30 @@ func TestParseSemver(t *testing.T) {
 		require.Equal(t, semverTuple{1, 2, 3}, result)
 	})
 
-	t.Run("leading zeros parsed as decimal", func(t *testing.T) {
-		result, err := parseSemver("01.02.03")
-		require.NoError(t, err)
-		require.Equal(t, semverTuple{1, 2, 3}, result)
+	t.Run("leading zeros rejected per semver 2.0.0 §2", func(t *testing.T) {
+		invalidCases := []string{
+			"01.2.3",
+			"1.02.3",
+			"1.2.03",
+			"01.02.03",
+			"1.07.3",
+			"001.2.3",
+		}
+		for _, input := range invalidCases {
+			t.Run(input, func(t *testing.T) {
+				_, err := parseSemver(input)
+				require.Error(t, err, "expected error for input: %s", input)
+			})
+		}
+
+		// A literal "0" component is fine
+		validCases := []string{"0.1.0", "1.0.0", "0.0.0"}
+		for _, input := range validCases {
+			t.Run(input, func(t *testing.T) {
+				_, err := parseSemver(input)
+				require.NoError(t, err, "expected no error for valid input: %s", input)
+			})
+		}
 	})
 
 	t.Run("invalid values", func(t *testing.T) {
@@ -1203,6 +1223,52 @@ func TestMatchPropertySemverErrorHandling(t *testing.T) {
 		isMatch, err := matchProperty(property, NewProperties().Set("version", "1.2.3"))
 		require.Error(t, err)
 		require.False(t, isMatch)
+	})
+
+	t.Run("leading-zero property value rejected", func(t *testing.T) {
+		property := FlagProperty{
+			Key:      "version",
+			Value:    "1.2.3",
+			Operator: "semver_eq",
+		}
+
+		for _, badValue := range []string{"01.2.3", "1.02.3", "1.2.03", "1.07.3", "001.2.3"} {
+			t.Run(badValue, func(t *testing.T) {
+				isMatch, err := matchProperty(property, NewProperties().Set("version", badValue))
+				require.Error(t, err)
+				require.False(t, isMatch)
+
+				var inconclusiveErr *InconclusiveMatchError
+				require.True(t, errors.As(err, &inconclusiveErr))
+			})
+		}
+	})
+
+	t.Run("leading-zero flag value rejected for caret/tilde/wildcard", func(t *testing.T) {
+		cases := []struct {
+			operator string
+			value    string
+		}{
+			{"semver_caret", "1.07.0"},
+			{"semver_tilde", "1.07.0"},
+			{"semver_wildcard", "01.*"},
+			{"semver_gt", "01.2.3"},
+		}
+		for _, c := range cases {
+			t.Run(c.operator+"/"+c.value, func(t *testing.T) {
+				property := FlagProperty{
+					Key:      "version",
+					Value:    c.value,
+					Operator: c.operator,
+				}
+				isMatch, err := matchProperty(property, NewProperties().Set("version", "2.0.0"))
+				require.Error(t, err)
+				require.False(t, isMatch)
+
+				var inconclusiveErr *InconclusiveMatchError
+				require.True(t, errors.As(err, &inconclusiveErr))
+			})
+		}
 	})
 }
 

--- a/featureflags.go
+++ b/featureflags.go
@@ -1592,6 +1592,18 @@ func (s semverTuple) compareTo(other semverTuple) int {
 	return 0
 }
 
+// parseSemverNumeric parses a single numeric identifier, rejecting leading
+// zeros per semver 2.0.0 §2 (numeric identifiers MUST NOT include them).
+func parseSemverNumeric(part string) (int, error) {
+	if part == "" {
+		return 0, errors.New("empty numeric identifier")
+	}
+	if len(part) > 1 && part[0] == '0' {
+		return 0, fmt.Errorf("numeric identifier has leading zero: '%s'", part)
+	}
+	return strconv.Atoi(part)
+}
+
 // parseSemver parses a version string into a semverTuple.
 // Parsing rules:
 // 1. Strip leading/trailing whitespace
@@ -1600,7 +1612,7 @@ func (s semverTuple) compareTo(other semverTuple) int {
 // 4. Split on . and parse first 3 components as integers
 // 5. Default missing components to 0
 // 6. Ignore extra components beyond the third
-// 7. Return error for invalid input
+// 7. Return error for invalid input (including numeric identifiers with leading zeros)
 func parseSemver(value string) (semverTuple, error) {
 	text := strings.TrimSpace(value)
 
@@ -1633,9 +1645,9 @@ func parseSemver(value string) (semverTuple, error) {
 		return semverTuple{}, errors.New("invalid semver: no version components")
 	}
 
-	major, err := strconv.Atoi(parts[0])
+	major, err := parseSemverNumeric(parts[0])
 	if err != nil {
-		return semverTuple{}, fmt.Errorf("invalid semver: major version '%s' is not a number", parts[0])
+		return semverTuple{}, fmt.Errorf("invalid semver: major version '%s': %w", parts[0], err)
 	}
 
 	minor := 0
@@ -1643,9 +1655,9 @@ func parseSemver(value string) (semverTuple, error) {
 		if parts[1] == "" {
 			return semverTuple{}, errors.New("invalid semver: empty minor version component")
 		}
-		minor, err = strconv.Atoi(parts[1])
+		minor, err = parseSemverNumeric(parts[1])
 		if err != nil {
-			return semverTuple{}, fmt.Errorf("invalid semver: minor version '%s' is not a number", parts[1])
+			return semverTuple{}, fmt.Errorf("invalid semver: minor version '%s': %w", parts[1], err)
 		}
 	}
 
@@ -1654,9 +1666,9 @@ func parseSemver(value string) (semverTuple, error) {
 		if parts[2] == "" {
 			return semverTuple{}, errors.New("invalid semver: empty patch version component")
 		}
-		patch, err = strconv.Atoi(parts[2])
+		patch, err = parseSemverNumeric(parts[2])
 		if err != nil {
-			return semverTuple{}, fmt.Errorf("invalid semver: patch version '%s' is not a number", parts[2])
+			return semverTuple{}, fmt.Errorf("invalid semver: patch version '%s': %w", parts[2], err)
 		}
 	}
 
@@ -1729,9 +1741,9 @@ func computeWildcardBounds(value string) (lower, upper semverTuple, err error) {
 		return semverTuple{}, semverTuple{}, errors.New("invalid wildcard pattern: no version components")
 	}
 
-	major, err := strconv.Atoi(nonEmptyParts[0])
+	major, err := parseSemverNumeric(nonEmptyParts[0])
 	if err != nil {
-		return semverTuple{}, semverTuple{}, fmt.Errorf("invalid wildcard pattern: major version '%s' is not a number", nonEmptyParts[0])
+		return semverTuple{}, semverTuple{}, fmt.Errorf("invalid wildcard pattern: major version '%s': %w", nonEmptyParts[0], err)
 	}
 
 	if len(nonEmptyParts) == 1 {
@@ -1741,9 +1753,9 @@ func computeWildcardBounds(value string) (lower, upper semverTuple, err error) {
 		return lower, upper, nil
 	}
 
-	minor, err := strconv.Atoi(nonEmptyParts[1])
+	minor, err := parseSemverNumeric(nonEmptyParts[1])
 	if err != nil {
-		return semverTuple{}, semverTuple{}, fmt.Errorf("invalid wildcard pattern: minor version '%s' is not a number", nonEmptyParts[1])
+		return semverTuple{}, semverTuple{}, fmt.Errorf("invalid wildcard pattern: minor version '%s': %w", nonEmptyParts[1], err)
 	}
 
 	if len(nonEmptyParts) == 2 {
@@ -1754,9 +1766,9 @@ func computeWildcardBounds(value string) (lower, upper semverTuple, err error) {
 	}
 
 	// X.Y.Z.* pattern - treat as X.Y.Z to X.Y.(Z+1)
-	patch, err := strconv.Atoi(nonEmptyParts[2])
+	patch, err := parseSemverNumeric(nonEmptyParts[2])
 	if err != nil {
-		return semverTuple{}, semverTuple{}, fmt.Errorf("invalid wildcard pattern: patch version '%s' is not a number", nonEmptyParts[2])
+		return semverTuple{}, semverTuple{}, fmt.Errorf("invalid wildcard pattern: patch version '%s': %w", nonEmptyParts[2], err)
 	}
 	lower = semverTuple{major: major, minor: minor, patch: patch}
 	upper = semverTuple{major: major, minor: minor, patch: patch + 1}


### PR DESCRIPTION
## Summary

Per [semver 2.0.0 §2](https://semver.org/#spec-item-2), numeric identifiers MUST NOT include leading zeros. Values like `1.07.3` or `01.2.3` are not valid semver — the local feature flag evaluator currently parses them silently (via `strconv.Atoi("07") → 7`), which means a person property of `1.07.3` would incorrectly match a `semver_eq` condition against `1.7.3`.

This PR makes the parser reject leading zeros in numeric identifiers. Both override values and flag values are validated; invalid inputs surface an `InconclusiveMatchError` so the condition does not match.

## Changes

- New `parseSemverNumeric` helper that wraps `strconv.Atoi` with a leading-zero check.
- `parseSemver` and `computeWildcardBounds` use the new helper.
- Inverted the existing `parseSemver` subtest that asserted `01.02.03` parses to `{1, 2, 3}` — it now asserts an error.
- Added matchProperty-level rejection tests for override values and for flag values across `semver_caret`, `semver_tilde`, `semver_wildcard`, and `semver_gt`.

## Test plan

- [x] `go test -run "Semver|TestParseSemver|TestMatchPropertySemver" .` — all pass
- [x] New rejection subtests pass
- [x] `gofmt -l .` clean