### PR TITLE
feat: add server-side request context

### DIFF
--- a/.changeset/bright-ravens-panic.md
+++ b/.changeset/bright-ravens-panic.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Add opt-in panic capture for request context middleware.

--- a/.changeset/silver-pumas-share.md
+++ b/.changeset/silver-pumas-share.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Add server-side request context helpers for net/http capture and exception events, plus `EvaluateFlagsWithContext` for using request-scoped distinct IDs during flag evaluation. Request-context flag evaluation does not generate personless IDs.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ handler := posthog.NewRequestContextMiddleware(
 )
 ```
 
+Optionally capture panics as PostHog exception events and re-panic with the original value:
+
+```go
+handler := posthog.NewRequestContextMiddleware(
+    next,
+    posthog.WithCapturePanics(client),
+)
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, build, and test instructions.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,30 @@ func main() {
 }
 ```
 
+## Server-side request context
+
+For `net/http` apps, wrap handlers with request context middleware and use request-scoped helpers with `r.Context()`:
+
+```go
+handler := posthog.NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    flags, _ := posthog.EvaluateFlagsWithContext(r.Context(), client, posthog.EvaluateFlagsPayload{})
+    posthog.EnqueueWithContext(r.Context(), client, posthog.Capture{Event: "checkout started", Flags: flags})
+}))
+```
+
+The middleware adds `$current_url`, `$request_method`, `$request_path`, `$user_agent`, and `$ip`. By default it also uses `X-PostHog-Distinct-Id` and `X-PostHog-Session-Id` tracing headers; explicit `DistinctId` and `$session_id` values on the event override request context. When request context is attached but no identity is available, capture and exception events are sent personlessly with `$process_person_profile: false`. Plain `Enqueue` calls without request context still require `DistinctId`.
+
+Tracing headers are client-controlled analytics context, not authentication or authorization. For security-sensitive server-side decisions, pass an authenticated `DistinctId` explicitly instead of relying on request headers.
+
+Disable tracing header capture while keeping request metadata:
+
+```go
+handler := posthog.NewRequestContextMiddleware(
+    next,
+    posthog.WithCaptureTracingHeaders(false),
+)
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, build, and test instructions.

--- a/capture.go
+++ b/capture.go
@@ -97,12 +97,8 @@ func (msg Capture) internal() {
 }
 
 func (msg Capture) Validate() error {
-	if len(msg.Event) == 0 {
-		return FieldError{
-			Type:  "posthog.Capture",
-			Name:  "Event",
-			Value: msg.Event,
-		}
+	if err := validateCaptureEvent(msg); err != nil {
+		return err
 	}
 
 	if len(msg.DistinctId) == 0 {
@@ -110,6 +106,18 @@ func (msg Capture) Validate() error {
 			Type:  "posthog.Capture",
 			Name:  "DistinctId",
 			Value: msg.DistinctId,
+		}
+	}
+
+	return nil
+}
+
+func validateCaptureEvent(msg Capture) error {
+	if len(msg.Event) == 0 {
+		return FieldError{
+			Type:  "posthog.Capture",
+			Name:  "Event",
+			Value: msg.Event,
 		}
 	}
 

--- a/error_tracking_slog.go
+++ b/error_tracking_slog.go
@@ -71,7 +71,7 @@ func (h *SlogCaptureHandler) Handle(ctx context.Context, r slog.Record) error {
 		ExceptionFingerprint: h.cfg.fingerprint(ctx, r),
 		Properties:           h.cfg.properties(ctx, r),
 	}
-	_ = h.client.Enqueue(ex) // ignore enqueue error to keep logging safe
+	_ = enqueueWithContext(ctx, h.client, ex) // ignore enqueue error to keep logging safe
 
 	return err
 }

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -2,6 +2,7 @@ package posthog
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -174,6 +175,80 @@ func TestEvaluateFlags_ReturnsSnapshotWithSingleRequest(t *testing.T) {
 	keys := snap.Keys()
 	if len(keys) == 0 {
 		t.Fatal("expected at least one flag key")
+	}
+}
+
+func TestEvaluateFlagsWithContext_UsesRequestContextDistinctId(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+	defer fs.close()
+
+	client, capture, _ := newEvalClient(t, fs.server)
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{
+		DistinctId: "context-user",
+		SessionId:  "context-session",
+		Properties: NewProperties().Set("request", "metadata"),
+	})
+
+	snap, err := EvaluateFlagsWithContext(ctx, client, EvaluateFlagsPayload{})
+	if err != nil {
+		t.Fatalf("EvaluateFlagsWithContext returned error: %v", err)
+	}
+	call, _ := fs.lastCall()
+	if call.DistinctId != "context-user" {
+		t.Fatalf("expected /flags distinct_id from request context, got %q", call.DistinctId)
+	}
+
+	if !snap.IsEnabled("enabled-flag") {
+		t.Fatal("expected enabled-flag to be enabled")
+	}
+	events := waitForEventCount(capture, 1, 5*time.Second)
+	event := findEvent(events, "$feature_flag_called", "enabled-flag")
+	if event == nil {
+		t.Fatalf("expected $feature_flag_called event, got %+v", events)
+	}
+	if event.DistinctId != "context-user" {
+		t.Fatalf("expected feature flag event distinct_id from request context, got %q", event.DistinctId)
+	}
+	if event.Properties[propertySessionID] != "context-session" {
+		t.Fatalf("expected feature flag event session_id from request context, got %#v", event.Properties[propertySessionID])
+	}
+	if event.Properties["request"] != "metadata" {
+		t.Fatalf("expected feature flag event request metadata from request context, got %#v", event.Properties["request"])
+	}
+}
+
+func TestEvaluateFlagsWithContext_ExplicitDistinctIdOverridesRequestContext(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+	defer fs.close()
+
+	client, _, _ := newEvalClient(t, fs.server)
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{DistinctId: "context-user"})
+
+	_, err := EvaluateFlagsWithContext(ctx, client, EvaluateFlagsPayload{DistinctId: "explicit-user"})
+	if err != nil {
+		t.Fatalf("EvaluateFlagsWithContext returned error: %v", err)
+	}
+	call, _ := fs.lastCall()
+	if call.DistinctId != "explicit-user" {
+		t.Fatalf("expected explicit distinct_id to override request context, got %q", call.DistinctId)
+	}
+}
+
+func TestEvaluateFlagsWithContext_MissingDistinctIdReturnsError(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+	defer fs.close()
+
+	client, _, _ := newEvalClient(t, fs.server)
+
+	_, err := EvaluateFlagsWithContext(context.Background(), client, EvaluateFlagsPayload{})
+	if !errors.Is(err, ErrNoDistinctID) {
+		t.Fatalf("expected ErrNoDistinctID, got %v", err)
+	}
+	if fs.callCount() != 0 {
+		t.Fatalf("expected no /flags request without distinct_id, got %d", fs.callCount())
 	}
 }
 

--- a/negative_test.go
+++ b/negative_test.go
@@ -20,7 +20,7 @@ func TestEnqueue_InvalidMessageTypes(t *testing.T) {
 	})
 	defer client.Close()
 
