### PR TITLE
fix: include group context in $feature_flag_called dedupe key

### DIFF
--- a/.changeset/include-group-context-in-flag-called-dedupe.md
+++ b/.changeset/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,5 @@
+---
+'posthog-go': patch
+---
+
+Include group context in the `$feature_flag_called` LRU dedupe key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinct_id, flag, device_id)` was seen under.

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -644,6 +644,122 @@ func TestRefactor_LegacyAndSnapshotPathsDedupeIdentically(t *testing.T) {
 	}
 }
 
+func TestCaptureFlagCalled_FiresPerGroupContext(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+	defer fs.close()
+
+	client, capture, _ := newEvalClient(t, fs.server)
+
+	// Same user, same flag, but two different group contexts.
+	if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
+		Key:        "enabled-flag",
+		DistinctId: "user-1",
+		Groups:     Groups{"company": "org-a"},
+	}); err != nil {
+		t.Fatalf("IsFeatureEnabled error (org-a): %v", err)
+	}
+	if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
+		Key:        "enabled-flag",
+		DistinctId: "user-1",
+		Groups:     Groups{"company": "org-b"},
+	}); err != nil {
+		t.Fatalf("IsFeatureEnabled error (org-b): %v", err)
+	}
+
+	events := waitForEventCount(capture, 2, 5*time.Second)
+	seen := map[string]bool{}
+	count := 0
+	for _, ev := range events {
+		if ev.Event != "$feature_flag_called" || ev.Properties["$feature_flag"] != "enabled-flag" {
+			continue
+		}
+		count++
+		groups, _ := ev.Properties["$groups"].(Groups)
+		if v, ok := groups["company"]; ok {
+			if s, ok := v.(string); ok {
+				seen[s] = true
+			}
+		}
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 $feature_flag_called events (one per group), got %d", count)
+	}
+	if !seen["org-a"] || !seen["org-b"] {
+		t.Errorf("expected both org-a and org-b in fired events, got %v", seen)
+	}
+}
+
+func TestCaptureFlagCalled_DedupesAcrossRepeatedCallsUnderSameGroup(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+	defer fs.close()
+
+	client, capture, _ := newEvalClient(t, fs.server)
+
+	for i := 0; i < 3; i++ {
+		if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
+			Key:        "enabled-flag",
+			DistinctId: "user-1",
+			Groups:     Groups{"company": "org-a"},
+		}); err != nil {
+			t.Fatalf("IsFeatureEnabled error: %v", err)
+		}
+	}
+
+	// Three calls but only the first should produce an event.
+	time.Sleep(150 * time.Millisecond)
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	count := 0
+	for _, ev := range capture.events {
+		if ev.Event == "$feature_flag_called" && ev.Properties["$feature_flag"] == "enabled-flag" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 deduped $feature_flag_called event, got %d", count)
+	}
+}
+
+func TestCaptureFlagCalled_DedupesAcrossGroupKeyOrder(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+	defer fs.close()
+
+	client, capture, _ := newEvalClient(t, fs.server)
+
+	// Same groups, two different Go map insertion orders. Both must produce
+	// the same canonical dedup key.
+	if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
+		Key:        "enabled-flag",
+		DistinctId: "user-1",
+		Groups:     Groups{"company": "org-a", "team": "red"},
+	}); err != nil {
+		t.Fatalf("first IsFeatureEnabled error: %v", err)
+	}
+	if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
+		Key:        "enabled-flag",
+		DistinctId: "user-1",
+		Groups:     Groups{"team": "red", "company": "org-a"},
+	}); err != nil {
+		t.Fatalf("second IsFeatureEnabled error: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	count := 0
+	for _, ev := range capture.events {
+		if ev.Event == "$feature_flag_called" && ev.Properties["$feature_flag"] == "enabled-flag" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 deduped $feature_flag_called event, got %d", count)
+	}
+}
+
 func TestErrorsWhileComputingFlags_PropagatesToEvent(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -733,6 +733,9 @@ func TestCaptureFlagCalled_DedupesAcrossSameGroupContext(t *testing.T) {
 				}
 			}
 
+			// Wait for the first (and only) event to arrive, then briefly
+			// pause to catch any stragglers that would indicate broken dedup.
+			waitForEventCount(capture, 1, 5*time.Second)
 			time.Sleep(150 * time.Millisecond)
 			capture.mu.Lock()
 			defer capture.mu.Unlock()

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -690,73 +690,62 @@ func TestCaptureFlagCalled_FiresPerGroupContext(t *testing.T) {
 	}
 }
 
-func TestCaptureFlagCalled_DedupesAcrossRepeatedCallsUnderSameGroup(t *testing.T) {
+func TestCaptureFlagCalled_DedupesAcrossSameGroupContext(t *testing.T) {
 	t.Parallel()
-	fs := newFlagsServer(t, "test-flags-v4.json")
-	defer fs.close()
 
-	client, capture, _ := newEvalClient(t, fs.server)
-
-	for i := 0; i < 3; i++ {
-		if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
-			Key:        "enabled-flag",
-			DistinctId: "user-1",
-			Groups:     Groups{"company": "org-a"},
-		}); err != nil {
-			t.Fatalf("IsFeatureEnabled error: %v", err)
-		}
+	cases := []struct {
+		name  string
+		calls []Groups
+	}{
+		{
+			name: "repeated calls under same group",
+			calls: []Groups{
+				{"company": "org-a"},
+				{"company": "org-a"},
+				{"company": "org-a"},
+			},
+		},
+		{
+			name: "different group key insertion order",
+			calls: []Groups{
+				{"company": "org-a", "team": "red"},
+				{"team": "red", "company": "org-a"},
+			},
+		},
 	}
 
-	// Three calls but only the first should produce an event.
-	time.Sleep(150 * time.Millisecond)
-	capture.mu.Lock()
-	defer capture.mu.Unlock()
-	count := 0
-	for _, ev := range capture.events {
-		if ev.Event == "$feature_flag_called" && ev.Properties["$feature_flag"] == "enabled-flag" {
-			count++
-		}
-	}
-	if count != 1 {
-		t.Errorf("expected exactly 1 deduped $feature_flag_called event, got %d", count)
-	}
-}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fs := newFlagsServer(t, "test-flags-v4.json")
+			defer fs.close()
 
-func TestCaptureFlagCalled_DedupesAcrossGroupKeyOrder(t *testing.T) {
-	t.Parallel()
-	fs := newFlagsServer(t, "test-flags-v4.json")
-	defer fs.close()
+			client, capture, _ := newEvalClient(t, fs.server)
 
-	client, capture, _ := newEvalClient(t, fs.server)
+			for i, groups := range tc.calls {
+				if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
+					Key:        "enabled-flag",
+					DistinctId: "user-1",
+					Groups:     groups,
+				}); err != nil {
+					t.Fatalf("IsFeatureEnabled error (call %d): %v", i, err)
+				}
+			}
 
-	// Same groups, two different Go map insertion orders. Both must produce
-	// the same canonical dedup key.
-	if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
-		Key:        "enabled-flag",
-		DistinctId: "user-1",
-		Groups:     Groups{"company": "org-a", "team": "red"},
-	}); err != nil {
-		t.Fatalf("first IsFeatureEnabled error: %v", err)
-	}
-	if _, err := client.IsFeatureEnabled(FeatureFlagPayload{
-		Key:        "enabled-flag",
-		DistinctId: "user-1",
-		Groups:     Groups{"team": "red", "company": "org-a"},
-	}); err != nil {
-		t.Fatalf("second IsFeatureEnabled error: %v", err)
-	}
-
-	time.Sleep(150 * time.Millisecond)
-	capture.mu.Lock()
-	defer capture.mu.Unlock()
-	count := 0
-	for _, ev := range capture.events {
-		if ev.Event == "$feature_flag_called" && ev.Properties["$feature_flag"] == "enabled-flag" {
-			count++
-		}
-	}
-	if count != 1 {
-		t.Errorf("expected exactly 1 deduped $feature_flag_called event, got %d", count)
+			time.Sleep(150 * time.Millisecond)
+			capture.mu.Lock()
+			defer capture.mu.Unlock()
+			count := 0
+			for _, ev := range capture.events {
+				if ev.Event == "$feature_flag_called" && ev.Properties["$feature_flag"] == "enabled-flag" {
+					count++
+				}
+			}
+			if count != 1 {
+				t.Errorf("expected exactly 1 deduped $feature_flag_called event, got %d", count)
+			}
+		})
 	}
 }
 

--- a/posthog.go
+++ b/posthog.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -182,6 +183,12 @@ type flagUser struct {
 	distinctID string
 	flagKey    string
 	deviceID   string
+	// canonical JSON of the groups map (keys sorted) — empty when no groups
+	// were passed. Lets the same `(user, flag)` fire a separate
+	// `$feature_flag_called` event for each distinct group context, so
+	// group-scoped flags don't undercount exposures when a user is evaluated
+	// under multiple groups in the same process.
+	groupsRepr string
 }
 
 // Instantiate a new client that uses the write key passed as first argument to
@@ -661,17 +668,24 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 }
 
 // captureFlagCalledIfNeeded fires a $feature_flag_called event if the
-// (distinctId, key, deviceId) triple has not already been reported on this
-// client. The caller is responsible for building the full properties dict;
-// this helper only handles dedup and enqueue. It is shared by the legacy
-// per-flag evaluation path and the FeatureFlagEvaluations snapshot path so
-// both dedupe identically against the same per-distinct_id LRU cache.
+// (distinctId, key, deviceId, groups) tuple has not already been reported on
+// this client. Group context is included so group-scoped flags fire a
+// separate event for each group a user is evaluated under. The caller is
+// responsible for building the full properties dict; this helper only handles
+// dedup and enqueue. It is shared by the legacy per-flag evaluation path and
+// the FeatureFlagEvaluations snapshot path so both dedupe identically against
+// the same per-distinct_id LRU cache.
 func (c *client) captureFlagCalledIfNeeded(distinctId, key string, deviceId *string, properties Properties, groups Groups) {
 	deviceIDStr := ""
 	if deviceId != nil {
 		deviceIDStr = *deviceId
 	}
-	cacheKey := flagUser{distinctID: distinctId, flagKey: key, deviceID: deviceIDStr}
+	cacheKey := flagUser{
+		distinctID: distinctId,
+		flagKey:    key,
+		deviceID:   deviceIDStr,
+		groupsRepr: canonicalGroupsRepr(groups),
+	}
 	if c.distinctIdsFeatureFlagsReported.Contains(cacheKey) {
 		return
 	}
@@ -683,6 +697,40 @@ func (c *client) captureFlagCalledIfNeeded(distinctId, key string, deviceId *str
 	}); err == nil {
 		c.distinctIdsFeatureFlagsReported.Add(cacheKey, struct{}{})
 	}
+}
+
+// canonicalGroupsRepr returns a JSON string of the sorted key/value pairs of
+// the groups map. Two equal maps that were built with keys inserted in a
+// different order produce the same string, so they dedupe to one cache entry.
+// Empty / nil groups produce an empty string.
+func canonicalGroupsRepr(groups Groups) string {
+	if len(groups) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([][2]interface{}, len(keys))
+	for i, k := range keys {
+		pairs[i] = [2]interface{}{k, groups[k]}
+	}
+	b, err := json.Marshal(pairs)
+	if err != nil {
+		// Fallback to a stable string concat — the JSON encode failure path
+		// shouldn't realistically trigger for a map[string]interface{}, but
+		// staying deterministic keeps the dedup behavior consistent.
+		var sb strings.Builder
+		for _, k := range keys {
+			sb.WriteString(k)
+			sb.WriteString("=")
+			sb.WriteString(fmt.Sprintf("%v", groups[k]))
+			sb.WriteString(";")
+		}
+		return sb.String()
+	}
+	return string(b)
 }
 
 func (c *client) GetRemoteConfigPayload(flagKey string) (string, error) {


### PR DESCRIPTION
## :bulb: Motivation and Context

In `captureFlagCalledIfNeeded` (`posthog.go`), the per-`distinct_id` LRU dedupe key only included `(distinct_id, flag_key, device_id)`. For group-scoped flags this meant that when the same user was evaluated under a different group, no new `$feature_flag_called` event was fired — causing per-group exposure undercount for experiments scoped to a group key.

Mirrors the posthog-node fix in PostHog/posthog-js#3658 (which closes PostHog/posthog-js#3651). Both SDKs share the same dedupe shape, so backend evaluation needs the same change.

## :green_heart: How did you test it?

Added three table-style tests in `feature_flag_evaluations_test.go`:

- `TestCaptureFlagCalled_FiresPerGroupContext` — same user, same flag, two different group contexts → two events fired, both `$groups` payloads observed.
- `TestCaptureFlagCalled_DedupesAcrossRepeatedCallsUnderSameGroup` — repeated access under the same group → one event.
- `TestCaptureFlagCalled_DedupesAcrossGroupKeyOrder` — same groups passed with different Go map insertion order → still one event (canonicalized by `sort.Strings` + JSON encode).

`go test -count=1 ./...` is green.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*