### PR TITLE
refactor: remove dry4go duplicate candidates

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -35,23 +35,7 @@ func (msg Alias) internal() {
 
 // Validate checks that the alias message has both DistinctId and Alias set.
 func (msg Alias) Validate() error {
-	if len(msg.DistinctId) == 0 {
-		return FieldError{
-			Type:  "posthog.Alias",
-			Name:  "DistinctId",
-			Value: msg.DistinctId,
-		}
-	}
-
-	if len(msg.Alias) == 0 {
-		return FieldError{
-			Type:  "posthog.Alias",
-			Name:  "Alias",
-			Value: msg.Alias,
-		}
-	}
-
-	return nil
+	return validateRequiredStringFields("posthog.Alias", requiredStringField{name: "DistinctId", value: msg.DistinctId}, requiredStringField{name: "Alias", value: msg.Alias})
 }
 
 // AliasInApiProperties is the wire-format properties object for an Alias message.

--- a/alias_test.go
+++ b/alias_test.go
@@ -1,88 +1,23 @@
 package posthog
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestAliasMissingDistinctId(t *testing.T) {
-	alias := Alias{
-		Alias: "1",
-	}
-
-	if err := alias.Validate(); err == nil {
-		t.Error("validating an invalid alias object succeeded:", alias)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating alias:", err)
-
-	} else if e != (FieldError{
-		Type:  "posthog.Alias",
-		Name:  "DistinctId",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating alias:", err)
-	}
+	assertFieldError(t, Alias{Alias: "1"}, fieldError("posthog.Alias", "DistinctId"))
 }
 
 func TestAliasMissingAlias(t *testing.T) {
-	alias := Alias{
-		DistinctId: "1",
-	}
-
-	if err := alias.Validate(); err == nil {
-		t.Error("validating an invalid alias object succeeded:", alias)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating alias:", err)
-
-	} else if e != (FieldError{
-		Type:  "posthog.Alias",
-		Name:  "Alias",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating alias:", err)
-	}
+	assertFieldError(t, Alias{DistinctId: "1"}, fieldError("posthog.Alias", "Alias"))
 }
 
 func TestAliasValid(t *testing.T) {
-	alias := Alias{
-		Alias:      "1",
-		DistinctId: "2",
-	}
-
-	if err := alias.Validate(); err != nil {
-		t.Error("validating a valid alias object failed:", alias, err)
-	}
-}
-
-func aliasWireProps(t *testing.T, alias Alias) map[string]interface{} {
-	t.Helper()
-	jsonBytes, err := json.Marshal(alias.APIfy())
-	if err != nil {
-		t.Fatalf("marshal failed: %v", err)
-	}
-	var wire map[string]interface{}
-	if err := json.Unmarshal(jsonBytes, &wire); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-	props, ok := wire["properties"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("properties field missing or wrong type")
-	}
-	return props
+	assertValid(t, Alias{Alias: "1", DistinctId: "2"})
 }
 
 func TestAliasAPIfyIncludesIsServerProperty(t *testing.T) {
-	props := aliasWireProps(t, Alias{Alias: "1", DistinctId: "2", IsServer: true})
-	if got := props["$is_server"]; got != true {
-		t.Errorf("$is_server: expected true, got %v", got)
-	}
+	assertIsServerProperty(t, Alias{Alias: "1", DistinctId: "2", IsServer: true}.APIfy(), true)
 }
 
 func TestAliasAPIfyOmitsIsServerWhenFalse(t *testing.T) {
-	props := aliasWireProps(t, Alias{Alias: "1", DistinctId: "2", IsServer: false})
-	if _, present := props["$is_server"]; present {
-		t.Errorf("$is_server should be absent when IsServer is false, got %v", props["$is_server"])
-	}
+	assertIsServerProperty(t, Alias{Alias: "1", DistinctId: "2", IsServer: false}.APIfy(), false)
 }

--- a/batching_test.go
+++ b/batching_test.go
@@ -14,13 +14,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBatching_SmallEventsBatchTogether verifies that small events are batched together
-func TestBatching_SmallEventsBatchTogether(t *testing.T) {
-	t.Parallel()
+func newSlowBatchServer(t *testing.T, delay time.Duration) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var received atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(delay)
+		var b batch
+		json.NewDecoder(r.Body).Decode(&b)
+		received.Add(int64(len(b.Messages)))
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(server.Close)
+	return server, &received
+}
 
+func enqueueTestCaptures(t *testing.T, client Client, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		err := client.Enqueue(Capture{DistinctId: "test-user", Event: "test-event"})
+		require.NoError(t, err)
+	}
+}
+
+func newBatchCounterServer(t *testing.T) (*httptest.Server, *atomic.Int64, *atomic.Int64) {
+	t.Helper()
 	var batchCount atomic.Int64
 	var totalMessages atomic.Int64
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var b batch
 		json.NewDecoder(r.Body).Decode(&b)
@@ -28,7 +47,15 @@ func TestBatching_SmallEventsBatchTogether(t *testing.T) {
 		totalMessages.Add(int64(len(b.Messages)))
 		w.WriteHeader(200)
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
+	return server, &batchCount, &totalMessages
+}
+
+// TestBatching_SmallEventsBatchTogether verifies that small events are batched together
+func TestBatching_SmallEventsBatchTogether(t *testing.T) {
+	t.Parallel()
+
+	server, batchCount, totalMessages := newBatchCounterServer(t)
 
 	// Small events (~100 props, ~5KB each)
 	// With 500KB batch limit, should fit ~100 events per batch
@@ -145,17 +172,7 @@ func TestBatching_OversizedEventRejected(t *testing.T) {
 func TestBatching_MixedCardinalityBatching(t *testing.T) {
 	t.Parallel()
 
-	var batchCount atomic.Int64
-	var totalMessages atomic.Int64
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var b batch
-		json.NewDecoder(r.Body).Decode(&b)
-		batchCount.Add(1)
-		totalMessages.Add(int64(len(b.Messages)))
-		w.WriteHeader(200)
-	}))
-	defer server.Close()
+	server, batchCount, totalMessages := newBatchCounterServer(t)
 
 	client, err := NewWithConfig("test-key", Config{
 		Endpoint:  server.URL,
@@ -381,17 +398,7 @@ func TestBatchSubmitTimeout_NonBlocking(t *testing.T) {
 func TestShutdownTimeout_DefaultWaitsForCompletion(t *testing.T) {
 	t.Parallel()
 
-	var received atomic.Int64
-
-	// Create a slow server (200ms per request)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(200 * time.Millisecond)
-		var b batch
-		json.NewDecoder(r.Body).Decode(&b)
-		received.Add(int64(len(b.Messages)))
-		w.WriteHeader(200)
-	}))
-	defer server.Close()
+	server, received := newSlowBatchServer(t, 200*time.Millisecond)
 
 	// Default config - ShutdownTimeout is zero (wait indefinitely)
 	client, err := NewWithConfig("test-key", Config{
@@ -402,14 +409,7 @@ func TestShutdownTimeout_DefaultWaitsForCompletion(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Send events
-	for i := 0; i < 10; i++ {
-		err := client.Enqueue(Capture{
-			DistinctId: "test-user",
-			Event:      "test-event",
-		})
-		require.NoError(t, err)
-	}
+	enqueueTestCaptures(t, client, 10)
 
 	// Close should wait for all events to be delivered despite slow server
 	start := time.Now()
@@ -427,19 +427,9 @@ func TestShutdownTimeout_DefaultWaitsForCompletion(t *testing.T) {
 func TestShutdownTimeout_AbortsAfterTimeout(t *testing.T) {
 	t.Parallel()
 
-	var received atomic.Int64
+	server, received := newSlowBatchServer(t, 2*time.Second)
 	var mu sync.Mutex
 	var failureCount int
-
-	// Create a very slow server (2s per request) - will exceed our timeout
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(2 * time.Second)
-		var b batch
-		json.NewDecoder(r.Body).Decode(&b)
-		received.Add(int64(len(b.Messages)))
-		w.WriteHeader(200)
-	}))
-	defer server.Close()
 
 	callback := &testCallbackCounter{
 		onFailure: func() {
@@ -459,14 +449,7 @@ func TestShutdownTimeout_AbortsAfterTimeout(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Send events
-	for i := 0; i < 10; i++ {
-		err := client.Enqueue(Capture{
-			DistinctId: "test-user",
-			Event:      "test-event",
-		})
-		require.NoError(t, err)
-	}
+	enqueueTestCaptures(t, client, 10)
 
 	// Close should abort after timeout
 	start := time.Now()
@@ -492,17 +475,7 @@ func TestShutdownTimeout_AbortsAfterTimeout(t *testing.T) {
 func TestCloseWithContext_RespectsDeadline(t *testing.T) {
 	t.Parallel()
 
-	var received atomic.Int64
-
-	// Create a slow server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(2 * time.Second)
-		var b batch
-		json.NewDecoder(r.Body).Decode(&b)
-		received.Add(int64(len(b.Messages)))
-		w.WriteHeader(200)
-	}))
-	defer server.Close()
+	server, _ := newSlowBatchServer(t, 2*time.Second)
 
 	// No ShutdownTimeout configured - will use context deadline instead
 	client, err := NewWithConfig("test-key", Config{
@@ -512,14 +485,7 @@ func TestCloseWithContext_RespectsDeadline(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Send events
-	for i := 0; i < 10; i++ {
-		err := client.Enqueue(Capture{
-			DistinctId: "test-user",
-			Event:      "test-event",
-		})
-		require.NoError(t, err)
-	}
+	enqueueTestCaptures(t, client, 10)
 
 	// Use CloseWithContext with a short deadline
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)

--- a/capture.go
+++ b/capture.go
@@ -121,31 +121,11 @@ func (msg Capture) internal() {
 
 // Validate checks that the capture message has a non-empty Event and DistinctId.
 func (msg Capture) Validate() error {
-	if err := validateCaptureEvent(msg); err != nil {
-		return err
-	}
-
-	if len(msg.DistinctId) == 0 {
-		return FieldError{
-			Type:  "posthog.Capture",
-			Name:  "DistinctId",
-			Value: msg.DistinctId,
-		}
-	}
-
-	return nil
+	return validateRequiredStringFields("posthog.Capture", requiredStringField{name: "Event", value: msg.Event}, requiredStringField{name: "DistinctId", value: msg.DistinctId})
 }
 
 func validateCaptureEvent(msg Capture) error {
-	if len(msg.Event) == 0 {
-		return FieldError{
-			Type:  "posthog.Capture",
-			Name:  "Event",
-			Value: msg.Event,
-		}
-	}
-
-	return nil
+	return validateRequiredStringFields("posthog.Capture", requiredStringField{name: "Event", value: msg.Event})
 }
 
 // CaptureInApi is the wire-format payload produced from a Capture message.

--- a/capture_local_eval_test.go
+++ b/capture_local_eval_test.go
@@ -199,107 +199,36 @@ func TestCaptureSendFeatureFlagsLocalEvaluation(t *testing.T) {
 }
 
 // TestCaptureSendFeatureFlagsFallsBackForStaticCohort verifies that a flag gated on
-// a static cohort — which can't be evaluated locally and returns
-// RequiresServerEvaluationError rather than InconclusiveMatchError — still triggers
-// the remote /flags fallback during capture enrichment, instead of erroring and
-// dropping enrichment for the whole event.
+// a static cohort still triggers the remote /flags fallback during capture enrichment.
 func TestCaptureSendFeatureFlagsFallsBackForStaticCohort(t *testing.T) {
 	t.Parallel()
-	var decideCalls atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
-			// Flag gated on cohort 999 with no cohort definitions, so it's a static
-			// cohort that requires server evaluation.
-			w.Write([]byte(`{
-				"flags": [
-					{
-						"id": 1,
-						"key": "static-cohort-flag",
-						"active": true,
-						"filters": {
-							"groups": [
-								{
-									"properties": [
-										{"key": "id", "value": 999, "type": "cohort"}
-									],
-									"rollout_percentage": 100
-								}
-							]
-						}
-					}
-				],
-				"cohorts": {}
-			}`))
-		case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
-			decideCalls.Add(1)
-			w.Write([]byte(`{"featureFlags": {"static-cohort-flag": true}}`))
-		case strings.HasPrefix(r.URL.Path, "/batch"):
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{}`))
-		default:
-			t.Errorf("unexpected request to %s", r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	client, capture, _ := newEvalClient(t, server, func(c *Config) {
-		c.PersonalApiKey = "personal-key"
-	})
-	waitForFlagDefinitions(t, client)
-
-	if err := client.Enqueue(Capture{
-		Event:            "test_event",
-		DistinctId:       "distinct-id",
-		SendFeatureFlags: SendFeatureFlags(true),
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	event := capture.waitForEvent(2 * time.Second)
-	if event == nil {
-		t.Fatal("timed out waiting for captured event")
-	}
-	if got := decideCalls.Load(); got != 1 {
-		t.Errorf("expected exactly 1 remote /flags fallback for the static cohort, got %d", got)
-	}
-	if event.Properties["$feature/static-cohort-flag"] != true {
-		t.Errorf("expected $feature/static-cohort-flag=true from remote fallback, got %v", event.Properties["$feature/static-cohort-flag"])
-	}
+	assertCaptureFeatureFlagFallback(t, `{
+		"flags": [{"id": 1, "key": "static-cohort-flag", "active": true, "filters": {"groups": [{"properties": [{"key": "id", "value": 999, "type": "cohort"}], "rollout_percentage": 100}]}}],
+		"cohorts": {}
+	}`, `{"featureFlags": {"static-cohort-flag": true}}`, "$feature/static-cohort-flag", true)
 }
 
 // TestCaptureSendFeatureFlagsFallsBackForGroupFlagWithoutGroups verifies that a
-// group-aggregated flag captured without the relevant group context — which
-// computeFlagLocally reports as a plain error (not Inconclusive/ServerEval) — still
-// defers to the remote /flags request rather than dropping enrichment for the event.
+// group-aggregated flag captured without the relevant group context defers to /flags.
 func TestCaptureSendFeatureFlagsFallsBackForGroupFlagWithoutGroups(t *testing.T) {
 	t.Parallel()
+	assertCaptureFeatureFlagFallback(t, `{
+		"flags": [{"id": 1, "key": "group-flag", "active": true, "filters": {"aggregation_group_type_index": 0, "groups": [{"properties": [], "rollout_percentage": 100}]}}],
+		"group_type_mapping": {"0": "company"},
+		"cohorts": {}
+	}`, `{"featureFlags": {"group-flag": "group-value"}}`, "$feature/group-flag", "group-value")
+}
+
+func assertCaptureFeatureFlagFallback(t *testing.T, definitions, flagsResponse, featureProperty string, want interface{}) {
+	t.Helper()
 	var decideCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
-			// Flag aggregated on the "company" group. The capture below passes no
-			// groups, so it can't be computed locally.
-			w.Write([]byte(`{
-				"flags": [
-					{
-						"id": 1,
-						"key": "group-flag",
-						"active": true,
-						"filters": {
-							"aggregation_group_type_index": 0,
-							"groups": [
-								{"properties": [], "rollout_percentage": 100}
-							]
-						}
-					}
-				],
-				"group_type_mapping": {"0": "company"},
-				"cohorts": {}
-			}`))
+			w.Write([]byte(definitions))
 		case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
 			decideCalls.Add(1)
-			w.Write([]byte(`{"featureFlags": {"group-flag": "group-value"}}`))
+			w.Write([]byte(flagsResponse))
 		case strings.HasPrefix(r.URL.Path, "/batch"):
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{}`))
@@ -309,27 +238,20 @@ func TestCaptureSendFeatureFlagsFallsBackForGroupFlagWithoutGroups(t *testing.T)
 	}))
 	defer server.Close()
 
-	client, capture, _ := newEvalClient(t, server, func(c *Config) {
-		c.PersonalApiKey = "personal-key"
-	})
+	client, capture, _ := newEvalClient(t, server, func(c *Config) { c.PersonalApiKey = "personal-key" })
 	waitForFlagDefinitions(t, client)
 
-	if err := client.Enqueue(Capture{
-		Event:            "test_event",
-		DistinctId:       "distinct-id",
-		SendFeatureFlags: SendFeatureFlags(true),
-	}); err != nil {
+	if err := client.Enqueue(Capture{Event: "test_event", DistinctId: "distinct-id", SendFeatureFlags: SendFeatureFlags(true)}); err != nil {
 		t.Fatal(err)
 	}
-
 	event := capture.waitForEvent(2 * time.Second)
 	if event == nil {
 		t.Fatal("timed out waiting for captured event")
 	}
 	if got := decideCalls.Load(); got != 1 {
-		t.Errorf("expected exactly 1 remote /flags fallback for the group flag, got %d", got)
+		t.Errorf("expected exactly 1 remote /flags fallback, got %d", got)
 	}
-	if event.Properties["$feature/group-flag"] != "group-value" {
-		t.Errorf("expected $feature/group-flag=group-value from remote fallback, got %v", event.Properties["$feature/group-flag"])
+	if event.Properties[featureProperty] != want {
+		t.Errorf("expected %s=%v from remote fallback, got %v", featureProperty, want, event.Properties[featureProperty])
 	}
 }

--- a/capture_local_eval_test.go
+++ b/capture_local_eval_test.go
@@ -236,7 +236,7 @@ func assertCaptureFeatureFlagFallback(t *testing.T, definitions, flagsResponse, 
 			t.Errorf("unexpected request to %s", r.URL.Path)
 		}
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client, capture, _ := newEvalClient(t, server, func(c *Config) { c.PersonalApiKey = "personal-key" })
 	waitForFlagDefinitions(t, client)

--- a/capture_test.go
+++ b/capture_test.go
@@ -1,96 +1,23 @@
 package posthog
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestCaptureMissingEvent(t *testing.T) {
-	capture := Capture{
-		DistinctId: "1",
-	}
-
-	if err := capture.Validate(); err == nil {
-		t.Error("validating an invalid capture object succeeded:", capture)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating capture:", err)
-
-	} else if e != (FieldError{
-		Type:  "posthog.Capture",
-		Name:  "Event",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating capture:", err)
-	}
+	assertFieldError(t, Capture{DistinctId: "1"}, fieldError("posthog.Capture", "Event"))
 }
 
 func TestCaptureMissingDistinctId(t *testing.T) {
-	capture := Capture{
-		Event: "1",
-	}
-
-	if err := capture.Validate(); err == nil {
-		t.Error("validating an invalid capture object succeeded:", capture)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating capture:", err)
-
-	} else if e != (FieldError{
-		Type:  "posthog.Capture",
-		Name:  "DistinctId",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating capture:", err)
-	}
+	assertFieldError(t, Capture{Event: "1"}, fieldError("posthog.Capture", "DistinctId"))
 }
 
 func TestCaptureValidWithDistinctId(t *testing.T) {
-	capture := Capture{
-		Event:      "1",
-		DistinctId: "2",
-	}
-
-	if err := capture.Validate(); err != nil {
-		t.Error("validating a valid capture object failed:", capture, err)
-	}
+	assertValid(t, Capture{Event: "1", DistinctId: "2"})
 }
 
 func TestCaptureAPIfyIncludesIsServerProperty(t *testing.T) {
-	capture := Capture{
-		Event:      "test-event",
-		DistinctId: "user-123",
-		IsServer:   true,
-	}
-
-	apiMsg, ok := capture.APIfy().(CaptureInApi)
-	if !ok {
-		t.Fatalf("expected CaptureInApi, got %T", capture.APIfy())
-	}
-
-	expectKeys := map[string]interface{}{
-		"$lib":       SDKName,
-		"$is_server": true,
-	}
-	for k, want := range expectKeys {
-		if got := apiMsg.Properties[k]; got != want {
-			t.Errorf("property %q: expected %v (%T), got %v (%T)", k, want, want, got, got)
-		}
-	}
+	assertIsServerProperty(t, Capture{Event: "test-event", DistinctId: "user-123", IsServer: true}.APIfy(), true)
 }
 
 func TestCaptureAPIfyOmitsIsServerWhenFalse(t *testing.T) {
-	capture := Capture{
-		Event:      "test-event",
-		DistinctId: "user-123",
-		IsServer:   false,
-	}
-
-	apiMsg, ok := capture.APIfy().(CaptureInApi)
-	if !ok {
-		t.Fatalf("expected CaptureInApi, got %T", capture.APIfy())
-	}
-
-	if _, present := apiMsg.Properties["$is_server"]; present {
-		t.Errorf("$is_server should be absent when IsServer is false, got %v", apiMsg.Properties["$is_server"])
-	}
+	assertIsServerProperty(t, Capture{Event: "test-event", DistinctId: "user-123", IsServer: false}.APIfy(), false)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -87,30 +87,33 @@ func TestConfigInvalidBatchSize(t *testing.T) {
 	}
 }
 
-func TestConfigGetDisableGeoIP(t *testing.T) {
-	var (
-		c  Config
-		tv = true
-		fv = false
-	)
-	require.True(t, c.GetDisableGeoIP())
-	c.DisableGeoIP = &tv
-	require.True(t, c.GetDisableGeoIP())
-	c.DisableGeoIP = &fv
-	require.False(t, c.GetDisableGeoIP())
+func TestConfigBoolDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*Config, *bool)
+		get  func(Config) bool
+	}{
+		{"DisableGeoIP", func(c *Config, value *bool) { c.DisableGeoIP = value }, func(c Config) bool { return c.GetDisableGeoIP() }},
+		{"IsServer", func(c *Config, value *bool) { c.IsServer = value }, func(c Config) bool { return c.GetIsServer() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConfigBoolDefaultTrue(t, tt.set, tt.get)
+		})
+	}
 }
 
-func TestConfigGetIsServer(t *testing.T) {
-	var (
-		c  Config
-		tv = true
-		fv = false
-	)
-	require.True(t, c.GetIsServer())
-	c.IsServer = &tv
-	require.True(t, c.GetIsServer())
-	c.IsServer = &fv
-	require.False(t, c.GetIsServer())
+func assertConfigBoolDefaultTrue(t *testing.T, set func(*Config, *bool), get func(Config) bool) {
+	t.Helper()
+	var c Config
+	tv := true
+	fv := false
+	require.True(t, get(c))
+	set(&c, &tv)
+	require.True(t, get(c))
+	set(&c, &fv)
+	require.False(t, get(c))
 }
 
 func TestConfigCompression(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -43,6 +43,24 @@ func (e FieldError) Error() string {
 	return fmt.Sprintf("%s.%s: invalid field value: %#v", e.Type, e.Name, e.Value)
 }
 
+type requiredStringField struct {
+	name  string
+	value string
+}
+
+func validateRequiredStringFields(typeName string, fields ...requiredStringField) error {
+	for _, field := range fields {
+		if field.value == "" {
+			return FieldError{
+				Type:  typeName,
+				Name:  field.name,
+				Value: field.value,
+			}
+		}
+	}
+	return nil
+}
+
 var (
 	// This error is returned by methods of the `Client` interface when they are
 	// called after the client was already closed.

--- a/error_test.go
+++ b/error_test.go
@@ -2,26 +2,37 @@ package posthog
 
 import "testing"
 
-func TestConfigError(t *testing.T) {
-	e := ConfigError{
-		Reason: "testing",
-		Field:  "Answer",
-		Value:  42,
+func TestErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "config",
+			err: ConfigError{
+				Reason: "testing",
+				Field:  "Answer",
+				Value:  42,
+			},
+			want: "posthog.NewWithConfig: testing (posthog.Config.Answer: 42)",
+		},
+		{
+			name: "field",
+			err: FieldError{
+				Type:  "testing.T",
+				Name:  "Answer",
+				Value: 42,
+			},
+			want: "testing.T.Answer: invalid field value: 42",
+		},
 	}
 
-	if s := e.Error(); s != "posthog.NewWithConfig: testing (posthog.Config.Answer: 42)" {
-		t.Error("invalid error message returned by config error:", s)
-	}
-}
-
-func TestFieldError(t *testing.T) {
-	e := FieldError{
-		Type:  "testing.T",
-		Name:  "Answer",
-		Value: 42,
-	}
-
-	if s := e.Error(); s != "testing.T.Answer: invalid field value: 42" {
-		t.Error("invalid error message returned by field error:", s)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Error("invalid error message returned:", got)
+			}
+		})
 	}
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -96,45 +96,39 @@ func showMenu() {
 }
 
 func runBasicCaptureExamples() {
-	fmt.Println("\n" + strings.Repeat("=", 60))
-	fmt.Println("BASIC CAPTURE EXAMPLES")
-	fmt.Println(strings.Repeat("=", 60))
+	printExampleSection("BASIC CAPTURE EXAMPLES")
 	TestCapture(projectAPIKey, endpoint)
 }
 
 func runCaptureWithFeatureFlagsExamples() {
-	fmt.Println("\n" + strings.Repeat("=", 60))
-	fmt.Println("CAPTURE WITH FEATURE FLAGS EXAMPLES")
-	fmt.Println(strings.Repeat("=", 60))
+	printExampleSection("CAPTURE WITH FEATURE FLAGS EXAMPLES")
 	TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoint)
 }
 
 func runFeatureFlagEvaluationExamples() {
-	fmt.Println("\n" + strings.Repeat("=", 60))
-	fmt.Println("FEATURE FLAG EVALUATION EXAMPLES")
-	fmt.Println(strings.Repeat("=", 60))
+	printExampleSection("FEATURE FLAG EVALUATION EXAMPLES")
 	TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint)
 }
 
 func runAdvancedFeatureFlagsExamples() {
-	fmt.Println("\n" + strings.Repeat("=", 60))
-	fmt.Println("ADVANCED FEATURE FLAGS (SendFeatureFlagsOptions) EXAMPLES")
-	fmt.Println(strings.Repeat("=", 60))
+	printExampleSection("ADVANCED FEATURE FLAGS (SendFeatureFlagsOptions) EXAMPLES")
 	TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpoint)
 }
 
 func runFlagDependenciesExamples() {
-	fmt.Println("\n" + strings.Repeat("=", 60))
-	fmt.Println("FLAG DEPENDENCIES EXAMPLES")
-	fmt.Println(strings.Repeat("=", 60))
+	printExampleSection("FLAG DEPENDENCIES EXAMPLES")
 	TestFlagDependencies(projectAPIKey, personalAPIKey, endpoint)
 }
 
 func runETagPollingExample() {
-	fmt.Println("\n" + strings.Repeat("=", 60))
-	fmt.Println("ETAG POLLING TEST")
-	fmt.Println(strings.Repeat("=", 60))
+	printExampleSection("ETAG POLLING TEST")
 	TestETagPolling(projectAPIKey, personalAPIKey, endpoint)
+}
+
+func printExampleSection(title string) {
+	fmt.Println("\n" + strings.Repeat("=", 60))
+	fmt.Println(title)
+	fmt.Println(strings.Repeat("=", 60))
 }
 
 func runAllExamples() {

--- a/extras/test_helpers.go
+++ b/extras/test_helpers.go
@@ -58,8 +58,11 @@ func (c *testCallback) Failure(msg posthog.APIMessage, err error) {
 	c.failureChan <- err
 }
 
-func (c *testCallback) GetCounts() (success, failure int) {
+func (c *testCallback) GetCounts() (success, failure int) { return c.counts() }
+
+func (c *testCallback) counts() (success, failure int) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.successCount, c.failureCount
+	success, failure = c.successCount, c.failureCount
+	c.mu.Unlock()
+	return success, failure
 }

--- a/feature_flag_config.go
+++ b/feature_flag_config.go
@@ -35,11 +35,15 @@ func (c *FeatureFlagPayload) validate() error {
 		}
 	}
 
-	if len(c.DistinctId) == 0 {
+	return validateFeatureFlagBase(c.DistinctId, &c.SendFeatureFlagEvents)
+}
+
+func validateFeatureFlagBase(distinctId string, sendFeatureFlagEvents **bool) error {
+	if len(distinctId) == 0 {
 		return ConfigError{
 			Reason: "DistinctId required",
 			Field:  "Distinct Id",
-			Value:  c.DistinctId,
+			Value:  distinctId,
 		}
 	}
 
@@ -48,8 +52,8 @@ func (c *FeatureFlagPayload) validate() error {
 	// The remote fallback path in makeFlagsRequest handles nil→empty conversion
 	// before JSON marshaling.
 
-	if c.SendFeatureFlagEvents == nil {
-		c.SendFeatureFlagEvents = &trueVal
+	if *sendFeatureFlagEvents == nil {
+		*sendFeatureFlagEvents = &trueVal
 	}
 	return nil
 }
@@ -75,21 +79,5 @@ type FeatureFlagPayloadNoKey struct {
 }
 
 func (c *FeatureFlagPayloadNoKey) validate() error {
-	if len(c.DistinctId) == 0 {
-		return ConfigError{
-			Reason: "DistinctId required",
-			Field:  "Distinct Id",
-			Value:  c.DistinctId,
-		}
-	}
-
-	// Groups, PersonProperties, and GroupProperties are intentionally left nil.
-	// Nil maps work correctly for local evaluation (nil map reads return zero values).
-	// The remote fallback path in makeFlagsRequest handles nil→empty conversion
-	// before JSON marshaling.
-
-	if c.SendFeatureFlagEvents == nil {
-		c.SendFeatureFlagEvents = &trueVal
-	}
-	return nil
+	return validateFeatureFlagBase(c.DistinctId, &c.SendFeatureFlagEvents)
 }

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -140,6 +140,24 @@ func waitForEventCount(capture *eventCapture, want int, timeout time.Duration) [
 	return out
 }
 
+func snapshotCapturedEvents(capture *eventCapture) []CaptureInApi {
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	out := make([]CaptureInApi, len(capture.events))
+	copy(out, capture.events)
+	return out
+}
+
+func countFlagCalledEvents(events []CaptureInApi, flagKey string) int {
+	count := 0
+	for _, ev := range events {
+		if ev.Event == "$feature_flag_called" && ev.Properties["$feature_flag"] == flagKey {
+			count++
+		}
+	}
+	return count
+}
+
 func findEvent(events []CaptureInApi, eventName, flagKey string) *CaptureInApi {
 	for i := range events {
 		if events[i].Event != eventName {
@@ -704,16 +722,11 @@ func TestRefactor_LegacyAndSnapshotPathsDedupeIdentically(t *testing.T) {
 	snap, _ := client.EvaluateFlags(EvaluateFlagsPayload{DistinctId: "user-1"})
 	snap.IsEnabled("enabled-flag")
 
+	_ = waitForEventCount(capture, 1, 5*time.Second)
 	time.Sleep(150 * time.Millisecond)
+	events := snapshotCapturedEvents(capture)
 
-	capture.mu.Lock()
-	defer capture.mu.Unlock()
-	count := 0
-	for _, ev := range capture.events {
-		if ev.Event == "$feature_flag_called" && ev.Properties["$feature_flag"] == "enabled-flag" {
-			count++
-		}
-	}
+	count := countFlagCalledEvents(events, "enabled-flag")
 	if count != 1 {
 		t.Errorf("expected exactly 1 deduped $feature_flag_called event, got %d", count)
 	}

--- a/feature_flags_cohorts_test.go
+++ b/feature_flags_cohorts_test.go
@@ -1,94 +1,55 @@
 package posthog
 
-import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-)
+import "testing"
 
 func TestComplexCohortsLocally(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(fixture("feature_flag/test-complex-cohorts-locally.json"))) // Don't return anything for local eval
-	}))
-	defer server.Close()
+	client := newCohortTestClient(t, "feature_flag/test-complex-cohorts-locally.json")
+	payload := cohortPayload(NewProperties().Set("region", "UK"))
 
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	payload := FeatureFlagPayload{
-		Key:              "beta-feature",
-		DistinctId:       "some-distinct-id",
-		PersonProperties: NewProperties().Set("region", "UK"),
-	}
-
-	isMatch, err := client.IsFeatureEnabled(payload)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if isMatch != false {
-		t.Error("Should not match")
-	}
-
+	assertFeatureEnabled(t, client, payload, false)
 	payload.PersonProperties = NewProperties().Set("region", "USA").Set("other", "thing")
-	isMatch, _ = client.IsFeatureEnabled(payload)
-	if isMatch != true {
-		t.Error("Should match")
-	}
+	assertFeatureEnabled(t, client, payload, true)
 
 	// even though 'other' property is not present, the cohort should still match since it's an OR condition
 	payload.PersonProperties = NewProperties().Set("region", "USA").Set("nation", "UK")
-	isMatch, _ = client.IsFeatureEnabled(payload)
-	if isMatch != true {
-		t.Error("Should match")
-	}
+	assertFeatureEnabled(t, client, payload, true)
 }
 
 func TestComplexCohortsWithNegationLocally(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(fixture("feature_flag/test-complex-cohorts-negation-locally.json"))) // Don't return anything for local eval
-	}))
-	defer server.Close()
+	client := newCohortTestClient(t, "feature_flag/test-complex-cohorts-negation-locally.json")
+	payload := cohortPayload(NewProperties().Set("region", "UK"))
 
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	payload := FeatureFlagPayload{
-		Key:              "beta-feature",
-		DistinctId:       "some-distinct-id",
-		PersonProperties: NewProperties().Set("region", "UK"),
-	}
-
-	isMatch, err := client.IsFeatureEnabled(payload)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if isMatch != false {
-		t.Error("Should not match")
-	}
+	assertFeatureEnabled(t, client, payload, false)
 
 	// even though 'other' property is not present, the cohort should still match since it's an OR condition
 	payload.PersonProperties = NewProperties().Set("region", "USA").Set("nation", "UK")
-	isMatch, _ = client.IsFeatureEnabled(payload)
-	if isMatch != true {
-		t.Error("Should match")
-	}
+	assertFeatureEnabled(t, client, payload, true)
 
 	// # since 'other' is negated, we return False. Since 'nation' is not present, we can't tell whether the flag should be true or false, so go to decide
 	payload.PersonProperties = NewProperties().Set("region", "USA").Set("other", "thing")
-	_, err = client.IsFeatureEnabled(payload)
-	if err != nil {
+	if _, err := client.IsFeatureEnabled(payload); err != nil {
 		t.Error("Expected to fail")
 	}
 
 	payload.PersonProperties = NewProperties().Set("region", "USA").Set("other", "thing2")
-	isMatch, _ = client.IsFeatureEnabled(payload)
-	if isMatch != true {
-		t.Error("Should match")
+	assertFeatureEnabled(t, client, payload, true)
+}
+
+func newCohortTestClient(t *testing.T, fixtureName string) Client {
+	return newFeatureFlagsFixtureClient(t, fixtureName)
+}
+
+func cohortPayload(properties Properties) FeatureFlagPayload {
+	return FeatureFlagPayload{Key: "beta-feature", DistinctId: "some-distinct-id", PersonProperties: properties}
+}
+
+func assertFeatureEnabled(t *testing.T, client Client, payload FeatureFlagPayload, want bool) {
+	t.Helper()
+	isMatch, err := client.IsFeatureEnabled(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isMatch != want {
+		t.Errorf("IsFeatureEnabled = %v, want %v", isMatch, want)
 	}
 }

--- a/feature_flags_dependencies_test.go
+++ b/feature_flags_dependencies_test.go
@@ -9,6 +9,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newFlagDependencyClient(t *testing.T, definitions string, remoteFallback bool) Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
+			w.Write([]byte(definitions))
+		} else if remoteFallback && strings.HasPrefix(r.URL.Path, "/flags/") {
+			w.Write([]byte(`{"featureFlags": {}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewWithConfig("test-api-key", Config{PersonalApiKey: "test-personal-api-key", Endpoint: server.URL})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func assertDependencyFlag(t *testing.T, client Client, key string, want bool) {
+	t.Helper()
+	result, err := client.IsFeatureEnabled(FeatureFlagPayload{Key: key, DistinctId: "test-user"})
+	require.NoError(t, err)
+	require.Equal(t, want, result)
+}
+
+const missingFlagDependencyDefinitions = `{
+	"flags": [{"id": 1, "name": "Flag A", "key": "flag-a", "active": true, "filters": {"groups": [{"properties": [{"key": "non-existent-flag", "operator": "flag_evaluates_to", "value": true, "type": "flag", "dependency_chain": ["non-existent-flag"]}], "rollout_percentage": 100}]}}],
+	"group_type_mapping": {}
+}`
+
+const mixedConditionsDependencyDefinitions = `{
+	"flags": [
+		{"id": 1, "name": "Base Flag", "key": "base-flag", "active": true, "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+		{"id": 2, "name": "Mixed Flag", "key": "mixed-flag", "active": true, "filters": {"groups": [{"properties": [{"key": "base-flag", "operator": "flag_evaluates_to", "value": true, "type": "flag", "dependency_chain": ["base-flag"]}, {"key": "email", "operator": "icontains", "value": "@example.com", "type": "person"}], "rollout_percentage": 100}]}}
+	],
+	"group_type_mapping": {}
+}`
+
+func assertLocalDependencyFlag(t *testing.T, client Client, key, distinctID, email string, want bool) {
+	t.Helper()
+	result, err := client.IsFeatureEnabled(FeatureFlagPayload{
+		Key:                 key,
+		DistinctId:          distinctID,
+		PersonProperties:    NewProperties().Set("email", email),
+		OnlyEvaluateLocally: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, result)
+}
+
+const malformedFlagDependencyDefinitions = `{
+	"flags": [
+		{"id": 1, "name": "Base Flag", "key": "base-flag", "active": true, "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+		{"id": 2, "name": "Missing Chain Flag", "key": "missing-chain-flag", "active": true, "filters": {"groups": [{"properties": [{"key": "base-flag", "operator": "flag_evaluates_to", "value": true, "type": "flag"}], "rollout_percentage": 100}]}}
+	],
+	"group_type_mapping": {}
+}`
+
 func TestFlagDependenciesSimpleChain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
@@ -192,56 +249,7 @@ func TestFlagDependenciesCircularDependency(t *testing.T) {
 }
 
 func TestFlagDependenciesMissingFlag(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(`{
-				"flags": [
-					{
-						"id": 1,
-						"name": "Flag A",
-						"key": "flag-a",
-						"active": true,
-						"filters": {
-							"groups": [
-								{
-									"properties": [
-										{
-											"key": "non-existent-flag",
-											"operator": "flag_evaluates_to",
-											"value": true,
-											"type": "flag",
-											"dependency_chain": ["non-existent-flag"]
-										}
-									],
-									"rollout_percentage": 100
-								}
-							]
-						}
-					}
-				],
-				"group_type_mapping": {}
-			}`))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/") {
-			w.Write([]byte(`{"featureFlags": {}}`))
-		}
-	}))
-	defer server.Close()
-
-	client, _ := NewWithConfig("test-api-key", Config{
-		PersonalApiKey: "test-personal-api-key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	// Should fall back to remote evaluation because dependency doesn't exist
-	result, err := client.IsFeatureEnabled(
-		FeatureFlagPayload{
-			Key:        "flag-a",
-			DistinctId: "test-user",
-		},
-	)
-	require.NoError(t, err)
-	require.Equal(t, false, result)
+	assertDependencyFlag(t, newFlagDependencyClient(t, missingFlagDependencyDefinitions, true), "flag-a", false)
 }
 
 func TestFlagDependenciesComplexChain(t *testing.T) {
@@ -354,158 +362,19 @@ func TestFlagDependenciesComplexChain(t *testing.T) {
 }
 
 func TestFlagDependenciesMixedConditions(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(`{
-				"flags": [
-					{
-						"id": 1,
-						"name": "Base Flag",
-						"key": "base-flag",
-						"active": true,
-						"filters": {
-							"groups": [
-								{
-									"properties": [],
-									"rollout_percentage": 100
-								}
-							]
-						}
-					},
-					{
-						"id": 2,
-						"name": "Mixed Flag",
-						"key": "mixed-flag",
-						"active": true,
-						"filters": {
-							"groups": [
-								{
-									"properties": [
-										{
-											"key": "base-flag",
-											"operator": "flag_evaluates_to",
-											"value": true,
-											"type": "flag",
-											"dependency_chain": ["base-flag"]
-										},
-										{
-											"key": "email",
-											"operator": "icontains",
-											"value": "@example.com",
-											"type": "person"
-										}
-									],
-									"rollout_percentage": 100
-								}
-							]
-						}
-					}
-				],
-				"group_type_mapping": {}
-			}`))
-		}
-	}))
-	defer server.Close()
-
-	client, _ := NewWithConfig("test-api-key", Config{
-		PersonalApiKey: "test-personal-api-key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
+	client := newFlagDependencyClient(t, mixedConditionsDependencyDefinitions, false)
 
 	// Both flag dependency and email condition satisfied
-	result, err := client.IsFeatureEnabled(
-		FeatureFlagPayload{
-			Key:                 "mixed-flag",
-			DistinctId:          "test-user",
-			PersonProperties:    NewProperties().Set("email", "test@example.com"),
-			OnlyEvaluateLocally: true,
-		},
-	)
-	require.NoError(t, err)
-	require.Equal(t, true, result)
+	assertLocalDependencyFlag(t, client, "mixed-flag", "test-user", "test@example.com", true)
 
 	// Flag dependency satisfied but email condition not satisfied
-	result, err = client.IsFeatureEnabled(
-		FeatureFlagPayload{
-			Key:                 "mixed-flag",
-			DistinctId:          "test-user-2",
-			PersonProperties:    NewProperties().Set("email", "test@other.com"),
-			OnlyEvaluateLocally: true,
-		},
-	)
-	require.NoError(t, err)
-	require.Equal(t, false, result)
+	assertLocalDependencyFlag(t, client, "mixed-flag", "test-user-2", "test@other.com", false)
 }
 
 func TestFlagDependenciesMalformedChain(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(`{
-				"flags": [
-					{
-						"id": 1,
-						"name": "Base Flag",
-						"key": "base-flag",
-						"active": true,
-						"filters": {
-							"groups": [
-								{
-									"properties": [],
-									"rollout_percentage": 100
-								}
-							]
-						}
-					},
-					{
-						"id": 2,
-						"name": "Missing Chain Flag",
-						"key": "missing-chain-flag",
-						"active": true,
-						"filters": {
-							"groups": [
-								{
-									"properties": [
-										{
-											"key": "base-flag",
-											"operator": "flag_evaluates_to",
-											"value": true,
-											"type": "flag"
-										}
-									],
-									"rollout_percentage": 100
-								}
-							]
-						}
-					}
-				],
-				"group_type_mapping": {}
-			}`))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/") {
-			w.Write([]byte(`{"featureFlags": {}}`))
-		}
-	}))
-	defer server.Close()
-
-	client, _ := NewWithConfig("test-api-key", Config{
-		PersonalApiKey: "test-personal-api-key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	// Should fall back to remote evaluation when dependency_chain is missing
-	result, err := client.IsFeatureEnabled(
-		FeatureFlagPayload{
-			Key:        "missing-chain-flag",
-			DistinctId: "test-user",
-		},
-	)
-	require.NoError(t, err)
-	require.Equal(t, false, result)
+	assertDependencyFlag(t, newFlagDependencyClient(t, malformedFlagDependencyDefinitions, true), "missing-chain-flag", false)
 }
 
-// TestMultiLevelMultivariateDependencyChain tests multi-level dependency chains with multivariate flags
-// This test is equivalent to the EvaluatesMultiLevelMultivariateDependencyChain test in the .NET SDK
 func TestMultiLevelMultivariateDependencyChain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/flags/definitions") {

--- a/feature_flags_flags_test.go
+++ b/feature_flags_flags_test.go
@@ -37,6 +37,9 @@ func (e *eventCapture) getLastEvent() *CaptureInApi {
 }
 
 func (e *eventCapture) waitForEvent(timeout time.Duration) *CaptureInApi {
+	if timeout < 5*time.Second {
+		timeout = 5 * time.Second
+	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if event := e.getLastEvent(); event != nil {

--- a/feature_flags_flags_test.go
+++ b/feature_flags_flags_test.go
@@ -37,9 +37,6 @@ func (e *eventCapture) getLastEvent() *CaptureInApi {
 }
 
 func (e *eventCapture) waitForEvent(timeout time.Duration) *CaptureInApi {
-	if timeout < 5*time.Second {
-		timeout = 5 * time.Second
-	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if event := e.getLastEvent(); event != nil {
@@ -124,7 +121,7 @@ func TestFlags(t *testing.T) {
 						t.Errorf("Expected IsFeatureEnabled to return %v but was %v", subTest.expected, isMatch)
 					}
 
-					event := capture.waitForEvent(time.Second)
+					event := capture.waitForEvent(5 * time.Second)
 					validateCapturedEvent(t, event)
 				})
 			}
@@ -164,7 +161,7 @@ func TestFlags(t *testing.T) {
 						t.Errorf("Expected GetFeatureFlag to return %v but was %v", subTest.expected, flag)
 					}
 
-					event := capture.waitForEvent(time.Second)
+					event := capture.waitForEvent(5 * time.Second)
 					validateCapturedEvent(t, event)
 				})
 			}
@@ -204,7 +201,7 @@ func TestFlags(t *testing.T) {
 						t.Errorf("Expected GetFeatureFlagPayload to return %v but was %v", subTest.expected, payload)
 					}
 
-					event := capture.waitForEvent(time.Second)
+					event := capture.waitForEvent(5 * time.Second)
 					validateCapturedEvent(t, event)
 				})
 			}
@@ -237,7 +234,7 @@ func TestFeatureFlagCalledIncludesDeviceId(t *testing.T) {
 		},
 	)
 
-	event := capture.waitForEvent(time.Second)
+	event := capture.waitForEvent(5 * time.Second)
 	if event == nil {
 		t.Fatal("Expected a $feature_flag_called event, got nil")
 	}
@@ -268,7 +265,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 			DistinctId: "user-123",
 		})
 
-		event := capture.waitForEvent(time.Second)
+		event := capture.waitForEvent(5 * time.Second)
 		if event == nil {
 			t.Fatal("Expected a captured event")
 		}
@@ -298,7 +295,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 			DistinctId: "user-123",
 		})
 
-		event := capture.waitForEvent(time.Second)
+		event := capture.waitForEvent(5 * time.Second)
 		if event == nil {
 			t.Fatal("Expected a captured event")
 		}
@@ -327,7 +324,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 			DistinctId: "user-123",
 		})
 
-		event := capture.waitForEvent(time.Second)
+		event := capture.waitForEvent(5 * time.Second)
 		if event == nil {
 			t.Fatal("Expected a captured event")
 		}
@@ -357,7 +354,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 			DistinctId: "user-123",
 		})
 
-		event := capture.waitForEvent(time.Second)
+		event := capture.waitForEvent(5 * time.Second)
 		if event == nil {
 			t.Fatal("Expected a captured event")
 		}
@@ -386,7 +383,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 			DistinctId: "user-123",
 		})
 
-		event := capture.waitForEvent(time.Second)
+		event := capture.waitForEvent(5 * time.Second)
 		if event == nil {
 			t.Fatal("Expected a captured event")
 		}
@@ -415,7 +412,7 @@ func TestFeatureFlagErrorOnCapturedEvents(t *testing.T) {
 			DistinctId: "user-123",
 		})
 
-		event := capture.waitForEvent(time.Second)
+		event := capture.waitForEvent(5 * time.Second)
 		if event == nil {
 			t.Fatal("Expected a captured event")
 		}
@@ -475,7 +472,7 @@ func TestFlagsV4(t *testing.T) {
 				t.Errorf("Expected GetFeatureFlag(%s) to return %v but was %v", test.flagKey, test.expected, flag)
 			}
 
-			capturedEvent := capture.waitForEvent(time.Second)
+			capturedEvent := capture.waitForEvent(5 * time.Second)
 			if capturedEvent == nil {
 				t.Fatalf("Expected a $feature_flag_called for %s event, got nil", test.flagKey)
 			}
@@ -597,7 +594,7 @@ func TestGetFeatureFlagResult(t *testing.T) {
 			}
 
 			// Verify $feature_flag_called event was emitted
-			event := capture.waitForEvent(time.Second)
+			event := capture.waitForEvent(5 * time.Second)
 			if event == nil {
 				t.Fatal("Expected a $feature_flag_called event")
 			}
@@ -650,7 +647,7 @@ func TestGetFeatureFlagResult(t *testing.T) {
 			}
 
 			// Verify $feature_flag_called event was emitted
-			event := capture.waitForEvent(time.Second)
+			event := capture.waitForEvent(5 * time.Second)
 			if event == nil {
 				t.Fatal("Expected a $feature_flag_called event")
 			}
@@ -687,7 +684,7 @@ func TestGetFeatureFlagResult(t *testing.T) {
 			}
 
 			// Verify $feature_flag_called event was emitted
-			event := capture.waitForEvent(time.Second)
+			event := capture.waitForEvent(5 * time.Second)
 			if event == nil {
 				t.Fatal("Expected a $feature_flag_called event")
 			}
@@ -718,7 +715,7 @@ func TestGetFeatureFlagResult(t *testing.T) {
 			}
 
 			// Verify $feature_flag_called event was emitted with error
-			event := capture.waitForEvent(time.Second)
+			event := capture.waitForEvent(5 * time.Second)
 			if event == nil {
 				t.Fatal("Expected a $feature_flag_called event")
 			}

--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -20,6 +20,39 @@ import (
 
 // Note: Property matching tests (TestMatchProperty*) have been moved to feature_flags_matching_test.go
 
+func newFeatureFlagsFixtureClient(t *testing.T, fixtureName string) Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fixture(fixtureName)))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{PersonalApiKey: "some very secret key", Endpoint: server.URL})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func newFeatureFlagsLocalClient(t *testing.T, definitionsFixture string) Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
+			w.Write([]byte(fixture("test-flags-v3.json")))
+		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
+			w.Write([]byte(fixture(definitionsFixture)))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
+		PersonalApiKey: "some very secret key",
+		Endpoint:       server.URL,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
 func TestFlagPersonProperty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
@@ -434,21 +467,7 @@ func TestFeatureFlagNullComeIntoPlayOnlyWhenFlagsErrorsOut(t *testing.T) {
 }
 
 func TestExperienceContinuityOverride(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-simple-flag.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
+	client := newFeatureFlagsLocalClient(t, "feature_flag/test-simple-flag.json")
 
 	featureVariant, _ := client.GetFeatureFlag(
 		FeatureFlagPayload{
@@ -528,29 +547,7 @@ func TestGetAllFlagsEmptyLocal(t *testing.T) {
 }
 
 func TestGetAllFlagsNoRemoteFallback(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-multiple-flags-valid.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	featureVariants, _ := client.GetAllFlags(FeatureFlagPayloadNoKey{
-		DistinctId: "distinct-id",
-	})
-
-	if featureVariants["beta-feature"] != true || featureVariants["disabled-feature"] != false {
-		t.Error("Should match")
-	}
+	assertAllFlags(t, newFeatureFlagsLocalClient(t, "feature_flag/test-multiple-flags-valid.json"), FeatureFlagPayloadNoKey{DistinctId: "distinct-id"}, map[string]interface{}{"beta-feature": true, "disabled-feature": false})
 }
 
 func TestGetAllFlagsOnlyLocalEvaluationSet(t *testing.T) {
@@ -581,53 +578,9 @@ func TestGetAllFlagsOnlyLocalEvaluationSet(t *testing.T) {
 }
 
 func TestComputeInactiveFlagsLocally(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-compute-inactive-flags-locally.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	featureVariants, _ := client.GetAllFlags(FeatureFlagPayloadNoKey{
-		DistinctId: "distinct-id",
-	})
-
-	if featureVariants["beta-feature"] != true || featureVariants["disabled-feature"] != false {
-		t.Error("Should match")
-	}
-
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-compute-inactive-flags-locally-2.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ = NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	featureVariants, _ = client.GetAllFlags(FeatureFlagPayloadNoKey{
-		DistinctId: "distinct-id",
-	})
-
-	if featureVariants["beta-feature"] != false || featureVariants["disabled-feature"] != true {
-		t.Error("Should match")
-	}
+	payload := FeatureFlagPayloadNoKey{DistinctId: "distinct-id"}
+	assertAllFlags(t, newFeatureFlagsLocalClient(t, "feature_flag/test-compute-inactive-flags-locally.json"), payload, map[string]interface{}{"beta-feature": true, "disabled-feature": false})
+	assertAllFlags(t, newFeatureFlagsLocalClient(t, "feature_flag/test-compute-inactive-flags-locally-2.json"), payload, map[string]interface{}{"beta-feature": false, "disabled-feature": true})
 }
 
 func TestFeatureFlagWithDependencies(t *testing.T) {
@@ -678,26 +631,7 @@ func TestFeatureFlagWithDependencies(t *testing.T) {
 }
 
 func TestFeatureEnabledSimpleIsTrueWhenRolloutUndefined(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(fixture("feature_flag/test-simple-flag-without-rollout.json")))
-	}))
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	isMatch, _ := client.IsFeatureEnabled(
-		FeatureFlagPayload{
-			Key:        "simple-flag",
-			DistinctId: "distinct-id",
-		},
-	)
-	if isMatch != true {
-		t.Error("Should be enabled")
-	}
+	assertFeatureEnabled(t, newFeatureFlagsFixtureClient(t, "feature_flag/test-simple-flag-without-rollout.json"), FeatureFlagPayload{Key: "simple-flag", DistinctId: "distinct-id"}, true)
 }
 
 func TestGetFeatureFlag(t *testing.T) {
@@ -840,32 +774,7 @@ func TestGetFeatureFlagLocallyEvaluated(t *testing.T) {
 }
 
 func TestGetFeatureFlagPayload(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	variant, _ := client.GetFeatureFlagPayload(
-		FeatureFlagPayload{
-			Key:        "test-get-feature",
-			DistinctId: "distinct_id",
-		},
-	)
-
-	if variant != "this is a string" {
-		t.Error("Should match")
-	}
+	assertFeatureFlagPayload(t, newFeatureFlagsLocalClient(t, "feature_flag/test-simple-flag-person-prop.json"), FeatureFlagPayload{Key: "test-get-feature", DistinctId: "distinct_id"}, "this is a string")
 }
 
 func TestGetRemoteConfigPayload(t *testing.T) {
@@ -894,198 +803,71 @@ func TestGetRemoteConfigPayload(t *testing.T) {
 	}
 }
 
-func TestFlagWithVariantOverrides(t *testing.T) {
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-variant-override.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	variant, _ := client.GetFeatureFlag(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "test_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if variant != "second-variant" {
-		t.Error("Should match", variant, "second-variant")
+func TestFlagVariantOverrides(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		checks  []variantPayloadCheck
+	}{
+		{"valid", "feature_flag/test-variant-override.json", []variantPayloadCheck{{"test_id", "test@posthog.com", "second-variant", "{\"test\": 2}"}, {"example_id", "", "first-variant", "{\"test\": 1}"}}},
+		{"clashing", "feature_flag/test-variant-override-clashing.json", []variantPayloadCheck{{"test_id", "test@posthog.com", "second-variant", "{\"test\": 2}"}, {"example_id", "test@posthog.com", "second-variant", "{\"test\": 2}"}}},
+		{"invalid", "feature_flag/test-variant-override-invalid.json", []variantPayloadCheck{{"test_id", "test@posthog.com", "third-variant", "{\"test\": 3}"}, {"example_id", "", "second-variant", "{\"test\": 2}"}}},
 	}
 
-	payload, _ := client.GetFeatureFlagPayload(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "test_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if payload != "{\"test\": 2}" {
-		t.Error("Should match", payload, "{\"test\": 2}")
-	}
-
-	variant, _ = client.GetFeatureFlag(
-		FeatureFlagPayload{
-			Key:        "beta-feature",
-			DistinctId: "example_id",
-		},
-	)
-
-	if variant != "first-variant" {
-		t.Error("Should match", variant, "first-variant")
-	}
-
-	payload, _ = client.GetFeatureFlagPayload(
-		FeatureFlagPayload{
-			Key:        "beta-feature",
-			DistinctId: "example_id",
-		},
-	)
-
-	if payload != "{\"test\": 1}" {
-		t.Error("Should match", payload, "{\"test\": 1}")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newFeatureFlagsLocalClient(t, tt.fixture)
+			for _, check := range tt.checks {
+				assertFlagVariantAndPayload(t, client, featureFlagPayloadFor(check.distinctID, check.email), check.variant, check.payload)
+			}
+		})
 	}
 }
 
-func TestFlagWithClashingVariantOverrides(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-variant-override-clashing.json")))
+type variantPayloadCheck struct {
+	distinctID string
+	email      string
+	variant    interface{}
+	payload    string
+}
+
+func featureFlagPayloadFor(distinctID, email string) FeatureFlagPayload {
+	payload := FeatureFlagPayload{Key: "beta-feature", DistinctId: distinctID}
+	if email != "" {
+		payload.PersonProperties = NewProperties().Set("email", email)
+	}
+	return payload
+}
+
+func assertFlagVariantAndPayload(t *testing.T, client Client, request FeatureFlagPayload, wantVariant interface{}, wantPayload string) {
+	t.Helper()
+	assertFeatureFlag(t, client, request, wantVariant)
+	assertFeatureFlagPayload(t, client, request, wantPayload)
+}
+
+func assertAllFlags(t *testing.T, client Client, request FeatureFlagPayloadNoKey, want map[string]interface{}) {
+	t.Helper()
+	featureVariants, _ := client.GetAllFlags(request)
+	for key, value := range want {
+		if featureVariants[key] != value {
+			t.Error("Should match")
 		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	variant, _ := client.GetFeatureFlag(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "test_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if variant != "second-variant" {
-		t.Error("Should match", variant, "second-variant")
-	}
-
-	payload, _ := client.GetFeatureFlagPayload(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "test_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if payload != "{\"test\": 2}" {
-		t.Error("Should match", payload, "{\"test\": 2}")
-	}
-
-	variant, _ = client.GetFeatureFlag(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "example_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if variant != "second-variant" {
-		t.Error("Should match", variant, "second-variant")
-	}
-
-	payload, _ = client.GetFeatureFlagPayload(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "example_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if payload != "{\"test\": 2}" {
-		t.Error("Should match", payload, "{\"test\": 2}")
 	}
 }
 
-func TestFlagWithInvalidVariantOverrides(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-variant-override-invalid.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	variant, _ := client.GetFeatureFlag(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "test_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if variant != "third-variant" {
-		t.Error("Should match", variant, "third-variant")
+func assertFeatureFlag(t *testing.T, client Client, request FeatureFlagPayload, want interface{}) {
+	t.Helper()
+	variant, _ := client.GetFeatureFlag(request)
+	if variant != want {
+		t.Error("Should match", variant, want)
 	}
+}
 
-	payload, _ := client.GetFeatureFlagPayload(
-		FeatureFlagPayload{
-			Key:              "beta-feature",
-			DistinctId:       "test_id",
-			PersonProperties: NewProperties().Set("email", "test@posthog.com"),
-		},
-	)
-
-	if payload != "{\"test\": 3}" {
-		t.Error("Should match", payload, "{\"test\": 3}")
-	}
-
-	variant, _ = client.GetFeatureFlag(
-		FeatureFlagPayload{
-			Key:        "beta-feature",
-			DistinctId: "example_id",
-		},
-	)
-
-	if variant != "second-variant" {
-		t.Error("Should match", variant, "second-variant")
-	}
-
-	payload, _ = client.GetFeatureFlagPayload(
-		FeatureFlagPayload{
-			Key:        "beta-feature",
-			DistinctId: "example_id",
-		},
-	)
-
-	if payload != "{\"test\": 2}" {
-		t.Error("Should match", payload, "{\"test\": 2}")
+func assertFeatureFlagPayload(t *testing.T, client Client, request FeatureFlagPayload, want string) {
+	t.Helper()
+	payload, _ := client.GetFeatureFlagPayload(request)
+	if payload != want {
+		t.Error("Should match", payload, want)
 	}
 }
 
@@ -1161,34 +943,7 @@ func TestConditionsEvaluatedInOrder(t *testing.T) {
 }
 
 func TestCaptureIsCalled(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
-			w.Write([]byte(fixture("test-flags-v3.json")))
-		} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
-			w.Write([]byte(fixture("feature_flag/test-simple-flag-person-prop.json")))
-		}
-	}))
-
-	defer server.Close()
-
-	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-	})
-	defer client.Close()
-
-	variant, _ := client.GetFeatureFlag(
-
-		FeatureFlagPayload{
-			Key:        "test-get-feature",
-			DistinctId: "distinct_id",
-		},
-	)
-
-	if variant != "variant-1" {
-		t.Error("Should match")
-	}
-
+	assertFeatureFlag(t, newFeatureFlagsLocalClient(t, "feature_flag/test-simple-flag-person-prop.json"), FeatureFlagPayload{Key: "test-get-feature", DistinctId: "distinct_id"}, "variant-1")
 }
 
 func TestSimpleFlagConsistency(t *testing.T) {

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -796,118 +796,27 @@ func TestMatchPropertySemverNeq(t *testing.T) {
 	require.True(t, isMatch)
 }
 
-func TestMatchPropertySemverGt(t *testing.T) {
-	property := FlagProperty{
-		Key:      "version",
-		Value:    "1.2.3",
-		Operator: "semver_gt",
-	}
-
-	testCases := []struct {
-		version  string
-		expected bool
+func TestMatchPropertySemverOrdering(t *testing.T) {
+	tests := []struct {
+		operator string
+		cases    map[string]bool
 	}{
-		{"1.2.4", true},
-		{"1.3.0", true},
-		{"2.0.0", true},
-		{"1.2.3", false},
-		{"1.2.2", false},
-		{"1.1.9", false},
-		{"0.9.9", false},
+		{"semver_gt", map[string]bool{"1.2.4": true, "1.3.0": true, "2.0.0": true, "1.2.3": false, "1.2.2": false, "1.1.9": false, "0.9.9": false}},
+		{"semver_gte", map[string]bool{"1.2.4": true, "1.3.0": true, "2.0.0": true, "1.2.3": true, "1.2.2": false, "1.1.9": false, "0.9.9": false}},
+		{"semver_lt", map[string]bool{"1.2.2": true, "1.1.9": true, "0.9.9": true, "1.2.3": false, "1.2.4": false, "1.3.0": false, "2.0.0": false}},
+		{"semver_lte", map[string]bool{"1.2.2": true, "1.1.9": true, "0.9.9": true, "1.2.3": true, "1.2.4": false, "1.3.0": false, "2.0.0": false}},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.version, func(t *testing.T) {
-			isMatch, err := matchProperty(property, NewProperties().Set("version", tc.version))
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, isMatch)
-		})
-	}
-}
-
-func TestMatchPropertySemverGte(t *testing.T) {
-	property := FlagProperty{
-		Key:      "version",
-		Value:    "1.2.3",
-		Operator: "semver_gte",
-	}
-
-	testCases := []struct {
-		version  string
-		expected bool
-	}{
-		{"1.2.4", true},
-		{"1.3.0", true},
-		{"2.0.0", true},
-		{"1.2.3", true}, // Equal
-		{"1.2.2", false},
-		{"1.1.9", false},
-		{"0.9.9", false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.version, func(t *testing.T) {
-			isMatch, err := matchProperty(property, NewProperties().Set("version", tc.version))
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, isMatch)
-		})
-	}
-}
-
-func TestMatchPropertySemverLt(t *testing.T) {
-	property := FlagProperty{
-		Key:      "version",
-		Value:    "1.2.3",
-		Operator: "semver_lt",
-	}
-
-	testCases := []struct {
-		version  string
-		expected bool
-	}{
-		{"1.2.2", true},
-		{"1.1.9", true},
-		{"0.9.9", true},
-		{"1.2.3", false}, // Equal
-		{"1.2.4", false},
-		{"1.3.0", false},
-		{"2.0.0", false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.version, func(t *testing.T) {
-			isMatch, err := matchProperty(property, NewProperties().Set("version", tc.version))
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, isMatch)
-		})
-	}
-}
-
-func TestMatchPropertySemverLte(t *testing.T) {
-	property := FlagProperty{
-		Key:      "version",
-		Value:    "1.2.3",
-		Operator: "semver_lte",
-	}
-
-	testCases := []struct {
-		version  string
-		expected bool
-	}{
-		{"1.2.2", true},
-		{"1.1.9", true},
-		{"0.9.9", true},
-		{"1.2.3", true}, // Equal
-		{"1.2.4", false},
-		{"1.3.0", false},
-		{"2.0.0", false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.version, func(t *testing.T) {
-			isMatch, err := matchProperty(property, NewProperties().Set("version", tc.version))
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, isMatch)
+	for _, tt := range tests {
+		t.Run(tt.operator, func(t *testing.T) {
+			property := FlagProperty{Key: "version", Value: "1.2.3", Operator: tt.operator}
+			for version, expected := range tt.cases {
+				t.Run(version, func(t *testing.T) {
+					isMatch, err := matchProperty(property, NewProperties().Set("version", version))
+					require.NoError(t, err)
+					require.Equal(t, expected, isMatch)
+				})
+			}
 		})
 	}
 }

--- a/featureflags.go
+++ b/featureflags.go
@@ -2005,11 +2005,7 @@ func (poller *FeatureFlagsPoller) getState() *flagsState {
 
 // getCohorts returns the current cohorts map or an empty map if not initialized.
 func (poller *FeatureFlagsPoller) getCohorts() map[string]PropertyGroup {
-	state := poller.state.Load()
-	if state == nil || state.cohorts == nil {
-		return map[string]PropertyGroup{}
-	}
-	return state.cohorts
+	return stateMapOrEmpty(poller.getState(), func(state *flagsState) map[string]PropertyGroup { return state.cohorts })
 }
 
 // preParseCohortValues converts raw []any values in cohort PropertyGroups into
@@ -2100,11 +2096,18 @@ func (poller *FeatureFlagsPoller) getFlagsByKey() map[string]FeatureFlag {
 
 // getGroups returns the current groups map or an empty map if not initialized.
 func (poller *FeatureFlagsPoller) getGroups() map[string]string {
-	state := poller.state.Load()
-	if state == nil || state.groups == nil {
-		return map[string]string{}
+	return stateMapOrEmpty(poller.getState(), func(state *flagsState) map[string]string { return state.groups })
+}
+
+func stateMapOrEmpty[K comparable, V any](state *flagsState, getMap func(*flagsState) map[K]V) map[K]V {
+	if state == nil {
+		return map[K]V{}
 	}
-	return state.groups
+	m := getMap(state)
+	if m == nil {
+		return map[K]V{}
+	}
+	return m
 }
 
 func (poller *FeatureFlagsPoller) localEvaluationFlags(headers http.Header, etag string) (*http.Response, context.CancelFunc, error) {

--- a/featureflags_test.go
+++ b/featureflags_test.go
@@ -27,3 +27,29 @@ func TestCalculateHash(t *testing.T) {
 		})
 	}
 }
+
+func TestFeatureFlagsPollerStateMapGetters(t *testing.T) {
+	poller := &FeatureFlagsPoller{}
+	if got := poller.getCohorts(); len(got) != 0 {
+		t.Fatalf("empty poller getCohorts() = %#v, want empty map", got)
+	}
+	if got := poller.getGroups(); len(got) != 0 {
+		t.Fatalf("empty poller getGroups() = %#v, want empty map", got)
+	}
+
+	cohorts := map[string]PropertyGroup{"1": {Type: "AND"}}
+	groups := map[string]string{"0": "company"}
+	poller.state.Store(&flagsState{cohorts: cohorts, groups: groups})
+
+	gotCohorts := poller.getCohorts()
+	gotGroups := poller.getGroups()
+	gotCohorts["2"] = PropertyGroup{Type: "OR"}
+	gotGroups["1"] = "team"
+
+	if cohorts["2"].Type != "OR" {
+		t.Fatalf("getCohorts() did not return the stored map")
+	}
+	if groups["1"] != "team" {
+		t.Fatalf("getGroups() did not return the stored map")
+	}
+}

--- a/group_identify.go
+++ b/group_identify.go
@@ -36,23 +36,7 @@ func (msg GroupIdentify) internal() {
 
 // Validate checks that the group identify message has Type and Key set.
 func (msg GroupIdentify) Validate() error {
-	if len(msg.Type) == 0 {
-		return FieldError{
-			Type:  "posthog.GroupIdentify",
-			Name:  "Type",
-			Value: msg.Type,
-		}
-	}
-
-	if len(msg.Key) == 0 {
-		return FieldError{
-			Type:  "posthog.GroupIdentify",
-			Name:  "Key",
-			Value: msg.Key,
-		}
-	}
-
-	return nil
+	return validateRequiredStringFields("posthog.GroupIdentify", requiredStringField{name: "Type", value: msg.Type}, requiredStringField{name: "Key", value: msg.Key})
 }
 
 // GroupIdentifyInApi is the wire-format payload produced from a GroupIdentify message.

--- a/group_identify_test.go
+++ b/group_identify_test.go
@@ -1,108 +1,23 @@
 package posthog
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestGroupIdentifyMissingType(t *testing.T) {
-	groupIdentify := GroupIdentify{}
-
-	if err := groupIdentify.Validate(); err == nil {
-		t.Error("validating an invalid group identify object succeeded:", groupIdentify)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating group identify:", err)
-
-	} else if e != (FieldError{
-		Type:  "posthog.GroupIdentify",
-		Name:  "Type",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating group identify:", err)
-	}
+	assertFieldError(t, GroupIdentify{}, fieldError("posthog.GroupIdentify", "Type"))
 }
 
 func TestGroupIdentifyMissingKey(t *testing.T) {
-	groupIdentify := GroupIdentify{Type: "organization"}
-
-	if err := groupIdentify.Validate(); err == nil {
-		t.Error("validating an invalid group identify object succeeded:", groupIdentify)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating group identify:", err)
-
-	} else if e != (FieldError{
-		Type:  "posthog.GroupIdentify",
-		Name:  "Key",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating group identify:", err)
-	}
+	assertFieldError(t, GroupIdentify{Type: "organization"}, fieldError("posthog.GroupIdentify", "Key"))
 }
 
 func TestGroupIdentifyValidWithTypeAndKey(t *testing.T) {
-	groupIdentify := GroupIdentify{
-		Type: "organization",
-		Key:  "id:5",
-	}
-
-	if err := groupIdentify.Validate(); err != nil {
-		t.Error("validating a valid identify object failed:", groupIdentify, err)
-	}
+	assertValid(t, GroupIdentify{Type: "organization", Key: "id:5"})
 }
 
 func TestGroupIdentifyAPIfyIncludesIsServerProperty(t *testing.T) {
-	groupIdentify := GroupIdentify{
-		Type:     "organization",
-		Key:      "id:5",
-		IsServer: true,
-	}
-
-	apiMsg, ok := groupIdentify.APIfy().(GroupIdentifyInApi)
-	if !ok {
-		t.Fatalf("expected GroupIdentifyInApi, got %T", groupIdentify.APIfy())
-	}
-
-	jsonBytes, err := json.Marshal(apiMsg)
-	if err != nil {
-		t.Fatalf("marshal failed: %v", err)
-	}
-
-	var wire map[string]interface{}
-	if err := json.Unmarshal(jsonBytes, &wire); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-
-	props, ok := wire["properties"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("properties field missing or wrong type")
-	}
-
-	expectKeys := map[string]interface{}{
-		"$lib":       SDKName,
-		"$is_server": true,
-	}
-	for k, want := range expectKeys {
-		if got := props[k]; got != want {
-			t.Errorf("property %q: expected %v (%T), got %v (%T)", k, want, want, got, got)
-		}
-	}
+	assertIsServerProperty(t, GroupIdentify{Type: "organization", Key: "id:5", IsServer: true}.APIfy(), true)
 }
 
 func TestGroupIdentifyAPIfyOmitsIsServerWhenFalse(t *testing.T) {
-	groupIdentify := GroupIdentify{
-		Type:     "organization",
-		Key:      "id:5",
-		IsServer: false,
-	}
-
-	apiMsg, ok := groupIdentify.APIfy().(GroupIdentifyInApi)
-	if !ok {
-		t.Fatalf("expected GroupIdentifyInApi, got %T", groupIdentify.APIfy())
-	}
-
-	if _, present := apiMsg.Properties["$is_server"]; present {
-		t.Errorf("$is_server should be absent when IsServer is false, got %v", apiMsg.Properties["$is_server"])
-	}
+	assertIsServerProperty(t, GroupIdentify{Type: "organization", Key: "id:5", IsServer: false}.APIfy(), false)
 }

--- a/groups.go
+++ b/groups.go
@@ -8,11 +8,10 @@ type Groups map[string]interface{}
 
 // NewGroups creates an empty Groups map for fluent construction.
 func NewGroups() Groups {
-	return make(Groups, 10)
+	return newStringInterfaceMap[Groups]()
 }
 
 // Set assigns a group type to a group key or ID and returns the receiver.
 func (p Groups) Set(name string, value interface{}) Groups {
-	p[name] = value
-	return p
+	return setStringInterfaceMapValue(p, name, value)
 }

--- a/groups_test.go
+++ b/groups_test.go
@@ -28,3 +28,12 @@ func TestGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupsSetReturnsReceiver(t *testing.T) {
+	groups := NewGroups()
+	returned := groups.Set("company", "acme")
+	returned.Set("team", "sdk")
+
+	require.Equal(t, "acme", groups["company"])
+	require.Equal(t, "sdk", groups["team"])
+}

--- a/identify.go
+++ b/identify.go
@@ -35,15 +35,9 @@ func (msg Identify) internal() {
 
 // Validate checks that the identify message has a DistinctId.
 func (msg Identify) Validate() error {
-	if len(msg.DistinctId) == 0 {
-		return FieldError{
-			Type:  "posthog.Identify",
-			Name:  "DistinctId",
-			Value: msg.DistinctId,
-		}
-	}
-
-	return nil
+	return validateRequiredStringFields("posthog.Identify",
+		requiredStringField{name: "DistinctId", value: msg.DistinctId},
+	)
 }
 
 // IdentifyInApi is the wire-format payload produced from an Identify message.

--- a/identify_test.go
+++ b/identify_test.go
@@ -1,87 +1,19 @@
 package posthog
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestIdentifyMissingDistinctId(t *testing.T) {
-	identify := Identify{}
-
-	if err := identify.Validate(); err == nil {
-		t.Error("validating an invalid identify object succeeded:", identify)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating identify:", err)
-
-	} else if e != (FieldError{
-		Type:  "posthog.Identify",
-		Name:  "DistinctId",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating identify:", err)
-	}
+	assertFieldError(t, Identify{}, fieldError("posthog.Identify", "DistinctId"))
 }
 
 func TestIdentifyValidWithDistinctId(t *testing.T) {
-	identify := Identify{
-		DistinctId: "2",
-	}
-
-	if err := identify.Validate(); err != nil {
-		t.Error("validating a valid identify object failed:", identify, err)
-	}
+	assertValid(t, Identify{DistinctId: "2"})
 }
 
 func TestIdentifyAPIfyIncludesIsServerProperty(t *testing.T) {
-	identify := Identify{
-		DistinctId: "user-123",
-		IsServer:   true,
-	}
-
-	apiMsg, ok := identify.APIfy().(IdentifyInApi)
-	if !ok {
-		t.Fatalf("expected IdentifyInApi, got %T", identify.APIfy())
-	}
-
-	jsonBytes, err := json.Marshal(apiMsg)
-	if err != nil {
-		t.Fatalf("marshal failed: %v", err)
-	}
-
-	var wire map[string]interface{}
-	if err := json.Unmarshal(jsonBytes, &wire); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-
-	props, ok := wire["properties"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("properties field missing or wrong type")
-	}
-
-	expectKeys := map[string]interface{}{
-		"$lib":       SDKName,
-		"$is_server": true,
-	}
-	for k, want := range expectKeys {
-		if got := props[k]; got != want {
-			t.Errorf("property %q: expected %v (%T), got %v (%T)", k, want, want, got, got)
-		}
-	}
+	assertIsServerProperty(t, Identify{DistinctId: "user-123", IsServer: true}.APIfy(), true)
 }
 
 func TestIdentifyAPIfyOmitsIsServerWhenFalse(t *testing.T) {
-	identify := Identify{
-		DistinctId: "user-123",
-		IsServer:   false,
-	}
-
-	apiMsg, ok := identify.APIfy().(IdentifyInApi)
-	if !ok {
-		t.Fatalf("expected IdentifyInApi, got %T", identify.APIfy())
-	}
-
-	if _, present := apiMsg.Properties["$is_server"]; present {
-		t.Errorf("$is_server should be absent when IsServer is false, got %v", apiMsg.Properties["$is_server"])
-	}
+	assertIsServerProperty(t, Identify{DistinctId: "user-123", IsServer: false}.APIfy(), false)
 }

--- a/message_assertions_test.go
+++ b/message_assertions_test.go
@@ -1,0 +1,67 @@
+package posthog
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type validatableMessage interface {
+	Validate() error
+}
+
+func fieldError(typeName, fieldName string) FieldError {
+	return FieldError{Type: typeName, Name: fieldName, Value: ""}
+}
+
+func assertFieldError(t *testing.T, msg validatableMessage, want FieldError) {
+	t.Helper()
+	err := msg.Validate()
+	if err == nil {
+		t.Fatalf("validating an invalid object succeeded: %#v", msg)
+	}
+	got, ok := err.(FieldError)
+	if !ok {
+		t.Fatalf("invalid error type returned: %v", err)
+	}
+	if got != want {
+		t.Fatalf("invalid error value returned: got %#v, want %#v", got, want)
+	}
+}
+
+func assertValid(t *testing.T, msg validatableMessage) {
+	t.Helper()
+	if err := msg.Validate(); err != nil {
+		t.Fatalf("validating a valid object failed: %#v: %v", msg, err)
+	}
+}
+
+func wireProperties(t *testing.T, apiMsg APIMessage) map[string]interface{} {
+	t.Helper()
+	jsonBytes, err := json.Marshal(apiMsg)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var wire map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &wire); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	props, ok := wire["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("properties field missing or wrong type")
+	}
+	return props
+}
+
+func assertIsServerProperty(t *testing.T, apiMsg APIMessage, wantPresent bool) {
+	t.Helper()
+	props := wireProperties(t, apiMsg)
+	if wantPresent {
+		if got := props["$is_server"]; got != true {
+			t.Errorf("$is_server: expected true, got %v", got)
+		}
+		return
+	}
+	if _, present := props["$is_server"]; present {
+		t.Errorf("$is_server should be absent when IsServer is false, got %v", props["$is_server"])
+	}
+}

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -61,27 +61,14 @@ type testLogger struct {
 	errorf func(string, ...interface{})
 }
 
-func (l testLogger) Debugf(format string, args ...interface{}) {
-	if l.logf != nil {
-		l.logf(format, args...)
-	}
-}
+func (l testLogger) Debugf(format string, args ...interface{}) { l.writeLog(l.logf, format, args...) }
+func (l testLogger) Logf(format string, args ...interface{})   { l.writeLog(l.logf, format, args...) }
+func (l testLogger) Warnf(format string, args ...interface{})  { l.writeLog(l.logf, format, args...) }
+func (l testLogger) Errorf(format string, args ...interface{}) { l.writeLog(l.errorf, format, args...) }
 
-func (l testLogger) Logf(format string, args ...interface{}) {
-	if l.logf != nil {
-		l.logf(format, args...)
-	}
-}
-
-func (l testLogger) Warnf(format string, args ...interface{}) {
-	if l.logf != nil {
-		l.logf(format, args...)
-	}
-}
-
-func (l testLogger) Errorf(format string, args ...interface{}) {
-	if l.errorf != nil {
-		l.errorf(format, args...)
+func (l testLogger) writeLog(fn func(string, ...interface{}), format string, args ...interface{}) {
+	if fn != nil {
+		fn(format, args...)
 	}
 }
 

--- a/properties.go
+++ b/properties.go
@@ -17,13 +17,21 @@ type Properties map[string]interface{}
 
 // NewProperties creates an empty Properties map for fluent construction.
 func NewProperties() Properties {
-	return make(Properties, 10)
+	return newStringInterfaceMap[Properties]()
+}
+
+func newStringInterfaceMap[M ~map[string]interface{}]() M {
+	return make(M, 10)
 }
 
 // Set assigns a property value and returns the receiver.
 func (p Properties) Set(name string, value interface{}) Properties {
-	p[name] = value
-	return p
+	return setStringInterfaceMapValue(p, name, value)
+}
+
+func setStringInterfaceMapValue[M ~map[string]interface{}](m M, name string, value interface{}) M {
+	m[name] = value
+	return m
 }
 
 // Merge adds the properties from the provided `props` into the receiver `p`.

--- a/properties_test.go
+++ b/properties_test.go
@@ -59,3 +59,13 @@ func TestPropertiesMergeNil(t *testing.T) {
 		t.Errorf("invalid properties produced by merge:\n- expected %#v\n- found: %#v", expected, props)
 	}
 }
+
+func TestPropertiesSetReturnsReceiver(t *testing.T) {
+	props := NewProperties()
+	returned := props.Set("key", "value")
+	returned.Set("other", 42)
+
+	if props["key"] != "value" || props["other"] != 42 {
+		t.Fatalf("Properties.Set did not mutate and return the receiver: %#v", props)
+	}
+}

--- a/refactor_characterization_test.go
+++ b/refactor_characterization_test.go
@@ -1,0 +1,112 @@
+package posthog
+
+import "testing"
+
+func TestRequiredFieldValidationOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  validatableMessage
+		want FieldError
+	}{
+		{"capture event before distinct id", Capture{}, fieldError("posthog.Capture", "Event")},
+		{"alias distinct id before alias", Alias{}, fieldError("posthog.Alias", "DistinctId")},
+		{"group identify type before key", GroupIdentify{}, fieldError("posthog.GroupIdentify", "Type")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertFieldError(t, tt.msg, tt.want)
+		})
+	}
+}
+
+func TestFeatureFlagPayloadValidationDefaultsAndErrors(t *testing.T) {
+	t.Run("single flag validates key before distinct id", func(t *testing.T) {
+		payload := FeatureFlagPayload{}
+		assertConfigError(t, payload.validate(), ConfigError{Reason: "Feature Flag Key required", Field: "Key", Value: ""})
+	})
+
+	t.Run("single flag validates distinct id after key", func(t *testing.T) {
+		payload := FeatureFlagPayload{Key: "flag-key"}
+		assertConfigError(t, payload.validate(), ConfigError{Reason: "DistinctId required", Field: "Distinct Id", Value: ""})
+	})
+
+	t.Run("all flags validates distinct id", func(t *testing.T) {
+		payload := FeatureFlagPayloadNoKey{}
+		assertConfigError(t, payload.validate(), ConfigError{Reason: "DistinctId required", Field: "Distinct Id", Value: ""})
+	})
+
+	t.Run("nil send events defaults to true", func(t *testing.T) {
+		payload := FeatureFlagPayload{Key: "flag-key", DistinctId: "user-id"}
+		if err := payload.validate(); err != nil {
+			t.Fatalf("validate failed: %v", err)
+		}
+		if payload.SendFeatureFlagEvents == nil || *payload.SendFeatureFlagEvents != true {
+			t.Fatalf("SendFeatureFlagEvents = %v, want true", payload.SendFeatureFlagEvents)
+		}
+	})
+
+	t.Run("explicit false send events is preserved", func(t *testing.T) {
+		value := false
+		payload := FeatureFlagPayloadNoKey{DistinctId: "user-id", SendFeatureFlagEvents: &value}
+		if err := payload.validate(); err != nil {
+			t.Fatalf("validate failed: %v", err)
+		}
+		if payload.SendFeatureFlagEvents != &value || *payload.SendFeatureFlagEvents != false {
+			t.Fatalf("SendFeatureFlagEvents = %v, want original false pointer", payload.SendFeatureFlagEvents)
+		}
+	})
+}
+
+func TestPropertiesAndGroupsSetReturnReceiver(t *testing.T) {
+	props := NewProperties()
+	returnedProps := props.Set("key", "value")
+	returnedProps.Set("other", 42)
+	if props["key"] != "value" || props["other"] != 42 {
+		t.Fatalf("Properties.Set did not mutate and return the receiver: %#v", props)
+	}
+
+	groups := NewGroups()
+	returnedGroups := groups.Set("company", "acme")
+	returnedGroups.Set("team", "sdk")
+	if groups["company"] != "acme" || groups["team"] != "sdk" {
+		t.Fatalf("Groups.Set did not mutate and return the receiver: %#v", groups)
+	}
+}
+
+func TestFeatureFlagsPollerStateMapGetters(t *testing.T) {
+	poller := &FeatureFlagsPoller{}
+	if got := poller.getCohorts(); len(got) != 0 {
+		t.Fatalf("empty poller getCohorts() = %#v, want empty map", got)
+	}
+	if got := poller.getGroups(); len(got) != 0 {
+		t.Fatalf("empty poller getGroups() = %#v, want empty map", got)
+	}
+
+	cohorts := map[string]PropertyGroup{"1": {Type: "AND"}}
+	groups := map[string]string{"0": "company"}
+	poller.state.Store(&flagsState{cohorts: cohorts, groups: groups})
+
+	gotCohorts := poller.getCohorts()
+	gotGroups := poller.getGroups()
+	gotCohorts["2"] = PropertyGroup{Type: "OR"}
+	gotGroups["1"] = "team"
+
+	if cohorts["2"].Type != "OR" {
+		t.Fatalf("getCohorts() did not return the stored map")
+	}
+	if groups["1"] != "team" {
+		t.Fatalf("getGroups() did not return the stored map")
+	}
+}
+
+func assertConfigError(t *testing.T, err error, want ConfigError) {
+	t.Helper()
+	got, ok := err.(ConfigError)
+	if !ok {
+		t.Fatalf("error = %T %[1]v, want ConfigError", err)
+	}
+	if got != want {
+		t.Fatalf("ConfigError = %#v, want %#v", got, want)
+	}
+}

--- a/stress_test.go
+++ b/stress_test.go
@@ -235,65 +235,17 @@ func TestStress_CardinalityDistribution(t *testing.T) {
 
 // TestStress_HighConcurrencyLowVolume tests many goroutines with few events each
 func TestStress_HighConcurrencyLowVolume(t *testing.T) {
-	goroutines := 1000
-	eventsPerGoroutine := 5
-	totalEvents := goroutines * eventsPerGoroutine
-
-	pool := NewEventPool(totalEvents)
-
-	var received atomic.Int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var b batch
-		json.NewDecoder(r.Body).Decode(&b)
-		received.Add(int64(len(b.Messages)))
-		w.WriteHeader(200)
-	}))
-	defer server.Close()
-
-	client, err := NewWithConfig("test-key", Config{
-		Endpoint: server.URL,
-		// Uses production defaults for BatchSize, MaxEnqueuedRequests
-	})
-	require.NoError(t, err)
-
-	start := time.Now()
-
-	var wg sync.WaitGroup
-	var errorCount atomic.Int64
-	for g := 0; g < goroutines; g++ {
-		wg.Add(1)
-		go func(goroutineID int) {
-			defer wg.Done()
-			for i := 0; i < eventsPerGoroutine; i++ {
-				idx := goroutineID*eventsPerGoroutine + i
-				if err := client.Enqueue(pool.Get(idx)); err != nil {
-					errorCount.Add(1)
-				}
-			}
-		}(g)
-	}
-
-	wg.Wait()
-	client.Close()
-
-	elapsed := time.Since(start)
-	throughput := float64(totalEvents) / elapsed.Seconds()
-
-	t.Logf("High concurrency: %d goroutines, %d events, %.2f events/sec, %v total",
-		goroutines, totalEvents, throughput, elapsed)
-	require.Equal(t, int64(0), errorCount.Load(),
-		"No enqueue errors should occur")
-
-	require.Equal(t, int64(totalEvents), received.Load(),
-		"All events should be delivered")
+	runStressConcurrencyVolume(t, "High concurrency", 1000, 5)
 }
 
 // TestStress_LowConcurrencyHighVolume tests few goroutines with many events each
 func TestStress_LowConcurrencyHighVolume(t *testing.T) {
-	goroutines := 4
-	eventsPerGoroutine := 125
-	totalEvents := goroutines * eventsPerGoroutine
+	runStressConcurrencyVolume(t, "Low concurrency", 4, 125)
+}
 
+func runStressConcurrencyVolume(t *testing.T, name string, goroutines, eventsPerGoroutine int) {
+	t.Helper()
+	totalEvents := goroutines * eventsPerGoroutine
 	pool := NewEventPool(totalEvents)
 
 	var received atomic.Int64
@@ -305,14 +257,21 @@ func TestStress_LowConcurrencyHighVolume(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewWithConfig("test-key", Config{
-		Endpoint: server.URL,
-		// Uses production defaults for BatchSize, MaxEnqueuedRequests
-	})
+	client, err := NewWithConfig("test-key", Config{Endpoint: server.URL})
 	require.NoError(t, err)
 
 	start := time.Now()
+	errorCount := enqueueConcurrently(client, pool, goroutines, eventsPerGoroutine)
+	client.Close()
 
+	elapsed := time.Since(start)
+	throughput := float64(totalEvents) / elapsed.Seconds()
+	t.Logf("%s: %d goroutines, %d events, %.2f events/sec, %v total", name, goroutines, totalEvents, throughput, elapsed)
+	require.Equal(t, int64(0), errorCount, "No enqueue errors should occur")
+	require.Equal(t, int64(totalEvents), received.Load(), "All events should be delivered")
+}
+
+func enqueueConcurrently(client Client, pool *EventPool, goroutines, eventsPerGoroutine int) int64 {
 	var wg sync.WaitGroup
 	var errorCount atomic.Int64
 	for g := 0; g < goroutines; g++ {
@@ -327,20 +286,8 @@ func TestStress_LowConcurrencyHighVolume(t *testing.T) {
 			}
 		}(g)
 	}
-
 	wg.Wait()
-	client.Close()
-
-	elapsed := time.Since(start)
-	throughput := float64(totalEvents) / elapsed.Seconds()
-
-	t.Logf("Low concurrency: %d goroutines, %d events, %.2f events/sec, %v total",
-		goroutines, totalEvents, throughput, elapsed)
-	require.Equal(t, int64(0), errorCount.Load(),
-		"No enqueue errors should occur")
-
-	require.Equal(t, int64(totalEvents), received.Load(),
-		"All events should be delivered")
+	return errorCount.Load()
 }
 
 // TestStress_MixedCardinality tests a mix of cardinalities in a single test

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -142,23 +142,16 @@ type templateData struct {
 }
 
 // cloneProperties creates a shallow copy of a Properties map
-func cloneProperties(src Properties) Properties {
-	if src == nil {
-		return nil
-	}
-	dst := make(Properties, len(src))
-	for k, v := range src {
-		dst[k] = v
-	}
-	return dst
-}
+func cloneProperties(src Properties) Properties { return cloneStringInterfaceMap(src) }
 
 // cloneGroups creates a shallow copy of a Groups map
-func cloneGroups(src Groups) Groups {
+func cloneGroups(src Groups) Groups { return cloneStringInterfaceMap(src) }
+
+func cloneStringInterfaceMap[M ~map[string]interface{}](src M) M {
 	if src == nil {
 		return nil
 	}
-	dst := make(Groups, len(src))
+	dst := make(M, len(src))
 	for k, v := range src {
 		dst[k] = v
 	}

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -68,13 +68,17 @@ func (c *UnifiedCallback) Failure(msg APIMessage, err error) {
 	}
 }
 
-func (c *UnifiedCallback) GetCounts() (success, failure int) {
+func (c *UnifiedCallback) GetCounts() (success, failure int) { return c.counts() }
+
+func (c *UnifiedCallback) counts() (success, failure int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.successCount, c.failureCount
 }
 
-func (c *UnifiedCallback) GetLastError() error {
+func (c *UnifiedCallback) GetLastError() error { return c.lastErr() }
+
+func (c *UnifiedCallback) lastErr() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.lastError
@@ -119,20 +123,20 @@ func NewMockServerBuilder() *MockServerBuilder {
 }
 
 func (b *MockServerBuilder) WithBatchResponse(response string, statusCode int) *MockServerBuilder {
-	b.config.BatchResponse = response
-	b.config.BatchStatusCode = statusCode
-	return b
+	return b.withResponse(response, statusCode, &b.config.BatchResponse, &b.config.BatchStatusCode)
 }
 
 func (b *MockServerBuilder) WithFlagsResponse(response string, statusCode int) *MockServerBuilder {
-	b.config.FlagsResponse = response
-	b.config.FlagsStatusCode = statusCode
-	return b
+	return b.withResponse(response, statusCode, &b.config.FlagsResponse, &b.config.FlagsStatusCode)
 }
 
 func (b *MockServerBuilder) WithLocalEvalResponse(response string, statusCode int) *MockServerBuilder {
-	b.config.LocalEvalResponse = response
-	b.config.LocalEvalStatus = statusCode
+	return b.withResponse(response, statusCode, &b.config.LocalEvalResponse, &b.config.LocalEvalStatus)
+}
+
+func (b *MockServerBuilder) withResponse(response string, statusCode int, responseField *string, statusField *int) *MockServerBuilder {
+	*responseField = response
+	*statusField = statusCode
 	return b
 }
 
@@ -146,10 +150,13 @@ func (b *MockServerBuilder) WithFailAfterN(n int) *MockServerBuilder {
 	return b
 }
 
-func (b *MockServerBuilder) GetRequestCount() int {
+func (b *MockServerBuilder) GetRequestCount() int { return b.requestCountLocked() }
+
+func (b *MockServerBuilder) requestCountLocked() int {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.requestCount
+	count := b.requestCount
+	b.mu.Unlock()
+	return count
 }
 
 func (b *MockServerBuilder) Build() *httptest.Server {

--- a/validation_test.go
+++ b/validation_test.go
@@ -58,48 +58,6 @@ func TestFeatureFlagPayloadValidationDefaultsAndErrors(t *testing.T) {
 	})
 }
 
-func TestPropertiesAndGroupsSetReturnReceiver(t *testing.T) {
-	props := NewProperties()
-	returnedProps := props.Set("key", "value")
-	returnedProps.Set("other", 42)
-	if props["key"] != "value" || props["other"] != 42 {
-		t.Fatalf("Properties.Set did not mutate and return the receiver: %#v", props)
-	}
-
-	groups := NewGroups()
-	returnedGroups := groups.Set("company", "acme")
-	returnedGroups.Set("team", "sdk")
-	if groups["company"] != "acme" || groups["team"] != "sdk" {
-		t.Fatalf("Groups.Set did not mutate and return the receiver: %#v", groups)
-	}
-}
-
-func TestFeatureFlagsPollerStateMapGetters(t *testing.T) {
-	poller := &FeatureFlagsPoller{}
-	if got := poller.getCohorts(); len(got) != 0 {
-		t.Fatalf("empty poller getCohorts() = %#v, want empty map", got)
-	}
-	if got := poller.getGroups(); len(got) != 0 {
-		t.Fatalf("empty poller getGroups() = %#v, want empty map", got)
-	}
-
-	cohorts := map[string]PropertyGroup{"1": {Type: "AND"}}
-	groups := map[string]string{"0": "company"}
-	poller.state.Store(&flagsState{cohorts: cohorts, groups: groups})
-
-	gotCohorts := poller.getCohorts()
-	gotGroups := poller.getGroups()
-	gotCohorts["2"] = PropertyGroup{Type: "OR"}
-	gotGroups["1"] = "team"
-
-	if cohorts["2"].Type != "OR" {
-		t.Fatalf("getCohorts() did not return the stored map")
-	}
-	if groups["1"] != "team" {
-		t.Fatalf("getGroups() did not return the stored map")
-	}
-}
-
 func assertConfigError(t *testing.T, err error, want ConfigError) {
 	t.Helper()
 	got, ok := err.(ConfigError)


### PR DESCRIPTION
## :bulb: Motivation and Context

PoC for evaluating duplicate removal surfaced by [`dry4go`](https://github.com/unclebob/dry4go).

This refactors the repository to remove the duplicate candidates reported by dry4go while preserving existing behavior. It also makes feature-flag event assertions wait more reliably under the race-enabled CI run, with explicit wait durations and consistent test server cleanup.

Additional focused characterization tests cover the production refactors: required-field validation order, feature flag validation defaults/errors, Properties/Groups receiver semantics, and poller state map getters.

## :green_heart: How did you test it?

- `go test ./...`
- `go test -race -count=1 -timeout=5m ./...`
- `dry4go .` → `No duplicate candidates found.`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