-	t.Run("capture_missing_distinct_id", func(t *testing.T) {
+	t.Run("capture_missing_distinct_id_without_request_context", func(t *testing.T) {
 		err := client.Enqueue(Capture{
 			Event: "test_event",
 		})

--- a/noop_posthog.go
+++ b/noop_posthog.go
@@ -22,6 +22,10 @@ func (c *noopClient) Enqueue(Message) error {
 	return ErrSDKDisabled
 }
 
+func (c *noopClient) EnqueueWithContext(context.Context, Message) error {
+	return ErrSDKDisabled
+}
+
 func (c *noopClient) IsFeatureEnabled(FeatureFlagPayload) (interface{}, error) {
 	return false, ErrSDKDisabled
 }
@@ -47,6 +51,10 @@ func (c *noopClient) GetAllFlags(FeatureFlagPayloadNoKey) (map[string]interface{
 }
 
 func (c *noopClient) EvaluateFlags(EvaluateFlagsPayload) (*FeatureFlagEvaluations, error) {
+	return noopFeatureFlagEvaluations, ErrSDKDisabled
+}
+
+func (c *noopClient) EvaluateFlagsWithContext(context.Context, EvaluateFlagsPayload) (*FeatureFlagEvaluations, error) {
 	return noopFeatureFlagEvaluations, ErrSDKDisabled
 }
 

--- a/posthog.go
+++ b/posthog.go
@@ -409,6 +409,9 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 		}
 		m.DistinctId = captureContext.distinctID
 		m.Properties = captureContext.properties
+		if err = m.Validate(); err != nil {
+			return
+		}
 		if m.Flags != nil {
 			if m.shouldSendFeatureFlags() {
 				c.Warnf("[FEATURE FLAGS] Both Flags and SendFeatureFlags were set on Capture; using Flags and ignoring SendFeatureFlags.")

--- a/posthog.go
+++ b/posthog.go
@@ -1021,11 +1021,7 @@ func recordFromFlagDetail(detail FlagDetail) evaluatedFlagRecord {
 
 func ptrString(s string) *string { return &s }
 
-// featureFlagEvaluationsHost wires the snapshot's callbacks to this client.
-func (c *client) featureFlagEvaluationsHost() featureFlagEvaluationsHost {
-	return c.featureFlagEvaluationsHostWithContext(context.Background())
-}
-
+// featureFlagEvaluationsHostWithContext wires the snapshot's callbacks to this client.
 func (c *client) featureFlagEvaluationsHostWithContext(ctx context.Context) featureFlagEvaluationsHost {
 	return featureFlagEvaluationsHost{
 		captureFlagCalledIfNeeded: func(distinctId, key string, deviceId *string, properties Properties, groups Groups) {

--- a/posthog.go
+++ b/posthog.go
@@ -315,16 +315,21 @@ func dereferenceMessage(msg Message) Message {
 	return msg
 }
 
-func (c *client) Enqueue(msg Message) (err error) {
+func (c *client) Enqueue(msg Message) error {
+	return c.EnqueueWithContext(context.Background(), msg)
+}
+
+func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	// Fast path: check if client is closed before doing any work
 	if c.closed.Load() {
 		return ErrClosed
 	}
 
 	msg = dereferenceMessage(msg)
-	if err = msg.Validate(); err != nil {
-		return
-	}
 
 	var ts = c.now()
 
@@ -344,6 +349,9 @@ func (c *client) Enqueue(msg Message) (err error) {
 
 	switch m := msg.(type) {
 	case Alias:
+		if err = m.Validate(); err != nil {
+			return
+		}
 		m.Type = "alias"
 		m.Uuid = makeUUID(m.Uuid)
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
@@ -357,6 +365,9 @@ func (c *client) Enqueue(msg Message) (err error) {
 		return
 
 	case Identify:
+		if err = m.Validate(); err != nil {
+			return
+		}
 		m.Type = "identify"
 		m.Uuid = makeUUID(m.Uuid)
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
@@ -370,6 +381,9 @@ func (c *client) Enqueue(msg Message) (err error) {
 		return
 
 	case GroupIdentify:
+		if err = m.Validate(); err != nil {
+			return
+		}
 		m.Uuid = makeUUID(m.Uuid)
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
 		m.DisableGeoIP = c.GetDisableGeoIP()
@@ -382,9 +396,19 @@ func (c *client) Enqueue(msg Message) (err error) {
 		return
 
 	case Capture:
+		if err = validateCaptureEvent(m); err != nil {
+			return
+		}
 		m.Type = "capture"
 		m.Uuid = makeUUID(m.Uuid)
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
+		captureContext, captureContextErr := resolveCaptureContext(ctx, m.DistinctId, m.Properties, "posthog.Capture")
+		if captureContextErr != nil {
+			err = captureContextErr
+			return
+		}
+		m.DistinctId = captureContext.distinctID
+		m.Properties = captureContext.properties
 		if m.Flags != nil {
 			if m.shouldSendFeatureFlags() {
 				c.Warnf("[FEATURE FLAGS] Both Flags and SendFeatureFlags were set on Capture; using Flags and ignoring SendFeatureFlags.")
@@ -394,8 +418,9 @@ func (c *client) Enqueue(msg Message) (err error) {
 			// merge order so callers can manually overwrite $feature/<key>
 			// or $active_feature_flags if they need to.
 			m.Properties = m.Flags.eventProperties().Merge(m.Properties)
-		} else if m.shouldSendFeatureFlags() {
-			// Add all feature variants to event
+		} else if m.shouldSendFeatureFlags() && !captureContext.generatedPersonlessDistinctID {
+			// Add all feature variants to event. Skip for generated personless IDs so
+			// feature flag evaluation always uses a stable caller- or context-supplied ID.
 			personProperties := NewProperties()
 			groupProperties := map[string]Properties{}
 			opts := m.getFeatureFlagsOptions()
@@ -436,6 +461,9 @@ func (c *client) Enqueue(msg Message) (err error) {
 			m.Properties = NewProperties()
 		}
 		m.Properties.Merge(c.DefaultEventProperties)
+		if captureContext.personlessProcessProfileGuard {
+			m.Properties[propertyProcessPersonProfile] = false
+		}
 		data, apiMsg, serErr := prepareForSend(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)
@@ -449,6 +477,16 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Uuid = makeUUID(m.Uuid)
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
 		m.DisableGeoIP = c.GetDisableGeoIP()
+		captureContext, captureContextErr := resolveCaptureContext(ctx, m.DistinctId, m.Properties, "posthog.Exception")
+		if captureContextErr != nil {
+			err = captureContextErr
+			return
+		}
+		m.DistinctId = captureContext.distinctID
+		m.Properties = captureContext.properties
+		if err = m.Validate(); err != nil {
+			return
+		}
 		data, apiMsg, serErr := prepareForSend(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)
@@ -458,6 +496,9 @@ func (c *client) Enqueue(msg Message) (err error) {
 		return
 
 	default:
+		if err = msg.Validate(); err != nil {
+			return
+		}
 		err = fmt.Errorf("messages with custom types cannot be enqueued: %T", msg)
 		return
 	}
@@ -667,6 +708,10 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 // per-flag evaluation path and the FeatureFlagEvaluations snapshot path so
 // both dedupe identically against the same per-distinct_id LRU cache.
 func (c *client) captureFlagCalledIfNeeded(distinctId, key string, deviceId *string, properties Properties, groups Groups) {
+	c.captureFlagCalledIfNeededWithContext(context.Background(), distinctId, key, deviceId, properties, groups)
+}
+
+func (c *client) captureFlagCalledIfNeededWithContext(ctx context.Context, distinctId, key string, deviceId *string, properties Properties, groups Groups) {
 	deviceIDStr := ""
 	if deviceId != nil {
 		deviceIDStr = *deviceId
@@ -675,7 +720,7 @@ func (c *client) captureFlagCalledIfNeeded(distinctId, key string, deviceId *str
 	if c.distinctIdsFeatureFlagsReported.Contains(cacheKey) {
 		return
 	}
-	if err := c.Enqueue(Capture{
+	if err := c.EnqueueWithContext(ctx, Capture{
 		DistinctId: distinctId,
 		Event:      "$feature_flag_called",
 		Properties: properties,
@@ -766,7 +811,24 @@ type EvaluateFlagsPayload struct {
 }
 
 func (c *client) EvaluateFlags(payload EvaluateFlagsPayload) (*FeatureFlagEvaluations, error) {
-	host := c.featureFlagEvaluationsHost()
+	return c.evaluateFlagsWithContext(context.Background(), payload)
+}
+
+func (c *client) EvaluateFlagsWithContext(ctx context.Context, payload EvaluateFlagsPayload) (*FeatureFlagEvaluations, error) {
+	return c.evaluateFlagsWithContext(ctx, payload)
+}
+
+func (c *client) evaluateFlagsWithContext(ctx context.Context, payload EvaluateFlagsPayload) (*FeatureFlagEvaluations, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if payload.DistinctId == "" {
+		if requestContext, ok := RequestContextFromContext(ctx); ok {
+			payload.DistinctId = requestContext.DistinctId
+		}
+	}
+
+	host := c.featureFlagEvaluationsHostWithContext(ctx)
 
 	if payload.DistinctId == "" {
 		c.Warnf("EvaluateFlags called without a DistinctId")
@@ -961,9 +1023,15 @@ func ptrString(s string) *string { return &s }
 
 // featureFlagEvaluationsHost wires the snapshot's callbacks to this client.
 func (c *client) featureFlagEvaluationsHost() featureFlagEvaluationsHost {
+	return c.featureFlagEvaluationsHostWithContext(context.Background())
+}
+
+func (c *client) featureFlagEvaluationsHostWithContext(ctx context.Context) featureFlagEvaluationsHost {
 	return featureFlagEvaluationsHost{
-		captureFlagCalledIfNeeded: c.captureFlagCalledIfNeeded,
-		logger:                    c.Logger,
+		captureFlagCalledIfNeeded: func(distinctId, key string, deviceId *string, properties Properties, groups Groups) {
+			c.captureFlagCalledIfNeededWithContext(ctx, distinctId, key, deviceId, properties, groups)
+		},
+		logger: c.Logger,
 	}
 }
 

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -419,8 +419,14 @@ func assertPayloadEqual(t *testing.T, expected, actual string) {
 		}
 	}
 
+	knownSysCtxKeys := map[string]struct{}{
+		"$os":         {},
+		"$os_version": {},
+		"$os_distro":  {},
+		"$go_version": {},
+	}
 	opt := cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
-		_, ok := sysCtx[k]
+		_, ok := knownSysCtxKeys[k]
 		return ok
 	})
 	if diff := cmp.Diff(expectedJSON, actualJSON, opt); diff != "" {

--- a/request_context.go
+++ b/request_context.go
@@ -1,10 +1,15 @@
 package posthog
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"runtime"
+	"runtime/debug"
+	"strconv"
 	"strings"
 )
 
@@ -19,6 +24,8 @@ const (
 	propertyRequestPath          = "$request_path"
 	propertyUserAgent            = "$user_agent"
 	propertyIP                   = "$ip"
+	propertyResponseStatusCode   = "$response_status_code"
+	propertyExceptionSource      = "$exception_source"
 
 	maxRequestContextValueLength = 1000
 )
@@ -108,6 +115,13 @@ type RequestContextOptions struct {
 	// are read into request-scoped analytics context. It defaults to true in NewRequestContextMiddleware.
 	// When disabled, the middleware still attaches request metadata to the request context.
 	CaptureTracingHeaders bool
+
+	// CapturePanics controls whether NewRequestContextMiddleware captures downstream panics as
+	// PostHog exception events before re-panicking. It defaults to false.
+	CapturePanics bool
+
+	// PanicCaptureClient receives panic exception events when CapturePanics is enabled.
+	PanicCaptureClient EnqueueClient
 }
 
 // RequestContextOption customizes request context middleware.
@@ -117,6 +131,15 @@ type RequestContextOption func(*RequestContextOptions)
 func WithCaptureTracingHeaders(enabled bool) RequestContextOption {
 	return func(options *RequestContextOptions) {
 		options.CaptureTracingHeaders = enabled
+	}
+}
+
+// WithCapturePanics configures request context middleware to capture downstream panics as
+// PostHog exception events using client, then re-panic with the original value.
+func WithCapturePanics(client EnqueueClient) RequestContextOption {
+	return func(options *RequestContextOptions) {
+		options.CapturePanics = client != nil
+		options.PanicCaptureClient = client
 	}
 }
 
@@ -149,7 +172,29 @@ func NewRequestContextMiddleware(next http.Handler, opts ...RequestContextOption
 		ctx := WithFreshRequestContext(r.Context(), requestContext)
 		req := r.WithContext(ctx)
 
-		next.ServeHTTP(w, req)
+		if !options.CapturePanics {
+			next.ServeHTTP(w, req)
+			return
+		}
+
+		statusWriter := newResponseStatusWriter(w)
+		completed := false
+		defer func() {
+			if completed {
+				return
+			}
+
+			panicStack := debug.Stack()
+			panicValue := recover()
+			if panicValue == nil {
+				return
+			}
+			capturePanic(ctx, options.PanicCaptureClient, panicValue, statusWriter.statusCode, panicStack)
+			panic(panicValue)
+		}()
+
+		next.ServeHTTP(wrapResponseStatusWriter(statusWriter), req)
+		completed = true
 	})
 }
 
@@ -389,4 +434,329 @@ func enqueueWithContext(ctx context.Context, client EnqueueClient, msg Message) 
 		return contextClient.EnqueueWithContext(ctx, msg)
 	}
 	return client.Enqueue(msg)
+}
+
+func capturePanic(ctx context.Context, client EnqueueClient, panicValue interface{}, statusCode int, panicStack []byte) {
+	defer func() {
+		// Panic capture runs while the host application is already panicking. Any SDK,
+		// callback, or client panic here must not replace the original application panic.
+		_ = recover()
+	}()
+
+	if client == nil {
+		return
+	}
+	if statusCode < http.StatusBadRequest {
+		statusCode = http.StatusInternalServerError
+	}
+
+	exception := Exception{
+		Properties: NewProperties().
+			Set(propertyResponseStatusCode, statusCode).
+			Set(propertyExceptionSource, "panic"),
+		ExceptionList: []ExceptionItem{{
+			Type:       "panic",
+			Value:      fmt.Sprint(panicValue),
+			Stacktrace: stackTraceFromDebugStack(panicStack),
+		}},
+	}
+
+	_ = enqueueWithContext(ctx, client, exception)
+}
+
+func stackTraceFromDebugStack(stack []byte) *ExceptionStacktrace {
+	frames := parseDebugStackFrames(stack)
+	if len(frames) == 0 {
+		return DefaultStackTraceExtractor{InAppDecider: SimpleInAppDecider}.GetStackTrace(4)
+	}
+
+	return &ExceptionStacktrace{
+		Type:   "raw",
+		Frames: frames,
+	}
+}
+
+func parseDebugStackFrames(stack []byte) []StackFrame {
+	lines := strings.Split(string(stack), "\n")
+	frames := make([]StackFrame, 0, len(lines)/2)
+	include := false
+
+	for i := 1; i+1 < len(lines); i += 2 {
+		function := strings.TrimSpace(lines[i])
+		if function == "" {
+			continue
+		}
+		if strings.HasPrefix(function, "panic(") {
+			include = true
+			continue
+		}
+		if !include {
+			continue
+		}
+
+		filename, lineNo, ok := parseDebugStackFileLine(lines[i+1])
+		if !ok {
+			continue
+		}
+
+		frames = append(frames, StackFrame{
+			Filename:  filename,
+			LineNo:    lineNo,
+			Function:  function,
+			InApp:     SimpleInAppDecider(runtime.Frame{File: filename, Function: function}),
+			Synthetic: false,
+			Platform:  "go",
+		})
+	}
+
+	return frames
+}
+
+func parseDebugStackFileLine(line string) (string, int, bool) {
+	fileLine := strings.TrimSpace(line)
+	if fileLine == "" {
+		return "", 0, false
+	}
+	if idx := strings.Index(fileLine, " +"); idx >= 0 {
+		fileLine = fileLine[:idx]
+	}
+	colon := strings.LastIndex(fileLine, ":")
+	if colon <= 0 || colon == len(fileLine)-1 {
+		return "", 0, false
+	}
+	lineNo, err := strconv.Atoi(fileLine[colon+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return fileLine[:colon], lineNo, true
+}
+
+type responseStatusWriter struct {
+	http.ResponseWriter
+	statusCode  int
+	wroteHeader bool
+	flusher     http.Flusher
+	hijacker    http.Hijacker
+	pusher      http.Pusher
+	readerFrom  io.ReaderFrom
+}
+
+func newResponseStatusWriter(w http.ResponseWriter) *responseStatusWriter {
+	statusWriter := &responseStatusWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	if flusher, ok := w.(http.Flusher); ok {
+		statusWriter.flusher = flusher
+	}
+	if hijacker, ok := w.(http.Hijacker); ok {
+		statusWriter.hijacker = hijacker
+	}
+	if pusher, ok := w.(http.Pusher); ok {
+		statusWriter.pusher = pusher
+	}
+	if readerFrom, ok := w.(io.ReaderFrom); ok {
+		statusWriter.readerFrom = readerFrom
+	}
+	return statusWriter
+}
+
+func (w *responseStatusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *responseStatusWriter) WriteHeader(statusCode int) {
+	if !w.wroteHeader {
+		w.statusCode = statusCode
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *responseStatusWriter) Write(data []byte) (int, error) {
+	if !w.wroteHeader {
+		w.statusCode = http.StatusOK
+		w.wroteHeader = true
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+const (
+	responseStatusFlusherFlag = 1 << iota
+	responseStatusHijackerFlag
+	responseStatusPusherFlag
+	responseStatusReaderFromFlag
+)
+
+func wrapResponseStatusWriter(w *responseStatusWriter) http.ResponseWriter {
+	flags := 0
+	if w.flusher != nil {
+		flags |= responseStatusFlusherFlag
+	}
+	if w.hijacker != nil {
+		flags |= responseStatusHijackerFlag
+	}
+	if w.pusher != nil {
+		flags |= responseStatusPusherFlag
+	}
+	if w.readerFrom != nil {
+		flags |= responseStatusReaderFromFlag
+	}
+
+	switch flags {
+	case responseStatusFlusherFlag:
+		return &responseStatusWriterFlusher{w}
+	case responseStatusHijackerFlag:
+		return &responseStatusWriterHijacker{w}
+	case responseStatusPusherFlag:
+		return &responseStatusWriterPusher{w}
+	case responseStatusReaderFromFlag:
+		return &responseStatusWriterReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag:
+		return &responseStatusWriterFlusherHijacker{w}
+	case responseStatusFlusherFlag | responseStatusPusherFlag:
+		return &responseStatusWriterFlusherPusher{w}
+	case responseStatusFlusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherReaderFrom{w}
+	case responseStatusHijackerFlag | responseStatusPusherFlag:
+		return &responseStatusWriterHijackerPusher{w}
+	case responseStatusHijackerFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterHijackerReaderFrom{w}
+	case responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterPusherReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag | responseStatusPusherFlag:
+		return &responseStatusWriterFlusherHijackerPusher{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherHijackerReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherPusherReaderFrom{w}
+	case responseStatusHijackerFlag | responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterHijackerPusherReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag | responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherHijackerPusherReaderFrom{w}
+	default:
+		return w
+	}
+}
+
+type responseStatusWriterFlusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusher) Flush() { w.flusher.Flush() }
+
+type responseStatusWriterHijacker struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+
+type responseStatusWriterPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherHijacker struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijacker) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+
+type responseStatusWriterFlusherPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherPusher) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterFlusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterHijackerPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterHijackerPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterHijackerReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijackerReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterHijackerReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherHijackerPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijackerPusher) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterFlusherHijackerPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterFlusherHijackerReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijackerReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijackerReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterFlusherHijackerReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherPusherReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterFlusherPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterHijackerPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijackerPusherReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterHijackerPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterHijackerPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherHijackerPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
 }

--- a/request_context.go
+++ b/request_context.go
@@ -1,0 +1,392 @@
+package posthog
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+const (
+	HeaderPostHogDistinctID = "X-PostHog-Distinct-Id"
+	HeaderPostHogSessionID  = "X-PostHog-Session-Id"
+
+	propertyProcessPersonProfile = "$process_person_profile"
+	propertySessionID            = "$session_id"
+	propertyCurrentURL           = "$current_url"
+	propertyRequestMethod        = "$request_method"
+	propertyRequestPath          = "$request_path"
+	propertyUserAgent            = "$user_agent"
+	propertyIP                   = "$ip"
+
+	maxRequestContextValueLength = 1000
+)
+
+type requestContextKey struct{}
+
+// RequestContext carries request-scoped PostHog metadata that is applied to capture and exception events
+// enqueued with EnqueueWithContext.
+//
+// DistinctId and SessionId usually come from PostHog tracing headers. Properties usually contain safe
+// request metadata such as $current_url, $request_method, $request_path, $user_agent, and $ip.
+type RequestContext struct {
+	DistinctId string
+	SessionId  string
+	Properties Properties
+}
+
+// WithRequestContext returns a child context with PostHog request metadata attached. Existing PostHog
+// request context values are inherited: non-empty DistinctId and SessionId override the parent values,
+// and Properties are merged with child properties taking precedence.
+func WithRequestContext(ctx context.Context, requestContext RequestContext) context.Context {
+	return withRequestContext(ctx, requestContext, false)
+}
+
+// WithFreshRequestContext returns a child context with PostHog request metadata attached without inheriting
+// any existing PostHog request context from the parent.
+func WithFreshRequestContext(ctx context.Context, requestContext RequestContext) context.Context {
+	return withRequestContext(ctx, requestContext, true)
+}
+
+func withRequestContext(ctx context.Context, requestContext RequestContext, fresh bool) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var base RequestContext
+	if !fresh {
+		base, _ = RequestContextFromContext(ctx)
+	}
+
+	merged := RequestContext{
+		DistinctId: sanitizeRequestContextValue(base.DistinctId),
+		SessionId:  sanitizeRequestContextValue(base.SessionId),
+		Properties: cloneRequestProperties(base.Properties),
+	}
+
+	if distinctID := sanitizeRequestContextValue(requestContext.DistinctId); distinctID != "" {
+		merged.DistinctId = distinctID
+	}
+	if sessionID := sanitizeRequestContextValue(requestContext.SessionId); sessionID != "" {
+		merged.SessionId = sessionID
+	}
+	if len(requestContext.Properties) > 0 {
+		if merged.Properties == nil {
+			merged.Properties = NewProperties()
+		}
+		for key, value := range requestContext.Properties {
+			if key == "" {
+				continue
+			}
+			merged.Properties[key] = sanitizePropertyValue(value)
+		}
+	}
+
+	return context.WithValue(ctx, requestContextKey{}, merged)
+}
+
+// RequestContextFromContext returns the PostHog request metadata attached to ctx, if any.
+func RequestContextFromContext(ctx context.Context) (RequestContext, bool) {
+	if ctx == nil {
+		return RequestContext{}, false
+	}
+	requestContext, ok := ctx.Value(requestContextKey{}).(RequestContext)
+	if !ok {
+		return RequestContext{}, false
+	}
+	return RequestContext{
+		DistinctId: sanitizeRequestContextValue(requestContext.DistinctId),
+		SessionId:  sanitizeRequestContextValue(requestContext.SessionId),
+		Properties: cloneRequestProperties(requestContext.Properties),
+	}, true
+}
+
+// RequestContextOptions configures NewRequestContextMiddleware.
+type RequestContextOptions struct {
+	// CaptureTracingHeaders controls whether X-PostHog-Distinct-Id and X-PostHog-Session-Id
+	// are read into request-scoped analytics context. It defaults to true in NewRequestContextMiddleware.
+	// When disabled, the middleware still attaches request metadata to the request context.
+	CaptureTracingHeaders bool
+}
+
+// RequestContextOption customizes request context middleware.
+type RequestContextOption func(*RequestContextOptions)
+
+// WithCaptureTracingHeaders configures whether request context middleware reads PostHog tracing headers.
+func WithCaptureTracingHeaders(enabled bool) RequestContextOption {
+	return func(options *RequestContextOptions) {
+		options.CaptureTracingHeaders = enabled
+	}
+}
+
+func defaultRequestContextOptions() RequestContextOptions {
+	return RequestContextOptions{CaptureTracingHeaders: true}
+}
+
+// NewRequestContextMiddleware wraps an http.Handler with PostHog request-context extraction.
+//
+// The middleware always attaches safe request metadata to r.Context(). By default it also reads
+// X-PostHog-Distinct-Id and X-PostHog-Session-Id into request-scoped analytics context. Use
+// EnqueueWithContext(r.Context(), ...) for captures inside the request so this metadata is applied.
+func NewRequestContextMiddleware(next http.Handler, opts ...RequestContextOption) http.Handler {
+	options := defaultRequestContextOptions()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if next == nil {
+			return
+		}
+		if r == nil {
+			return
+		}
+
+		requestContext := ExtractRequestContext(r, options.CaptureTracingHeaders)
+		ctx := WithFreshRequestContext(r.Context(), requestContext)
+		req := r.WithContext(ctx)
+
+		next.ServeHTTP(w, req)
+	})
+}
+
+// ExtractRequestContext extracts sanitized PostHog request context from an HTTP request. Request metadata
+// is always extracted. Tracing headers are only read when captureTracingHeaders is true.
+func ExtractRequestContext(r *http.Request, captureTracingHeaders bool) RequestContext {
+	if r == nil {
+		return RequestContext{Properties: NewProperties()}
+	}
+
+	properties := NewProperties()
+	addPropertyIfPresent(properties, propertyCurrentURL, currentURL(r))
+	addPropertyIfPresent(properties, propertyRequestMethod, r.Method)
+	addPropertyIfPresent(properties, propertyRequestPath, requestPath(r))
+	addPropertyIfPresent(properties, propertyUserAgent, r.Header.Get("User-Agent"))
+	addPropertyIfPresent(properties, propertyIP, remoteIP(r))
+
+	var distinctID, sessionID string
+	if captureTracingHeaders {
+		distinctID = sanitizeRequestContextValue(r.Header.Get(HeaderPostHogDistinctID))
+		sessionID = sanitizeRequestContextValue(r.Header.Get(HeaderPostHogSessionID))
+	}
+
+	return RequestContext{
+		DistinctId: distinctID,
+		SessionId:  sessionID,
+		Properties: properties,
+	}
+}
+
+type captureContext struct {
+	distinctID                    string
+	properties                    Properties
+	generatedPersonlessDistinctID bool
+	personlessProcessProfileGuard bool
+}
+
+func resolveCaptureContext(ctx context.Context, distinctID string, properties Properties, fieldType string) (captureContext, error) {
+	requestContext, hasRequestContext := RequestContextFromContext(ctx)
+	resolvedDistinctID := distinctID
+	isPersonless := false
+	if resolvedDistinctID == "" && hasRequestContext {
+		resolvedDistinctID = requestContext.DistinctId
+	}
+	if resolvedDistinctID == "" {
+		if !hasRequestContext {
+			return captureContext{}, FieldError{
+				Type:  fieldType,
+				Name:  "DistinctId",
+				Value: distinctID,
+			}
+		}
+		resolvedDistinctID = makeUUID("")
+		isPersonless = true
+	}
+
+	resolved := captureContext{
+		distinctID:                    resolvedDistinctID,
+		properties:                    mergeContextProperties(requestContext, properties),
+		generatedPersonlessDistinctID: isPersonless,
+	}
+	if isPersonless {
+		if resolved.properties == nil {
+			resolved.properties = NewProperties()
+		}
+		if _, exists := resolved.properties[propertyProcessPersonProfile]; !exists {
+			resolved.properties[propertyProcessPersonProfile] = false
+			resolved.personlessProcessProfileGuard = true
+		}
+	}
+
+	return resolved, nil
+}
+
+func mergeContextProperties(requestContext RequestContext, explicit Properties) Properties {
+	var merged Properties
+	if len(requestContext.Properties) > 0 {
+		merged = cloneRequestProperties(requestContext.Properties)
+	}
+	if requestContext.SessionId != "" {
+		if merged == nil {
+			merged = NewProperties()
+		}
+		if _, exists := merged[propertySessionID]; !exists {
+			merged[propertySessionID] = requestContext.SessionId
+		}
+	}
+	if len(explicit) > 0 {
+		if merged == nil {
+			merged = NewProperties()
+		}
+		for key, value := range explicit {
+			merged[key] = value
+		}
+	}
+	return merged
+}
+
+func cloneRequestProperties(properties Properties) Properties {
+	if len(properties) == 0 {
+		return nil
+	}
+	cloned := make(Properties, len(properties))
+	for key, value := range properties {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func sanitizePropertyValue(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
+	if stringValue, ok := value.(string); ok {
+		return sanitizeRequestContextValue(stringValue)
+	}
+	return value
+}
+
+func addPropertyIfPresent(properties Properties, key, value string) {
+	if value = sanitizeRequestContextValue(value); value != "" {
+		properties.Set(key, value)
+	}
+}
+
+func sanitizeRequestContextValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+
+	builder := strings.Builder{}
+	builder.Grow(len(value))
+	for _, character := range value {
+		if character < 0x20 || character == 0x7f {
+			continue
+		}
+		builder.WriteRune(character)
+	}
+
+	sanitized := strings.TrimSpace(builder.String())
+	if sanitized == "" {
+		return ""
+	}
+	runes := []rune(sanitized)
+	if len(runes) > maxRequestContextValueLength {
+		return string(runes[:maxRequestContextValueLength])
+	}
+	return sanitized
+}
+
+func currentURL(r *http.Request) string {
+	scheme := requestScheme(r)
+	host := requestHost(r)
+	if scheme == "" || host == "" {
+		return ""
+	}
+	return scheme + "://" + host + requestPath(r)
+}
+
+func requestScheme(r *http.Request) string {
+	if r.URL != nil && r.URL.Scheme != "" {
+		return r.URL.Scheme
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func requestHost(r *http.Request) string {
+	if r.Host != "" {
+		return r.Host
+	}
+	if r.URL != nil {
+		return r.URL.Host
+	}
+	return ""
+}
+
+func requestPath(r *http.Request) string {
+	if r.URL == nil {
+		return ""
+	}
+	path := r.URL.EscapedPath()
+	if path == "" && r.URL.Path != "" {
+		path = r.URL.Path
+	}
+	return path
+}
+
+func remoteIP(r *http.Request) string {
+	if r.RemoteAddr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+// EnqueueWithContext queues a message and applies any PostHog request context attached to ctx.
+// Use this from HTTP handlers with r.Context() when NewRequestContextMiddleware is installed.
+func EnqueueWithContext(ctx context.Context, client EnqueueClient, msg Message) error {
+	return enqueueWithContext(ctx, client, msg)
+}
+
+// EvaluateFlagsWithContext evaluates feature flags and uses the request-scoped distinct ID attached
+// to ctx when payload.DistinctId is empty. It does not generate personless IDs: feature flag
+// evaluation requires a stable distinct ID and returns ErrNoDistinctID if neither payload nor ctx has one.
+func EvaluateFlagsWithContext(ctx context.Context, client Client, payload EvaluateFlagsPayload) (*FeatureFlagEvaluations, error) {
+	if client == nil {
+		return noopFeatureFlagEvaluations, fmt.Errorf("posthog: nil client")
+	}
+	if contextClient, ok := client.(interface {
+		EvaluateFlagsWithContext(context.Context, EvaluateFlagsPayload) (*FeatureFlagEvaluations, error)
+	}); ok {
+		return contextClient.EvaluateFlagsWithContext(ctx, payload)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if payload.DistinctId == "" {
+		if requestContext, ok := RequestContextFromContext(ctx); ok {
+			payload.DistinctId = requestContext.DistinctId
+		}
+	}
+	return client.EvaluateFlags(payload)
+}
+
+func enqueueWithContext(ctx context.Context, client EnqueueClient, msg Message) error {
+	if client == nil {
+		return fmt.Errorf("posthog: nil enqueue client")
+	}
+	if contextClient, ok := client.(interface {
+		EnqueueWithContext(context.Context, Message) error
+	}); ok {
+		return contextClient.EnqueueWithContext(ctx, msg)
+	}
+	return client.Enqueue(msg)
+}

--- a/request_context_test.go
+++ b/request_context_test.go
@@ -1,0 +1,372 @@
+package posthog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnqueueWithContext_AppliesRequestContextHeadersAndMetadata(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/test?oauth_code=secret", nil)
+	req.RemoteAddr = "10.0.0.2:4567"
+	req.Header.Set("x-posthog-distinct-id", " frontend-user ")
+	req.Header.Set("x-posthog-session-id", " frontend-session ")
+	req.Header.Set("User-Agent", "TestAgent/1.0")
+	ctx := WithFreshRequestContext(context.Background(), ExtractRequestContext(req, true))
+
+	err := EnqueueWithContext(ctx, client, Capture{Event: "request-context-event"})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	require.Equal(t, "frontend-user", event["distinct_id"])
+	properties := requireProperties(t, event)
+	require.Equal(t, "frontend-session", properties[propertySessionID])
+	require.Equal(t, "https://example.com/api/test", properties[propertyCurrentURL])
+	require.Equal(t, http.MethodPost, properties[propertyRequestMethod])
+	require.Equal(t, "/api/test", properties[propertyRequestPath])
+	require.Equal(t, "TestAgent/1.0", properties[propertyUserAgent])
+	require.Equal(t, "10.0.0.2", properties[propertyIP])
+	require.NotContains(t, properties, propertyProcessPersonProfile)
+}
+
+func TestEnqueueWithContext_ExplicitCaptureValuesOverrideContext(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{
+		DistinctId: "context-user",
+		SessionId:  "context-session",
+		Properties: NewProperties().Set("shared", "context-value").Set("context-only", "context-only-value"),
+	})
+
+	err := EnqueueWithContext(ctx, client, Capture{
+		DistinctId: "explicit-user",
+		Event:      "explicit-event",
+		Properties: NewProperties().Set("shared", "explicit-value").Set(propertySessionID, "explicit-session"),
+	})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	require.Equal(t, "explicit-user", event["distinct_id"])
+	properties := requireProperties(t, event)
+	require.Equal(t, "explicit-session", properties[propertySessionID])
+	require.Equal(t, "explicit-value", properties["shared"])
+	require.Equal(t, "context-only-value", properties["context-only"])
+	require.NotContains(t, properties, propertyProcessPersonProfile)
+}
+
+func TestEnqueue_MissingIdentityWithoutRequestContextReturnsDistinctIdError(t *testing.T) {
+	client, _ := NewWithConfig("test-key", Config{Transport: NoOpTransport()})
+	defer client.Close()
+
+	err := client.Enqueue(Capture{Event: "personless-event"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DistinctId")
+}
+
+func TestEnqueueWithContext_MissingIdentityWithRequestContextCreatesPersonlessCapture(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{})
+	err := EnqueueWithContext(ctx, client, Capture{Event: "personless-event"})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	distinctID, ok := event["distinct_id"].(string)
+	require.True(t, ok)
+	require.NoError(t, uuid.Validate(distinctID))
+	properties := requireProperties(t, event)
+	require.Equal(t, false, properties[propertyProcessPersonProfile])
+}
+
+func TestEnqueueWithContext_PersonlessCapturePreservesExplicitProcessPersonProfile(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{})
+	err := EnqueueWithContext(ctx, client, Capture{
+		Event:      "personless-event",
+		Properties: NewProperties().Set(propertyProcessPersonProfile, true),
+	})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	properties := requireProperties(t, event)
+	require.Equal(t, true, properties[propertyProcessPersonProfile])
+}
+
+func TestEnqueueWithContext_PersonlessCaptureSkipsSendFeatureFlags(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	logger := &captureLogger{}
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime, Logger: logger})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{})
+	err := EnqueueWithContext(ctx, client, Capture{
+		Event:            "personless-event",
+		SendFeatureFlags: SendFeatureFlags(true),
+	})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	properties := requireProperties(t, event)
+	require.NotContains(t, properties, "$active_feature_flags")
+	for key := range properties {
+		require.False(t, strings.HasPrefix(key, "$feature/"), "personless capture should not attach feature flag properties")
+	}
+	for _, warning := range logger.snapshot() {
+		require.NotContains(t, warning, "Capture.SendFeatureFlags")
+	}
+}
+
+func TestEnqueueWithContext_ExceptionUsesContextAndExplicitIdentity(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{
+		DistinctId: "context-user",
+		SessionId:  "context-session",
+		Properties: NewProperties().Set("request", "metadata"),
+	})
+
+	err := EnqueueWithContext(ctx, client, Exception{
+		DistinctId: "explicit-user",
+		ExceptionList: []ExceptionItem{{
+			Type:  "Error",
+			Value: "boom",
+		}},
+	})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	require.Equal(t, "$exception", event["event"])
+	properties := requireProperties(t, event)
+	require.Equal(t, "explicit-user", properties["distinct_id"])
+	require.Equal(t, "context-session", properties[propertySessionID])
+	require.Equal(t, "metadata", properties["request"])
+	require.NotContains(t, properties, propertyProcessPersonProfile)
+}
+
+func TestEnqueueWithContext_ExceptionFallsBackToRequestContext(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{
+		DistinctId: "context-user",
+		SessionId:  "context-session",
+	})
+
+	err := EnqueueWithContext(ctx, client, Exception{ExceptionList: []ExceptionItem{{Type: "Error", Value: "boom"}}})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	properties := requireProperties(t, event)
+	require.Equal(t, "context-user", properties["distinct_id"])
+	require.Equal(t, "context-session", properties[propertySessionID])
+	require.NotContains(t, properties, propertyProcessPersonProfile)
+}
+
+func TestEnqueue_ExceptionMissingIdentityWithoutRequestContextReturnsDistinctIdError(t *testing.T) {
+	client, _ := NewWithConfig("test-key", Config{Transport: NoOpTransport()})
+	defer client.Close()
+
+	err := client.Enqueue(Exception{ExceptionList: []ExceptionItem{{Type: "Error", Value: "boom"}}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DistinctId")
+}
+
+func TestEnqueueWithContext_ExceptionMissingIdentityWithRequestContextCreatesPersonlessEvent(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{})
+	err := EnqueueWithContext(ctx, client, Exception{ExceptionList: []ExceptionItem{{Type: "Error", Value: "boom"}}})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	properties := requireProperties(t, event)
+	distinctID, ok := properties["distinct_id"].(string)
+	require.True(t, ok)
+	require.NoError(t, uuid.Validate(distinctID))
+	require.Equal(t, false, properties[propertyProcessPersonProfile])
+}
+
+func TestRequestContextMiddleware_DisableTracingHeadersPreservesMetadata(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		requestContext, ok := RequestContextFromContext(r.Context())
+		require.True(t, ok)
+		require.Empty(t, requestContext.DistinctId)
+		require.Empty(t, requestContext.SessionId)
+		require.NoError(t, EnqueueWithContext(r.Context(), client, Capture{Event: "metadata-event"}))
+	}), WithCaptureTracingHeaders(false))
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/api/test?token=secret", nil)
+	req.RemoteAddr = "10.0.0.2:1234"
+	req.Header.Set(HeaderPostHogDistinctID, "header-user")
+	req.Header.Set(HeaderPostHogSessionID, "header-session")
+	req.Header.Set("User-Agent", "TestAgent/1.0")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	event := readSingleBatchEvent(t, body)
+	distinctID, ok := event["distinct_id"].(string)
+	require.True(t, ok)
+	require.NotEqual(t, "header-user", distinctID)
+	require.NoError(t, uuid.Validate(distinctID))
+	properties := requireProperties(t, event)
+	require.Equal(t, false, properties[propertyProcessPersonProfile])
+	require.NotContains(t, properties, propertySessionID)
+	require.Equal(t, "/api/test", properties[propertyRequestPath])
+	require.Equal(t, "TestAgent/1.0", properties[propertyUserAgent])
+	require.Equal(t, "10.0.0.2", properties[propertyIP])
+}
+
+func TestRequestContextMiddleware_SanitizesHeaders(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		require.NoError(t, EnqueueWithContext(r.Context(), client, Capture{Event: "sanitized-event"}))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/api/test", nil)
+	req.Header.Set(HeaderPostHogDistinctID, " \u0000\u0001\u0002 ")
+	req.Header.Set(HeaderPostHogSessionID, "  "+strings.Repeat("s", 1200)+"\u0000  ")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	event := readSingleBatchEvent(t, body)
+	distinctID, ok := event["distinct_id"].(string)
+	require.True(t, ok)
+	require.NoError(t, uuid.Validate(distinctID))
+	properties := requireProperties(t, event)
+	require.Equal(t, strings.Repeat("s", maxRequestContextValueLength), properties[propertySessionID])
+}
+
+func TestRequestContextMiddleware_ConcurrentRequestsDoNotLeak(t *testing.T) {
+	results := map[string]RequestContext{}
+	var mu sync.Mutex
+
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		requestContext, ok := RequestContextFromContext(r.Context())
+		require.True(t, ok)
+		mu.Lock()
+		results[r.URL.Path] = requestContext
+		mu.Unlock()
+	}))
+
+	first := httptest.NewRequest(http.MethodGet, "https://example.com/first", nil)
+	first.Header.Set(HeaderPostHogDistinctID, "user-a")
+	first.Header.Set(HeaderPostHogSessionID, "session-a")
+	second := httptest.NewRequest(http.MethodGet, "https://example.com/second", nil)
+	second.Header.Set(HeaderPostHogDistinctID, "user-b")
+	second.Header.Set(HeaderPostHogSessionID, "session-b")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		handler.ServeHTTP(httptest.NewRecorder(), first)
+	}()
+	go func() {
+		defer wg.Done()
+		handler.ServeHTTP(httptest.NewRecorder(), second)
+	}()
+	wg.Wait()
+
+	require.Equal(t, "user-a", results["/first"].DistinctId)
+	require.Equal(t, "session-a", results["/first"].SessionId)
+	require.Equal(t, "user-b", results["/second"].DistinctId)
+	require.Equal(t, "session-b", results["/second"].SessionId)
+}
+
+func TestEnqueueWithContext_PersonlessCaptureDefaultPropertiesCannotEnablePersonProfiles(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{
+		Endpoint:               server.URL,
+		BatchSize:              1,
+		now:                    mockTime,
+		DefaultEventProperties: NewProperties().Set(propertyProcessPersonProfile, true).Set("service", "api"),
+	})
+	defer client.Close()
+
+	ctx := WithFreshRequestContext(context.Background(), RequestContext{})
+	err := EnqueueWithContext(ctx, client, Capture{Event: "personless-event"})
+	require.NoError(t, err)
+
+	event := readSingleBatchEvent(t, body)
+	properties := requireProperties(t, event)
+	require.Equal(t, false, properties[propertyProcessPersonProfile])
+	require.Equal(t, "api", properties["service"])
+}
+
+func readSingleBatchEvent(t *testing.T, body <-chan []byte) map[string]interface{} {
+	t.Helper()
+
+	select {
+	case payload := <-body:
+		var decoded map[string]interface{}
+		require.NoError(t, json.Unmarshal(payload, &decoded))
+		batch, ok := decoded["batch"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, batch, 1)
+		event, ok := batch[0].(map[string]interface{})
+		require.True(t, ok)
+		return event
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for batch payload")
+		return nil
+	}
+}
+
+func requireProperties(t *testing.T, event map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	properties, ok := event["properties"].(map[string]interface{})
+	require.True(t, ok)
+	return properties
+}

--- a/request_context_test.go
+++ b/request_context_test.go
@@ -1,7 +1,11 @@
 package posthog
 
 import (
+	"bufio"
 	"context"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -345,6 +349,140 @@ func TestEnqueueWithContext_PersonlessCaptureDefaultPropertiesCannotEnablePerson
 	require.Equal(t, "api", properties["service"])
 }
 
+func TestRequestContextMiddleware_CapturesPanicsWithRequestContextAndRethrows(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		panic(errors.New("boom"))
+	}), WithCapturePanics(client))
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/test", nil)
+	req.RemoteAddr = "10.0.0.2:1234"
+	req.Header.Set(HeaderPostHogDistinctID, "client-user")
+	req.Header.Set(HeaderPostHogSessionID, "client-session")
+	require.Panics(t, func() { handler.ServeHTTP(httptest.NewRecorder(), req) })
+
+	event := readSingleBatchEvent(t, body)
+	require.Equal(t, "$exception", event["event"])
+	properties := requireProperties(t, event)
+	require.Equal(t, "client-user", properties["distinct_id"])
+	require.Equal(t, "client-session", properties[propertySessionID])
+	require.Equal(t, float64(http.StatusServiceUnavailable), properties[propertyResponseStatusCode])
+	require.Equal(t, "panic", properties[propertyExceptionSource])
+	requireExceptionStackContainsFunction(t, properties, "TestRequestContextMiddleware_CapturesPanicsWithRequestContextAndRethrows")
+}
+
+func TestRequestContextMiddleware_PanicCaptureFailuresDoNotReplaceOriginalPanic(t *testing.T) {
+	originalPanic := errors.New("original application panic")
+
+	tests := []struct {
+		name string
+		opts []RequestContextOption
+	}{
+		{
+			name: "enqueue panics",
+			opts: []RequestContextOption{WithCapturePanics(panickingEnqueueClient{})},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewRequestContextMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				panic(originalPanic)
+			}), tt.opts...)
+
+			req := httptest.NewRequest(http.MethodGet, "https://example.com/panic", nil)
+			require.PanicsWithValue(t, originalPanic, func() {
+				handler.ServeHTTP(httptest.NewRecorder(), req)
+			})
+		})
+	}
+}
+
+func TestRequestContextMiddleware_PanicCaptureUsesFirstResponseStatus(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.WriteHeader(http.StatusTeapot)
+		panic(errors.New("boom"))
+	}), WithCapturePanics(client))
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/panic", nil)
+	require.Panics(t, func() { handler.ServeHTTP(httptest.NewRecorder(), req) })
+
+	event := readSingleBatchEvent(t, body)
+	properties := requireProperties(t, event)
+	require.Equal(t, float64(http.StatusTooManyRequests), properties[propertyResponseStatusCode])
+}
+
+func TestResponseStatusWriterTracksFirstStatusAndUnwraps(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writer := &responseStatusWriter{ResponseWriter: recorder, statusCode: http.StatusOK}
+
+	require.Same(t, recorder, writer.Unwrap())
+	writer.WriteHeader(http.StatusAccepted)
+	writer.WriteHeader(http.StatusInternalServerError)
+	require.Equal(t, http.StatusAccepted, writer.statusCode)
+}
+
+func TestRequestContextMiddleware_PanicWriterDoesNotAdvertiseUnsupportedOptionalInterfaces(t *testing.T) {
+	var report optionalInterfaceReport
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		report = captureOptionalInterfaceReport(w)
+	}), WithCapturePanics(&noopClient{}))
+
+	handler.ServeHTTP(newMinimalResponseWriter(), httptest.NewRequest(http.MethodGet, "https://example.com", nil))
+
+	require.False(t, report.flusher)
+	require.False(t, report.hijacker)
+	require.False(t, report.pusher)
+	require.False(t, report.readerFrom)
+}
+
+func TestRequestContextMiddleware_PanicWriterPreservesSupportedOptionalInterfaces(t *testing.T) {
+	writer := &allOptionalResponseWriter{minimalResponseWriter: newMinimalResponseWriter()}
+	var report optionalInterfaceReport
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		report = captureOptionalInterfaceReport(w)
+		w.(http.Flusher).Flush()
+		_, _, _ = w.(http.Hijacker).Hijack()
+		require.NoError(t, w.(http.Pusher).Push("/asset.css", nil))
+		_, err := w.(io.ReaderFrom).ReadFrom(strings.NewReader("body"))
+		require.NoError(t, err)
+	}), WithCapturePanics(&noopClient{}))
+
+	handler.ServeHTTP(writer, httptest.NewRequest(http.MethodGet, "https://example.com", nil))
+
+	require.True(t, report.flusher)
+	require.True(t, report.hijacker)
+	require.True(t, report.pusher)
+	require.True(t, report.readerFrom)
+	require.True(t, writer.flushed)
+	require.True(t, writer.hijacked)
+	require.Equal(t, "/asset.css", writer.pushedTarget)
+	require.True(t, writer.readFromCalled)
+}
+
+type panickingEnqueueClient struct{}
+
+func (panickingEnqueueClient) Enqueue(Message) error {
+	panic("enqueue panic")
+}
+
+func (panickingEnqueueClient) EnqueueWithContext(context.Context, Message) error {
+	panic("enqueue with context panic")
+}
+
 func readSingleBatchEvent(t *testing.T, body <-chan []byte) map[string]interface{} {
 	t.Helper()
 
@@ -369,4 +507,89 @@ func requireProperties(t *testing.T, event map[string]interface{}) map[string]in
 	properties, ok := event["properties"].(map[string]interface{})
 	require.True(t, ok)
 	return properties
+}
+
+func requireExceptionStackContainsFunction(t *testing.T, properties map[string]interface{}, functionName string) {
+	t.Helper()
+	exceptionList, ok := properties["$exception_list"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, exceptionList)
+	exceptionItem, ok := exceptionList[0].(map[string]interface{})
+	require.True(t, ok)
+	stacktrace, ok := exceptionItem["stacktrace"].(map[string]interface{})
+	require.True(t, ok)
+	frames, ok := stacktrace["frames"].([]interface{})
+	require.True(t, ok)
+	for _, rawFrame := range frames {
+		frame, ok := rawFrame.(map[string]interface{})
+		require.True(t, ok)
+		function, _ := frame["function"].(string)
+		if strings.Contains(function, functionName) {
+			return
+		}
+	}
+	require.Failf(t, "missing panic frame", "expected stacktrace to contain function %q, got %#v", functionName, frames)
+}
+
+type optionalInterfaceReport struct {
+	flusher    bool
+	hijacker   bool
+	pusher     bool
+	readerFrom bool
+}
+
+func captureOptionalInterfaceReport(w http.ResponseWriter) optionalInterfaceReport {
+	_, flusher := w.(http.Flusher)
+	_, hijacker := w.(http.Hijacker)
+	_, pusher := w.(http.Pusher)
+	_, readerFrom := w.(io.ReaderFrom)
+	return optionalInterfaceReport{
+		flusher:    flusher,
+		hijacker:   hijacker,
+		pusher:     pusher,
+		readerFrom: readerFrom,
+	}
+}
+
+type minimalResponseWriter struct {
+	header http.Header
+	body   strings.Builder
+	status int
+}
+
+func newMinimalResponseWriter() *minimalResponseWriter {
+	return &minimalResponseWriter{header: http.Header{}, status: http.StatusOK}
+}
+
+func (w *minimalResponseWriter) Header() http.Header { return w.header }
+
+func (w *minimalResponseWriter) Write(data []byte) (int, error) {
+	return w.body.Write(data)
+}
+
+func (w *minimalResponseWriter) WriteHeader(statusCode int) { w.status = statusCode }
+
+type allOptionalResponseWriter struct {
+	*minimalResponseWriter
+	flushed        bool
+	hijacked       bool
+	pushedTarget   string
+	readFromCalled bool
+}
+
+func (w *allOptionalResponseWriter) Flush() { w.flushed = true }
+
+func (w *allOptionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacked = true
+	return nil, nil, nil
+}
+
+func (w *allOptionalResponseWriter) Push(target string, _ *http.PushOptions) error {
+	w.pushedTarget = target
+	return nil
+}
+
+func (w *allOptionalResponseWriter) ReadFrom(reader io.Reader) (int64, error) {
+	w.readFromCalled = true
+	return io.Copy(w.minimalResponseWriter, reader)
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Adds server-side request context support for Go `net/http` apps, matching the request-context patterns used in other PostHog server SDKs.

This lets handlers enqueue capture and exception events with request-scoped metadata and optional frontend tracing headers, while keeping explicit event identity authoritative and falling back to personless events when no identity is available.

Key changes:
- Add `RequestContext` helpers, `NewRequestContextMiddleware`, and `EnqueueWithContext`.
- Attach safe request metadata (`$current_url`, `$request_method`, `$request_path`, `$user_agent`, `$ip`) and optional tracing header values.
- Support personless capture/exception fallback with `$process_person_profile: false`.
- Add opt-in panic capture that re-panics and preserves host-app behavior.
- Document tracing headers as client-controlled analytics context, not auth/authz.

## :green_heart: How did you test it?

- `gofmt -l $(git diff --name-only -- '*.go') request_context.go request_context_test.go`
- `go test ./...`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
