### PR TITLE
feat: add request-context panic capture

### DIFF
--- a/.changeset/bright-ravens-panic.md
+++ b/.changeset/bright-ravens-panic.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Add opt-in panic capture for request context middleware.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ handler := posthog.NewRequestContextMiddleware(
 )
 ```
 
+Optionally capture panics as PostHog exception events and re-panic with the original value:
+
+```go
+handler := posthog.NewRequestContextMiddleware(
+    next,
+    posthog.WithCapturePanics(client),
+)
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, build, and test instructions.

--- a/request_context.go
+++ b/request_context.go
@@ -1,10 +1,15 @@
 package posthog
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"runtime"
+	"runtime/debug"
+	"strconv"
 	"strings"
 )
 
@@ -19,6 +24,8 @@ const (
 	propertyRequestPath          = "$request_path"
 	propertyUserAgent            = "$user_agent"
 	propertyIP                   = "$ip"
+	propertyResponseStatusCode   = "$response_status_code"
+	propertyExceptionSource      = "$exception_source"
 
 	maxRequestContextValueLength = 1000
 )
@@ -108,6 +115,13 @@ type RequestContextOptions struct {
 	// are read into request-scoped analytics context. It defaults to true in NewRequestContextMiddleware.
 	// When disabled, the middleware still attaches request metadata to the request context.
 	CaptureTracingHeaders bool
+
+	// CapturePanics controls whether NewRequestContextMiddleware captures downstream panics as
+	// PostHog exception events before re-panicking. It defaults to false.
+	CapturePanics bool
+
+	// PanicCaptureClient receives panic exception events when CapturePanics is enabled.
+	PanicCaptureClient EnqueueClient
 }
 
 // RequestContextOption customizes request context middleware.
@@ -117,6 +131,15 @@ type RequestContextOption func(*RequestContextOptions)
 func WithCaptureTracingHeaders(enabled bool) RequestContextOption {
 	return func(options *RequestContextOptions) {
 		options.CaptureTracingHeaders = enabled
+	}
+}
+
+// WithCapturePanics configures request context middleware to capture downstream panics as
+// PostHog exception events using client, then re-panic with the original value.
+func WithCapturePanics(client EnqueueClient) RequestContextOption {
+	return func(options *RequestContextOptions) {
+		options.CapturePanics = client != nil
+		options.PanicCaptureClient = client
 	}
 }
 
@@ -149,7 +172,29 @@ func NewRequestContextMiddleware(next http.Handler, opts ...RequestContextOption
 		ctx := WithFreshRequestContext(r.Context(), requestContext)
 		req := r.WithContext(ctx)
 
-		next.ServeHTTP(w, req)
+		if !options.CapturePanics {
+			next.ServeHTTP(w, req)
+			return
+		}
+
+		statusWriter := newResponseStatusWriter(w)
+		completed := false
+		defer func() {
+			if completed {
+				return
+			}
+
+			panicStack := debug.Stack()
+			panicValue := recover()
+			if panicValue == nil {
+				return
+			}
+			capturePanic(ctx, options.PanicCaptureClient, panicValue, statusWriter.statusCode, panicStack)
+			panic(panicValue)
+		}()
+
+		next.ServeHTTP(wrapResponseStatusWriter(statusWriter), req)
+		completed = true
 	})
 }
 
@@ -389,4 +434,329 @@ func enqueueWithContext(ctx context.Context, client EnqueueClient, msg Message) 
 		return contextClient.EnqueueWithContext(ctx, msg)
 	}
 	return client.Enqueue(msg)
