### PR TITLE
fix(flags): prefer local evaluation for SendFeatureFlags capture enrichment

### DIFF
--- a/.changeset/enrich-capture-with-local-eval.md
+++ b/.changeset/enrich-capture-with-local-eval.md
@@ -1,0 +1,7 @@
+---
+"posthog-go": patch
+---
+
+Capture with `SendFeatureFlags(true)` now prefers local evaluation when flag definitions are loaded, falling back to a remote `/flags` request only for flags that can't be computed locally. `OnlyEvaluateLocally` remains strictly local with no remote fallback.
+
+Captured events now exclude flags that evaluate to `false` from `$active_feature_flags` (they are still attached as `$feature/<key>=false`), matching the other PostHog SDKs.

--- a/capture_local_eval_test.go
+++ b/capture_local_eval_test.go
@@ -1,0 +1,355 @@
+package posthog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// captureLocalEvalServer is a mock PostHog endpoint that distinguishes local
+// evaluation definition fetches (/flags/definitions) from remote /flags (decide)
+// requests so capture-enrichment tests can assert whether a network /flags call
+// was made. A definitionsFixture of "" makes the definitions endpoint fail,
+// simulating definitions that never load.
+type captureLocalEvalServer struct {
+	server          *httptest.Server
+	definitionLoads atomic.Int32
+	decideCalls     atomic.Int32
+}
+
+func newCaptureLocalEvalServer(t *testing.T, definitionsFixture, decideResponse string) *captureLocalEvalServer {
+	t.Helper()
+	s := &captureLocalEvalServer{}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
+			s.definitionLoads.Add(1)
+			if definitionsFixture == "" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Write([]byte(fixture(definitionsFixture)))
+		case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
+			s.decideCalls.Add(1)
+			w.Write([]byte(decideResponse))
+		case strings.HasPrefix(r.URL.Path, "/batch"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+// waitForDefinitionFetch blocks until the poller has attempted to load local flag
+// definitions at least once, so a subsequent capture evaluates deterministically.
+func (s *captureLocalEvalServer) waitForDefinitionFetch(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.definitionLoads.Load() > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("local evaluation poller never fetched /flags/definitions")
+}
+
+// TestCaptureSendFeatureFlagsLocalEvaluation verifies that capture enrichment
+// prefers local evaluation and only contacts the remote /flags endpoint when a
+// flag can't be computed locally, while OnlyEvaluateLocally stays strictly local.
+func TestCaptureSendFeatureFlagsLocalEvaluation(t *testing.T) {
+	// test-multiple-flags-valid.json: beta-feature (rollout 100% -> true),
+	// disabled-feature (rollout 0% -> false). Both resolvable locally.
+	const validDefs = "feature_flag/test-multiple-flags-valid.json"
+	// test-multiple-flags.json adds beta-feature2, gated on a person property
+	// (country=US) the capture doesn't supply, so it can't be computed locally.
+	const mixedDefs = "feature_flag/test-multiple-flags.json"
+	const unusedDecide = `{"featureFlags": {"should-not": "be-used"}}`
+
+	tests := []struct {
+		name            string
+		definitions     string // "" => definitions endpoint fails to load
+		decideResponse  string
+		sendFlags       SendFeatureFlagsValue
+		wantDecideCalls int32
+		wantProps       map[string]interface{}
+		wantAbsent      []string
+		wantActiveFlags []string // nil => skip the $active_feature_flags check
+	}{
+		{
+			name:            "prefers local evaluation with no remote request",
+			definitions:     validDefs,
+			decideResponse:  unusedDecide,
+			sendFlags:       SendFeatureFlags(true),
+			wantDecideCalls: 0,
+			wantProps: map[string]interface{}{
+				"$feature/beta-feature": true,
+				// A disabled flag is still attached as $feature/<key>=false …
+				"$feature/disabled-feature": false,
+			},
+			// … but excluded from $active_feature_flags.
+			wantActiveFlags: []string{"beta-feature"},
+		},
+		{
+			name:            "falls back to remote for an uncomputable flag",
+			definitions:     mixedDefs,
+			decideResponse:  `{"featureFlags": {"beta-feature": "decide-fallback-value", "beta-feature2": "variant-2", "disabled-feature": false}}`,
+			sendFlags:       SendFeatureFlags(true),
+			wantDecideCalls: 1,
+			wantProps: map[string]interface{}{
+				// Remote evaluation is authoritative for the flags it returns.
+				"$feature/beta-feature":  "decide-fallback-value",
+				"$feature/beta-feature2": "variant-2",
+				// disabled-feature stays attached as false, excluded from active below.
+				"$feature/disabled-feature": false,
+			},
+			wantActiveFlags: []string{"beta-feature", "beta-feature2"},
+		},
+		{
+			name:           "remote turns off a locally-true flag",
+			definitions:    mixedDefs,
+			decideResponse: `{"featureFlags": {"beta-feature": false, "beta-feature2": "variant-2"}}`,
+			sendFlags:      SendFeatureFlags(true),
+			// beta-feature2 can't be computed locally, forcing a fallback. beta-feature
+			// resolves true locally but the remote turns it off, so it lands as
+			// $feature/beta-feature=false and drops out of $active_feature_flags.
+			wantDecideCalls: 1,
+			wantProps: map[string]interface{}{
+				"$feature/beta-feature":  false,
+				"$feature/beta-feature2": "variant-2",
+			},
+			wantActiveFlags: []string{"beta-feature2"},
+		},
+		{
+			name:            "falls back to remote when definitions fail to load",
+			definitions:     "",
+			decideResponse:  `{"featureFlags": {"remote-flag": true}}`,
+			sendFlags:       SendFeatureFlags(true),
+			wantDecideCalls: 1,
+			wantProps:       map[string]interface{}{"$feature/remote-flag": true},
+		},
+		{
+			name:            "OnlyEvaluateLocally stays strictly local",
+			definitions:     mixedDefs,
+			decideResponse:  unusedDecide,
+			sendFlags:       &SendFeatureFlagsOptions{OnlyEvaluateLocally: true},
+			wantDecideCalls: 0,
+			wantProps: map[string]interface{}{
+				"$feature/beta-feature":     true,
+				"$feature/disabled-feature": false,
+			},
+			// beta-feature2 can't be computed locally and must not appear without a fallback.
+			wantAbsent:      []string{"$feature/beta-feature2"},
+			wantActiveFlags: []string{"beta-feature"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // Capture loop variable for Go 1.21 compatibility
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := newCaptureLocalEvalServer(t, tt.definitions, tt.decideResponse)
+			client, capture, _ := newEvalClient(t, server.server, func(c *Config) {
+				c.PersonalApiKey = "personal-key"
+			})
+			server.waitForDefinitionFetch(t)
+
+			if err := client.Enqueue(Capture{
+				Event:            "test_event",
+				DistinctId:       "distinct-id",
+				SendFeatureFlags: tt.sendFlags,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			event := capture.waitForEvent(2 * time.Second)
+			if event == nil {
+				t.Fatal("timed out waiting for captured event")
+			}
+
+			if got := server.decideCalls.Load(); got != tt.wantDecideCalls {
+				t.Errorf("decide calls = %d, want %d", got, tt.wantDecideCalls)
+			}
+			for key, want := range tt.wantProps {
+				if got := event.Properties[key]; got != want {
+					t.Errorf("event property %s = %v, want %v", key, got, want)
+				}
+			}
+			for _, key := range tt.wantAbsent {
+				if _, ok := event.Properties[key]; ok {
+					t.Errorf("expected event property %s to be absent", key)
+				}
+			}
+			if tt.wantActiveFlags != nil {
+				active, ok := event.Properties["$active_feature_flags"].([]string)
+				if !ok {
+					t.Fatalf("expected $active_feature_flags to be []string, got %T", event.Properties["$active_feature_flags"])
+				}
+				got := make(map[string]bool, len(active))
+				for _, k := range active {
+					got[k] = true
+				}
+				if len(got) != len(tt.wantActiveFlags) {
+					t.Errorf("$active_feature_flags = %v, want %v", active, tt.wantActiveFlags)
+				}
+				for _, k := range tt.wantActiveFlags {
+					if !got[k] {
+						t.Errorf("$active_feature_flags = %v, missing %s", active, k)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestCaptureSendFeatureFlagsFallsBackForStaticCohort verifies that a flag gated on
+// a static cohort — which can't be evaluated locally and returns
+// RequiresServerEvaluationError rather than InconclusiveMatchError — still triggers
+// the remote /flags fallback during capture enrichment, instead of erroring and
+// dropping enrichment for the whole event.
+func TestCaptureSendFeatureFlagsFallsBackForStaticCohort(t *testing.T) {
+	t.Parallel()
+	var definitionLoads, decideCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
+			definitionLoads.Add(1)
+			// Flag gated on cohort 999 with no cohort definitions, so it's a static
+			// cohort that requires server evaluation.
+			w.Write([]byte(`{
+				"flags": [
+					{
+						"id": 1,
+						"key": "static-cohort-flag",
+						"active": true,
+						"filters": {
+							"groups": [
+								{
+									"properties": [
+										{"key": "id", "value": 999, "type": "cohort"}
+									],
+									"rollout_percentage": 100
+								}
+							]
+						}
+					}
+				],
+				"cohorts": {}
+			}`))
+		case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
+			decideCalls.Add(1)
+			w.Write([]byte(`{"featureFlags": {"static-cohort-flag": true}}`))
+		case strings.HasPrefix(r.URL.Path, "/batch"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, capture, _ := newEvalClient(t, server, func(c *Config) {
+		c.PersonalApiKey = "personal-key"
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && definitionLoads.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := client.Enqueue(Capture{
+		Event:            "test_event",
+		DistinctId:       "distinct-id",
+		SendFeatureFlags: SendFeatureFlags(true),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	event := capture.waitForEvent(2 * time.Second)
+	if event == nil {
+		t.Fatal("timed out waiting for captured event")
+	}
+	if got := decideCalls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 remote /flags fallback for the static cohort, got %d", got)
+	}
+	if event.Properties["$feature/static-cohort-flag"] != true {
+		t.Errorf("expected $feature/static-cohort-flag=true from remote fallback, got %v", event.Properties["$feature/static-cohort-flag"])
+	}
+}
+
+// TestCaptureSendFeatureFlagsFallsBackForGroupFlagWithoutGroups verifies that a
+// group-aggregated flag captured without the relevant group context — which
+// computeFlagLocally reports as a plain error (not Inconclusive/ServerEval) — still
+// defers to the remote /flags request rather than dropping enrichment for the event.
+func TestCaptureSendFeatureFlagsFallsBackForGroupFlagWithoutGroups(t *testing.T) {
+	t.Parallel()
+	var definitionLoads, decideCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
+			definitionLoads.Add(1)
+			// Flag aggregated on the "company" group. The capture below passes no
+			// groups, so it can't be computed locally.
+			w.Write([]byte(`{
+				"flags": [
+					{
+						"id": 1,
+						"key": "group-flag",
+						"active": true,
+						"filters": {
+							"aggregation_group_type_index": 0,
+							"groups": [
+								{"properties": [], "rollout_percentage": 100}
+							]
+						}
+					}
+				],
+				"group_type_mapping": {"0": "company"},
+				"cohorts": {}
+			}`))
+		case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
+			decideCalls.Add(1)
+			w.Write([]byte(`{"featureFlags": {"group-flag": "group-value"}}`))
+		case strings.HasPrefix(r.URL.Path, "/batch"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, capture, _ := newEvalClient(t, server, func(c *Config) {
+		c.PersonalApiKey = "personal-key"
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && definitionLoads.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := client.Enqueue(Capture{
+		Event:            "test_event",
+		DistinctId:       "distinct-id",
+		SendFeatureFlags: SendFeatureFlags(true),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	event := capture.waitForEvent(2 * time.Second)
+	if event == nil {
+		t.Fatal("timed out waiting for captured event")
+	}
+	if got := decideCalls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 remote /flags fallback for the group flag, got %d", got)
+	}
+	if event.Properties["$feature/group-flag"] != "group-value" {
+		t.Errorf("expected $feature/group-flag=group-value from remote fallback, got %v", event.Properties["$feature/group-flag"])
+	}
+}

--- a/capture_local_eval_test.go
+++ b/capture_local_eval_test.go
@@ -3,6 +3,7 @@ package posthog
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -15,9 +16,8 @@ import (
 // was made. A definitionsFixture of "" makes the definitions endpoint fail,
 // simulating definitions that never load.
 type captureLocalEvalServer struct {
-	server          *httptest.Server
-	definitionLoads atomic.Int32
-	decideCalls     atomic.Int32
+	server      *httptest.Server
+	decideCalls atomic.Int32
 }
 
 func newCaptureLocalEvalServer(t *testing.T, definitionsFixture, decideResponse string) *captureLocalEvalServer {
@@ -26,7 +26,6 @@ func newCaptureLocalEvalServer(t *testing.T, definitionsFixture, decideResponse 
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
-			s.definitionLoads.Add(1)
 			if definitionsFixture == "" {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
@@ -46,18 +45,16 @@ func newCaptureLocalEvalServer(t *testing.T, definitionsFixture, decideResponse 
 	return s
 }
 
-// waitForDefinitionFetch blocks until the poller has attempted to load local flag
-// definitions at least once, so a subsequent capture evaluates deterministically.
-func (s *captureLocalEvalServer) waitForDefinitionFetch(t *testing.T) {
+// waitForFlagDefinitions blocks until the poller's initial definitions fetch
+// completes (success or failure), so a subsequent capture evaluates against
+// settled poller state rather than racing the background fetch. The default
+// capture path reads poller state non-blockingly, so without this a capture
+// could run before definitions land and fall back to the remote /flags request.
+func waitForFlagDefinitions(t *testing.T, c Client) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if s.definitionLoads.Load() > 0 {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("local evaluation poller never fetched /flags/definitions")
+	// GetFeatureFlags blocks on the initial fetch; the error (e.g. definitions
+	// that fail to load) is intentionally ignored — we only need the fetch to settle.
+	_, _ = c.(*client).featureFlagsPoller.GetFeatureFlags()
 }
 
 // TestCaptureSendFeatureFlagsLocalEvaluation verifies that capture enrichment
@@ -158,7 +155,7 @@ func TestCaptureSendFeatureFlagsLocalEvaluation(t *testing.T) {
 			client, capture, _ := newEvalClient(t, server.server, func(c *Config) {
 				c.PersonalApiKey = "personal-key"
 			})
-			server.waitForDefinitionFetch(t)
+			waitForFlagDefinitions(t, client)
 
 			if err := client.Enqueue(Capture{
 				Event:            "test_event",
@@ -191,17 +188,10 @@ func TestCaptureSendFeatureFlagsLocalEvaluation(t *testing.T) {
 				if !ok {
 					t.Fatalf("expected $active_feature_flags to be []string, got %T", event.Properties["$active_feature_flags"])
 				}
-				got := make(map[string]bool, len(active))
-				for _, k := range active {
-					got[k] = true
-				}
-				if len(got) != len(tt.wantActiveFlags) {
+				// wantActiveFlags is kept sorted; $active_feature_flags is sorted for
+				// deterministic output, so assert exact ordered equality.
+				if !reflect.DeepEqual(active, tt.wantActiveFlags) {
 					t.Errorf("$active_feature_flags = %v, want %v", active, tt.wantActiveFlags)
-				}
-				for _, k := range tt.wantActiveFlags {
-					if !got[k] {
-						t.Errorf("$active_feature_flags = %v, missing %s", active, k)
-					}
 				}
 			}
 		})
@@ -215,11 +205,10 @@ func TestCaptureSendFeatureFlagsLocalEvaluation(t *testing.T) {
 // dropping enrichment for the whole event.
 func TestCaptureSendFeatureFlagsFallsBackForStaticCohort(t *testing.T) {
 	t.Parallel()
-	var definitionLoads, decideCalls atomic.Int32
+	var decideCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
-			definitionLoads.Add(1)
 			// Flag gated on cohort 999 with no cohort definitions, so it's a static
 			// cohort that requires server evaluation.
 			w.Write([]byte(`{
@@ -257,11 +246,7 @@ func TestCaptureSendFeatureFlagsFallsBackForStaticCohort(t *testing.T) {
 	client, capture, _ := newEvalClient(t, server, func(c *Config) {
 		c.PersonalApiKey = "personal-key"
 	})
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && definitionLoads.Load() == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForFlagDefinitions(t, client)
 
 	if err := client.Enqueue(Capture{
 		Event:            "test_event",
@@ -289,11 +274,10 @@ func TestCaptureSendFeatureFlagsFallsBackForStaticCohort(t *testing.T) {
 // defers to the remote /flags request rather than dropping enrichment for the event.
 func TestCaptureSendFeatureFlagsFallsBackForGroupFlagWithoutGroups(t *testing.T) {
 	t.Parallel()
-	var definitionLoads, decideCalls atomic.Int32
+	var decideCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
-			definitionLoads.Add(1)
 			// Flag aggregated on the "company" group. The capture below passes no
 			// groups, so it can't be computed locally.
 			w.Write([]byte(`{
@@ -328,11 +312,7 @@ func TestCaptureSendFeatureFlagsFallsBackForGroupFlagWithoutGroups(t *testing.T)
 	client, capture, _ := newEvalClient(t, server, func(c *Config) {
 		c.PersonalApiKey = "personal-key"
 	})
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && definitionLoads.Load() == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForFlagDefinitions(t, client)
 
 	if err := client.Enqueue(Capture{
 		Event:            "test_event",

--- a/featureflags.go
+++ b/featureflags.go
@@ -2171,19 +2171,30 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariants(distinctId string, devi
 // flags that cannot be computed locally (or when no local definitions are loaded).
 //
 // When onlyEvaluateLocally is true it stays strictly local: flags that cannot be evaluated
-// locally are simply omitted and no remote request is made. The returned map includes flags
-// that resolved to false; the caller attaches a $feature/<key> property for each entry and
-// excludes false-valued flags from $active_feature_flags, matching the other SDKs.
+// locally are simply omitted and no remote request is made, blocking on the initial
+// definitions fetch since it has no remote path to fall back to. The default path never
+// blocks on that fetch: if definitions aren't loaded yet it treats this as "no definitions"
+// and goes straight to the remote /flags fallback, so the first capture isn't stalled.
+//
+// The returned map includes flags that resolved to false; the caller attaches a
+// $feature/<key> property for each entry and excludes false-valued flags from
+// $active_feature_flags, matching the other SDKs.
 func (poller *FeatureFlagsPoller) getFeatureFlagVariantsWithFallback(distinctId string, deviceId *string, groups Groups, personProperties Properties, groupProperties map[string]Properties, onlyEvaluateLocally bool) (map[string]interface{}, error) {
-	flags, err := poller.GetFeatureFlags()
-	if err != nil {
-		// Local definitions are unavailable. The default path still falls back to the
-		// remote /flags request (the prior default behavior); only OnlyEvaluateLocally
-		// surfaces the error, since it must not contact the server.
-		if onlyEvaluateLocally {
+	var flags []FeatureFlag
+	if onlyEvaluateLocally {
+		// Strictly local: wait for the initial fetch and surface its error, since there
+		// is no remote path to fall back to.
+		loaded, err := poller.GetFeatureFlags()
+		if err != nil {
 			return nil, err
 		}
-		flags = nil
+		flags = loaded
+	} else if state := poller.getState(); state != nil {
+		// Default path: non-blocking read of already-loaded definitions. A nil state
+		// (initial fetch not finished, or it failed) is treated as "no definitions" and
+		// falls through to the remote /flags request below, preserving prior default
+		// behavior without stalling the first capture on the local-eval fetch.
+		flags = state.featureFlags
 	}
 
 	cohorts := poller.getCohorts()

--- a/featureflags.go
+++ b/featureflags.go
@@ -2200,6 +2200,11 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariantsWithFallback(distinctId 
 	cohorts := poller.getCohorts()
 	result := make(map[string]interface{}, len(flags))
 
+	// Merge distinct_id into person_properties so both local evaluation and the
+	// remote /flags fallback match on distinct_id as a person property, matching
+	// GetFeatureFlag and the GetAllFlags batch path.
+	personProperties = mergeDistinctIDIntoProperties(personProperties, distinctId)
+
 	// Fall back to the remote request when no definitions are loaded or any flag
 	// can't be computed locally.
 	fallbackToDecide := len(flags) == 0

--- a/featureflags.go
+++ b/featureflags.go
@@ -2166,18 +2166,34 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariants(distinctId string, devi
 	return poller.decider.makeFlagsRequest(distinctId, deviceId, groups, personProperties, groupProperties, poller.disableGeoIP, nil)
 }
 
-// getFeatureFlagVariantsLocalOnly evaluates all feature flags using only local evaluation
-func (poller *FeatureFlagsPoller) getFeatureFlagVariantsLocalOnly(distinctId string, deviceId *string, groups Groups, personProperties Properties, groupProperties map[string]Properties) (map[string]interface{}, error) {
+// getFeatureFlagVariantsWithFallback evaluates all feature flags for capture enrichment,
+// preferring local evaluation and only contacting the remote /flags endpoint to fill in
+// flags that cannot be computed locally (or when no local definitions are loaded).
+//
+// When onlyEvaluateLocally is true it stays strictly local: flags that cannot be evaluated
+// locally are simply omitted and no remote request is made. The returned map includes flags
+// that resolved to false; the caller attaches a $feature/<key> property for each entry and
+// excludes false-valued flags from $active_feature_flags, matching the other SDKs.
+func (poller *FeatureFlagsPoller) getFeatureFlagVariantsWithFallback(distinctId string, deviceId *string, groups Groups, personProperties Properties, groupProperties map[string]Properties, onlyEvaluateLocally bool) (map[string]interface{}, error) {
 	flags, err := poller.GetFeatureFlags()
 	if err != nil {
-		return nil, err
+		// Local definitions are unavailable. The default path still falls back to the
+		// remote /flags request (the prior default behavior); only OnlyEvaluateLocally
+		// surfaces the error, since it must not contact the server.
+		if onlyEvaluateLocally {
+			return nil, err
+		}
+		flags = nil
 	}
 
-	result := make(map[string]interface{})
 	cohorts := poller.getCohorts()
+	result := make(map[string]interface{}, len(flags))
 
+	// Fall back to the remote request when no definitions are loaded or any flag
+	// can't be computed locally.
+	fallbackToDecide := len(flags) == 0
 	for _, flag := range flags {
-		flagValue, err := poller.computeFlagLocally(
+		flagValue, computeErr := poller.computeFlagLocally(
 			flag,
 			distinctId,
 			deviceId,
@@ -2186,18 +2202,28 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariantsLocalOnly(distinctId str
 			groupProperties,
 			cohorts,
 		)
-
-		// Skip flags that can't be evaluated locally (e.g., experience continuity flags)
-		if err != nil {
-			if isInconclusiveError(err) {
-				continue
-			}
-			return nil, err
+		if computeErr != nil {
+			// Any flag we can't evaluate locally — experience continuity, missing
+			// properties, a static cohort, or missing group context — is deferred
+			// to the remote /flags request, which is authoritative. This mirrors
+			// GetAllFlags and the single-flag fallback. Under OnlyEvaluateLocally
+			// there is no remote call, so such flags are simply omitted.
+			fallbackToDecide = true
+			continue
 		}
+		result[flag.Key] = flagValue
+	}
 
-		// Only include flags that are not false
-		if flagValue != false {
-			result[flag.Key] = flagValue
+	if fallbackToDecide && !onlyEvaluateLocally {
+		flagsResponse, remoteErr := poller.getFeatureFlagVariants(distinctId, deviceId, groups, personProperties, groupProperties)
+		if remoteErr != nil {
+			return nil, remoteErr
+		}
+		if flagsResponse != nil {
+			// Remote evaluation is authoritative for the flags it returns.
+			for key, value := range flagsResponse.FeatureFlags {
+				result[key] = value
+			}
 		}
 	}
 

--- a/posthog.go
+++ b/posthog.go
@@ -472,6 +472,8 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 					activeFeatureFlags = append(activeFeatureFlags, feature)
 				}
 			}
+			// Sort for deterministic output, matching the snapshot Flags.eventProperties() path.
+			sort.Strings(activeFeatureFlags)
 			m.Properties["$active_feature_flags"] = activeFeatureFlags
 		}
 		if m.Properties == nil {

--- a/posthog.go
+++ b/posthog.go
@@ -463,18 +463,16 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 				m.Properties = NewProperties()
 			}
 
+			activeFeatureFlags := make([]string, 0, len(featureVariants))
 			for feature, variant := range featureVariants {
 				propKey := fmt.Sprintf("$feature/%s", feature)
 				m.Properties[propKey] = variant
+				// $active_feature_flags lists only flags that resolved to a non-false value.
+				if variant != false {
+					activeFeatureFlags = append(activeFeatureFlags, feature)
+				}
 			}
-			// Add all feature flag keys to $active_feature_flags key
-			featureKeys := make([]string, len(featureVariants))
-			i := 0
-			for k := range featureVariants {
-				featureKeys[i] = k
-				i++
-			}
-			m.Properties["$active_feature_flags"] = featureKeys
+			m.Properties["$active_feature_flags"] = activeFeatureFlags
 		}
 		if m.Properties == nil {
 			m.Properties = NewProperties()
@@ -1547,20 +1545,15 @@ func (c *client) getFeatureVariantsWithOptions(distinctId string, groups Groups,
 	}
 
 	var deviceId *string
-	if options != nil && options.DeviceId != nil {
+	onlyEvaluateLocally := false
+	if options != nil {
 		deviceId = options.DeviceId
+		onlyEvaluateLocally = options.OnlyEvaluateLocally
 	}
 
-	// If OnlyEvaluateLocally is set, only use local evaluation
-	if options != nil && options.OnlyEvaluateLocally {
-		return c.featureFlagsPoller.getFeatureFlagVariantsLocalOnly(distinctId, deviceId, groups, personProperties, groupProperties)
-	}
-
-	featureVariants, err := c.featureFlagsPoller.getFeatureFlagVariants(distinctId, deviceId, groups, personProperties, groupProperties)
-	if err != nil {
-		return nil, err
-	}
-	return featureVariants.FeatureFlags, nil
+	// Prefer local evaluation and only fall back to a remote /flags request for flags
+	// that can't be computed locally. OnlyEvaluateLocally keeps this strictly local.
+	return c.featureFlagsPoller.getFeatureFlagVariantsWithFallback(distinctId, deviceId, groups, personProperties, groupProperties, onlyEvaluateLocally)
 }
 
 func (c *client) makeRemoteConfigRequest(flagKey string) (string, error) {


### PR DESCRIPTION
## :bulb: Motivation and Context

When `Capture` is called with `SendFeatureFlags(true)` and local evaluation is configured (a personal API key is set and flag definitions are loaded), the SDK still made a remote `/flags` (decide) network request to enrich the event, even though the flags could be computed locally.

The default `SendFeatureFlags(true)` path now prefers local evaluation. The remote `/flags` endpoint is only contacted as a fallback for flags that cannot be computed locally (for example experience-continuity or static-cohort flags), or when no local definitions are loaded. When every flag resolves locally, no remote request is made. `OnlyEvaluateLocally: true` stays strictly local with no remote fallback.

This is the Go counterpart of the cross-SDK work tracked in PostHog/posthog#31373, following the Ruby, Python, Node, and dotnet implementations. It covers the Go checkbox only, so it intentionally avoids a closing keyword.

Part of PostHog/posthog#31373

### Implementation

`getFeatureVariantsWithOptions` now routes through a new poller method, `getFeatureFlagVariantsWithFallback`, instead of going straight to the remote path on the default branch. It evaluates each flag locally and defers any flag it cannot compute locally — and the no-definitions case — to a single remote `/flags` request, merging remote results with remote authoritative for the flags it returns. Any local-evaluation error (experience continuity, missing properties, static cohorts, or a group flag evaluated without group context) triggers the fallback, matching `GetAllFlags` and the single-flag path. If local definitions fail to load, the default path still falls back to the remote request, preserving the prior default behavior.

Captured events now exclude flags that evaluate to `false` from `$active_feature_flags`, while still attaching them as `$feature/<key>=false` — matching the other PostHog SDKs and Go's own `Flags`/`eventProperties` path. The default, local-only, and remote-fallback paths now produce identical property semantics. This also corrects prior behavior where the default remote path listed disabled flags in `$active_feature_flags`.

## :green_heart: How did you test it?

Added `capture_local_eval_test.go` with tests asserting against a mock that separates `/flags/definitions` (local) from `/flags` (remote decide):

- default `SendFeatureFlags(true)` with all-local-computable definitions makes 0 remote requests; disabled flags appear as `$feature/<key>=false` but are excluded from `$active_feature_flags`
- a flag gated on an unsupplied person property triggers exactly 1 remote fallback, remote values merged (remote authoritative)
- a flag that resolves true locally but is turned off by the remote response lands as `$feature/<key>=false` and drops out of `$active_feature_flags`
- local definitions failing to load still falls back to the remote `/flags` request
- `OnlyEvaluateLocally: true` with an uncomputable flag makes 0 remote requests and omits that flag
- a static-cohort flag (`RequiresServerEvaluationError`) falls back to the remote `/flags` request
- a group-aggregated flag captured without group context falls back to the remote `/flags` request

`go test ./...`, `go vet ./...`, `gofmt -l`, and `go test -race` on the affected tests all pass.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