+}
+
+func capturePanic(ctx context.Context, client EnqueueClient, panicValue interface{}, statusCode int, panicStack []byte) {
+	defer func() {
+		// Panic capture runs while the host application is already panicking. Any SDK,
+		// callback, or client panic here must not replace the original application panic.
+		_ = recover()
+	}()
+
+	if client == nil {
+		return
+	}
+	if statusCode < http.StatusBadRequest {
+		statusCode = http.StatusInternalServerError
+	}
+
+	exception := Exception{
+		Properties: NewProperties().
+			Set(propertyResponseStatusCode, statusCode).
+			Set(propertyExceptionSource, "panic"),
+		ExceptionList: []ExceptionItem{{
+			Type:       "panic",
+			Value:      fmt.Sprint(panicValue),
+			Stacktrace: stackTraceFromDebugStack(panicStack),
+		}},
+	}
+
+	_ = enqueueWithContext(ctx, client, exception)
+}
+
+func stackTraceFromDebugStack(stack []byte) *ExceptionStacktrace {
+	frames := parseDebugStackFrames(stack)
+	if len(frames) == 0 {
+		return DefaultStackTraceExtractor{InAppDecider: SimpleInAppDecider}.GetStackTrace(4)
+	}
+
+	return &ExceptionStacktrace{
+		Type:   "raw",
+		Frames: frames,
+	}
+}
+
+func parseDebugStackFrames(stack []byte) []StackFrame {
+	lines := strings.Split(string(stack), "\n")
+	frames := make([]StackFrame, 0, len(lines)/2)
+	include := false
+
+	for i := 1; i+1 < len(lines); i += 2 {
+		function := strings.TrimSpace(lines[i])
+		if function == "" {
+			continue
+		}
+		if strings.HasPrefix(function, "panic(") {
+			include = true
+			continue
+		}
+		if !include {
+			continue
+		}
+
+		filename, lineNo, ok := parseDebugStackFileLine(lines[i+1])
+		if !ok {
+			continue
+		}
+
+		frames = append(frames, StackFrame{
+			Filename:  filename,
+			LineNo:    lineNo,
+			Function:  function,
+			InApp:     SimpleInAppDecider(runtime.Frame{File: filename, Function: function}),
+			Synthetic: false,
+			Platform:  "go",
+		})
+	}
+
+	return frames
+}
+
+func parseDebugStackFileLine(line string) (string, int, bool) {
+	fileLine := strings.TrimSpace(line)
+	if fileLine == "" {
+		return "", 0, false
+	}
+	if idx := strings.Index(fileLine, " +"); idx >= 0 {
+		fileLine = fileLine[:idx]
+	}
+	colon := strings.LastIndex(fileLine, ":")
+	if colon <= 0 || colon == len(fileLine)-1 {
+		return "", 0, false
+	}
+	lineNo, err := strconv.Atoi(fileLine[colon+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return fileLine[:colon], lineNo, true
+}
+
+type responseStatusWriter struct {
+	http.ResponseWriter
+	statusCode  int
+	wroteHeader bool
+	flusher     http.Flusher
+	hijacker    http.Hijacker
+	pusher      http.Pusher
+	readerFrom  io.ReaderFrom
+}
+
+func newResponseStatusWriter(w http.ResponseWriter) *responseStatusWriter {
+	statusWriter := &responseStatusWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	if flusher, ok := w.(http.Flusher); ok {
+		statusWriter.flusher = flusher
+	}
+	if hijacker, ok := w.(http.Hijacker); ok {
+		statusWriter.hijacker = hijacker
+	}
+	if pusher, ok := w.(http.Pusher); ok {
+		statusWriter.pusher = pusher
+	}
+	if readerFrom, ok := w.(io.ReaderFrom); ok {
+		statusWriter.readerFrom = readerFrom
+	}
+	return statusWriter
+}
+
+func (w *responseStatusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *responseStatusWriter) WriteHeader(statusCode int) {
+	if !w.wroteHeader {
+		w.statusCode = statusCode
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *responseStatusWriter) Write(data []byte) (int, error) {
+	if !w.wroteHeader {
+		w.statusCode = http.StatusOK
+		w.wroteHeader = true
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+const (
+	responseStatusFlusherFlag = 1 << iota
+	responseStatusHijackerFlag
+	responseStatusPusherFlag
+	responseStatusReaderFromFlag
+)
+
+func wrapResponseStatusWriter(w *responseStatusWriter) http.ResponseWriter {
+	flags := 0
+	if w.flusher != nil {
+		flags |= responseStatusFlusherFlag
+	}
+	if w.hijacker != nil {
+		flags |= responseStatusHijackerFlag
+	}
+	if w.pusher != nil {
+		flags |= responseStatusPusherFlag
+	}
+	if w.readerFrom != nil {
+		flags |= responseStatusReaderFromFlag
+	}
+
+	switch flags {
+	case responseStatusFlusherFlag:
+		return &responseStatusWriterFlusher{w}
+	case responseStatusHijackerFlag:
+		return &responseStatusWriterHijacker{w}
+	case responseStatusPusherFlag:
+		return &responseStatusWriterPusher{w}
+	case responseStatusReaderFromFlag:
+		return &responseStatusWriterReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag:
+		return &responseStatusWriterFlusherHijacker{w}
+	case responseStatusFlusherFlag | responseStatusPusherFlag:
+		return &responseStatusWriterFlusherPusher{w}
+	case responseStatusFlusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherReaderFrom{w}
+	case responseStatusHijackerFlag | responseStatusPusherFlag:
+		return &responseStatusWriterHijackerPusher{w}
+	case responseStatusHijackerFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterHijackerReaderFrom{w}
+	case responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterPusherReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag | responseStatusPusherFlag:
+		return &responseStatusWriterFlusherHijackerPusher{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherHijackerReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherPusherReaderFrom{w}
+	case responseStatusHijackerFlag | responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterHijackerPusherReaderFrom{w}
+	case responseStatusFlusherFlag | responseStatusHijackerFlag | responseStatusPusherFlag | responseStatusReaderFromFlag:
+		return &responseStatusWriterFlusherHijackerPusherReaderFrom{w}
+	default:
+		return w
+	}
+}
+
+type responseStatusWriterFlusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusher) Flush() { w.flusher.Flush() }
+
+type responseStatusWriterHijacker struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+
+type responseStatusWriterPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherHijacker struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijacker) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+
+type responseStatusWriterFlusherPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherPusher) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterFlusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterHijackerPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterHijackerPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterHijackerReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijackerReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterHijackerReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherHijackerPusher struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijackerPusher) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterFlusherHijackerPusher) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+
+type responseStatusWriterFlusherHijackerReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijackerReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijackerReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterFlusherHijackerReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherPusherReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterFlusherPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterHijackerPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterHijackerPusherReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterHijackerPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterHijackerPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
+}
+
+type responseStatusWriterFlusherHijackerPusherReaderFrom struct{ *responseStatusWriter }
+
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) Flush() { w.flusher.Flush() }
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.hijacker.Hijack()
+}
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) Push(target string, opts *http.PushOptions) error {
+	return w.pusher.Push(target, opts)
+}
+func (w *responseStatusWriterFlusherHijackerPusherReaderFrom) ReadFrom(reader io.Reader) (int64, error) {
+	return w.readerFrom.ReadFrom(reader)
 }

--- a/request_context_test.go
+++ b/request_context_test.go
@@ -1,7 +1,11 @@
 package posthog
 
 import (
+	"bufio"
 	"context"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -345,6 +349,140 @@ func TestEnqueueWithContext_PersonlessCaptureDefaultPropertiesCannotEnablePerson
 	require.Equal(t, "api", properties["service"])
 }
 
+func TestRequestContextMiddleware_CapturesPanicsWithRequestContextAndRethrows(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		panic(errors.New("boom"))
+	}), WithCapturePanics(client))
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/test", nil)
+	req.RemoteAddr = "10.0.0.2:1234"
+	req.Header.Set(HeaderPostHogDistinctID, "client-user")
+	req.Header.Set(HeaderPostHogSessionID, "client-session")
+	require.Panics(t, func() { handler.ServeHTTP(httptest.NewRecorder(), req) })
+
+	event := readSingleBatchEvent(t, body)
+	require.Equal(t, "$exception", event["event"])
+	properties := requireProperties(t, event)
+	require.Equal(t, "client-user", properties["distinct_id"])
+	require.Equal(t, "client-session", properties[propertySessionID])
+	require.Equal(t, float64(http.StatusServiceUnavailable), properties[propertyResponseStatusCode])
+	require.Equal(t, "panic", properties[propertyExceptionSource])
+	requireExceptionStackContainsFunction(t, properties, "TestRequestContextMiddleware_CapturesPanicsWithRequestContextAndRethrows")
+}
+
+func TestRequestContextMiddleware_PanicCaptureFailuresDoNotReplaceOriginalPanic(t *testing.T) {
+	originalPanic := errors.New("original application panic")
+
+	tests := []struct {
+		name string
+		opts []RequestContextOption
+	}{
+		{
+			name: "enqueue panics",
+			opts: []RequestContextOption{WithCapturePanics(panickingEnqueueClient{})},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewRequestContextMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				panic(originalPanic)
+			}), tt.opts...)
+
+			req := httptest.NewRequest(http.MethodGet, "https://example.com/panic", nil)
+			require.PanicsWithValue(t, originalPanic, func() {
+				handler.ServeHTTP(httptest.NewRecorder(), req)
+			})
+		})
+	}
+}
+
+func TestRequestContextMiddleware_PanicCaptureUsesFirstResponseStatus(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	client, _ := NewWithConfig("test-key", Config{Endpoint: server.URL, BatchSize: 1, now: mockTime})
+	defer client.Close()
+
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.WriteHeader(http.StatusTeapot)
+		panic(errors.New("boom"))
+	}), WithCapturePanics(client))
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/panic", nil)
+	require.Panics(t, func() { handler.ServeHTTP(httptest.NewRecorder(), req) })
+
+	event := readSingleBatchEvent(t, body)
+	properties := requireProperties(t, event)
+	require.Equal(t, float64(http.StatusTooManyRequests), properties[propertyResponseStatusCode])
+}
+
+func TestResponseStatusWriterTracksFirstStatusAndUnwraps(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writer := &responseStatusWriter{ResponseWriter: recorder, statusCode: http.StatusOK}
+
+	require.Same(t, recorder, writer.Unwrap())
+	writer.WriteHeader(http.StatusAccepted)
+	writer.WriteHeader(http.StatusInternalServerError)
+	require.Equal(t, http.StatusAccepted, writer.statusCode)
+}
+
+func TestRequestContextMiddleware_PanicWriterDoesNotAdvertiseUnsupportedOptionalInterfaces(t *testing.T) {
+	var report optionalInterfaceReport
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		report = captureOptionalInterfaceReport(w)
+	}), WithCapturePanics(&noopClient{}))
+
+	handler.ServeHTTP(newMinimalResponseWriter(), httptest.NewRequest(http.MethodGet, "https://example.com", nil))
+
+	require.False(t, report.flusher)
+	require.False(t, report.hijacker)
+	require.False(t, report.pusher)
+	require.False(t, report.readerFrom)
+}
+
+func TestRequestContextMiddleware_PanicWriterPreservesSupportedOptionalInterfaces(t *testing.T) {
+	writer := &allOptionalResponseWriter{minimalResponseWriter: newMinimalResponseWriter()}
+	var report optionalInterfaceReport
+	handler := NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		report = captureOptionalInterfaceReport(w)
+		w.(http.Flusher).Flush()
+		_, _, _ = w.(http.Hijacker).Hijack()
+		require.NoError(t, w.(http.Pusher).Push("/asset.css", nil))
+		_, err := w.(io.ReaderFrom).ReadFrom(strings.NewReader("body"))
+		require.NoError(t, err)
+	}), WithCapturePanics(&noopClient{}))
+
+	handler.ServeHTTP(writer, httptest.NewRequest(http.MethodGet, "https://example.com", nil))
+
+	require.True(t, report.flusher)
+	require.True(t, report.hijacker)
+	require.True(t, report.pusher)
+	require.True(t, report.readerFrom)
+	require.True(t, writer.flushed)
+	require.True(t, writer.hijacked)
+	require.Equal(t, "/asset.css", writer.pushedTarget)
+	require.True(t, writer.readFromCalled)
+}
+
+type panickingEnqueueClient struct{}
+
+func (panickingEnqueueClient) Enqueue(Message) error {
+	panic("enqueue panic")
+}
+
+func (panickingEnqueueClient) EnqueueWithContext(context.Context, Message) error {
+	panic("enqueue with context panic")
+}
+
 func readSingleBatchEvent(t *testing.T, body <-chan []byte) map[string]interface{} {
 	t.Helper()
 
@@ -369,4 +507,89 @@ func requireProperties(t *testing.T, event map[string]interface{}) map[string]in
 	properties, ok := event["properties"].(map[string]interface{})
 	require.True(t, ok)
 	return properties
+}
+
+func requireExceptionStackContainsFunction(t *testing.T, properties map[string]interface{}, functionName string) {
+	t.Helper()
+	exceptionList, ok := properties["$exception_list"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, exceptionList)
+	exceptionItem, ok := exceptionList[0].(map[string]interface{})
+	require.True(t, ok)
+	stacktrace, ok := exceptionItem["stacktrace"].(map[string]interface{})
+	require.True(t, ok)
+	frames, ok := stacktrace["frames"].([]interface{})
+	require.True(t, ok)
+	for _, rawFrame := range frames {
+		frame, ok := rawFrame.(map[string]interface{})
+		require.True(t, ok)
+		function, _ := frame["function"].(string)
+		if strings.Contains(function, functionName) {
+			return
+		}
+	}
+	require.Failf(t, "missing panic frame", "expected stacktrace to contain function %q, got %#v", functionName, frames)
+}
+
+type optionalInterfaceReport struct {
+	flusher    bool
+	hijacker   bool
+	pusher     bool
+	readerFrom bool
+}
+
+func captureOptionalInterfaceReport(w http.ResponseWriter) optionalInterfaceReport {
+	_, flusher := w.(http.Flusher)
+	_, hijacker := w.(http.Hijacker)
+	_, pusher := w.(http.Pusher)
+	_, readerFrom := w.(io.ReaderFrom)
+	return optionalInterfaceReport{
+		flusher:    flusher,
+		hijacker:   hijacker,
+		pusher:     pusher,
+		readerFrom: readerFrom,
+	}
+}
+
+type minimalResponseWriter struct {
+	header http.Header
+	body   strings.Builder
+	status int
+}
+
+func newMinimalResponseWriter() *minimalResponseWriter {
+	return &minimalResponseWriter{header: http.Header{}, status: http.StatusOK}
+}
+
+func (w *minimalResponseWriter) Header() http.Header { return w.header }
+
+func (w *minimalResponseWriter) Write(data []byte) (int, error) {
+	return w.body.Write(data)
+}
+
+func (w *minimalResponseWriter) WriteHeader(statusCode int) { w.status = statusCode }
+
+type allOptionalResponseWriter struct {
+	*minimalResponseWriter
+	flushed        bool
+	hijacked       bool
+	pushedTarget   string
+	readFromCalled bool
+}
+
+func (w *allOptionalResponseWriter) Flush() { w.flushed = true }
+
+func (w *allOptionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacked = true
+	return nil, nil, nil
+}
+
+func (w *allOptionalResponseWriter) Push(target string, _ *http.PushOptions) error {
+	w.pushedTarget = target
+	return nil
+}
+
+func (w *allOptionalResponseWriter) ReadFrom(reader io.Reader) (int64, error) {
+	w.readFromCalled = true
+	return io.Copy(w.minimalResponseWriter, reader)
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Builds on the server-side request context work in #201 by adding opt-in panic capture for `net/http` middleware.

This lets apps capture panics as PostHog exception events with request metadata and response status, while still re-panicking with the original value so host application behavior is preserved.

Key changes:
- Add `WithCapturePanics(client)` request-context middleware option.
- Capture panic exceptions with `$response_status_code` and `$exception_source: "panic"`.
- Preserve optional `http.ResponseWriter` interfaces only when the wrapped writer supports them.
- Ensure panic-capture failures cannot replace the original application panic.

## :green_heart: How did you test it?

- `go test ./...`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
