### PR TITLE
feat(feature-flags): support early_exit in local evaluation

### DIFF
--- a/.changeset/cool-hats-stop.md
+++ b/.changeset/cool-hats-stop.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Support the `early_exit` flag filter in local evaluation. When a flag's `filters.early_exit` is `true` and a condition group's property filters match (or there are none) but the rollout percentage excludes the user, evaluation now stops and returns `false` immediately instead of falling through to later groups. Mirrors the server-side (Rust) evaluation engine. A property-filter mismatch still falls through as before, and behaviour is unchanged when `early_exit` is unset or `false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Minor Changes
+
+- Support the `early_exit` option on feature flag filters during local evaluation. When a flag has `filters.early_exit` set to `true` and a condition group matches its property filters (or has none) but the rollout percentage excludes the user, local evaluation now returns a definitive disabled result immediately instead of falling through to later condition groups, mirroring the server-side evaluation engine. Property-filter mismatches continue to fall through as before, and behaviour is unchanged when `early_exit` is absent or `false`.
+
 ## 1.14.0
 
 ### Minor Changes

--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -744,6 +744,18 @@ func TestFeatureFlagEarlyExit(t *testing.T) {
 			personProperties: NewProperties().Set("region", "USA"),
 			expected:         true,
 		},
+		{
+			// early_exit enabled, but a prior condition group is inconclusive
+			// (missing property). The early-exit OutOfRolloutBound group must
+			// not continue to the third (matching) group — it must propagate the
+			// inconclusive error so the poller falls back to the server. The
+			// server mock has no record of this flag so the result is false,
+			// not the spurious true that the third group would produce locally.
+			name:             "inconclusive prior group forces server fallback on early-exit",
+			fixture:          "feature_flag/test-early-exit-inconclusive-prior.json",
+			personProperties: NewProperties().Set("region", "USA"),
+			expected:         false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -767,6 +779,8 @@ func TestFeatureFlagEarlyExit(t *testing.T) {
 			key := "early-exit-flag"
 			if strings.Contains(fixtureFile, "property-mismatch") {
 				key = "early-exit-property-mismatch-flag"
+			} else if strings.Contains(fixtureFile, "inconclusive-prior") {
+				key = "early-exit-inconclusive-prior-flag"
 			}
 
 			result, err := client.GetFeatureFlag(FeatureFlagPayload{

--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -700,6 +700,86 @@ func TestFeatureEnabledSimpleIsTrueWhenRolloutUndefined(t *testing.T) {
 	}
 }
 
+func TestFeatureFlagEarlyExit(t *testing.T) {
+	// Each fixture defines two condition groups that both match on region=USA:
+	// the first with rollout_percentage 0 (always out of rollout bound) and the
+	// second with rollout_percentage 100 (always in rollout). The behaviour
+	// depends solely on the filters.early_exit flag.
+	tests := []struct {
+		name             string
+		fixture          string
+		personProperties Properties
+		expected         interface{}
+	}{
+		{
+			// early_exit enabled: the first group is out of rollout bound, so
+			// evaluation short-circuits to false without considering the
+			// second (matching) group.
+			name:             "early_exit enabled returns false and skips later matching group",
+			fixture:          "feature_flag/test-early-exit.json",
+			personProperties: NewProperties().Set("region", "USA"),
+			expected:         false,
+		},
+		{
+			// early_exit unset: existing behaviour, falls through to the second
+			// matching group and returns true.
+			name:             "early_exit unset falls through to later matching group",
+			fixture:          "feature_flag/test-early-exit-unset.json",
+			personProperties: NewProperties().Set("region", "USA"),
+			expected:         true,
+		},
+		{
+			// early_exit explicitly false: same as unset, falls through.
+			name:             "early_exit explicitly false falls through to later matching group",
+			fixture:          "feature_flag/test-early-exit-false.json",
+			personProperties: NewProperties().Set("region", "USA"),
+			expected:         true,
+		},
+		{
+			// early_exit enabled but the first group fails on a PROPERTY filter
+			// (region != Canada), which is NO_MATCH and must always fall
+			// through to the second matching group rather than early-exit.
+			name:             "property mismatch does not early-exit even when enabled",
+			fixture:          "feature_flag/test-early-exit-property-mismatch.json",
+			personProperties: NewProperties().Set("region", "USA"),
+			expected:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixtureFile := tt.fixture
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {
+					w.Write([]byte(fixture("test-flags-v3.json")))
+				} else if strings.HasPrefix(r.URL.Path, "/flags/definitions") {
+					w.Write([]byte(fixture(fixtureFile)))
+				}
+			}))
+			defer server.Close()
+
+			client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
+				PersonalApiKey: "some very secret key",
+				Endpoint:       server.URL,
+			})
+			defer client.Close()
+
+			key := "early-exit-flag"
+			if strings.Contains(fixtureFile, "property-mismatch") {
+				key = "early-exit-property-mismatch-flag"
+			}
+
+			result, err := client.GetFeatureFlag(FeatureFlagPayload{
+				Key:              key,
+				DistinctId:       "some-distinct-id",
+				PersonProperties: tt.personProperties,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestGetFeatureFlag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/flags" || r.URL.Path == "/flags/" {

--- a/featureflags.go
+++ b/featureflags.go
@@ -1040,8 +1040,10 @@ func (poller *FeatureFlagsPoller) matchFeatureFlagProperties(
 			// The property filters matched (or there were none) but the rollout
 			// excluded the user. When early_exit is enabled, mirror the server
 			// engine by returning a definitive disabled result instead of
-			// falling through to later condition groups.
-			if flag.Filters.EarlyExit {
+			// falling through to later condition groups. An inconclusive prior
+			// group takes priority: we can't decide locally, so we must fall
+			// back to the server.
+			if flag.Filters.EarlyExit && !isInconclusive {
 				return false, nil
 			}
 		case conditionNoMatch:

--- a/featureflags.go
+++ b/featureflags.go
@@ -1040,10 +1040,13 @@ func (poller *FeatureFlagsPoller) matchFeatureFlagProperties(
 			// The property filters matched (or there were none) but the rollout
 			// excluded the user. When early_exit is enabled, mirror the server
 			// engine by returning a definitive disabled result instead of
-			// falling through to later condition groups. An inconclusive prior
-			// group takes priority: we can't decide locally, so we must fall
-			// back to the server.
-			if flag.Filters.EarlyExit && !isInconclusive {
+			// falling through to later condition groups. If a prior group was
+			// inconclusive we can't decide locally, so return errInconclusiveMatch
+			// to force a server fallback rather than continuing evaluation.
+			if flag.Filters.EarlyExit {
+				if isInconclusive {
+					return false, errInconclusiveMatch
+				}
 				return false, nil
 			}
 		case conditionNoMatch:

--- a/featureflags.go
+++ b/featureflags.go
@@ -117,6 +117,11 @@ type Filter struct {
 	AggregationGroupTypeIndex *uint8 `json:"aggregation_group_type_index"`
 	// Groups contains the ordered condition groups to evaluate.
 	Groups []FeatureFlagCondition `json:"groups"`
+	// EarlyExit, when true, stops local condition evaluation and returns a
+	// definitive disabled result as soon as a condition group matches its
+	// property filters (or has none) but the rollout percentage excludes the
+	// user, instead of falling through to later condition groups.
+	EarlyExit bool `json:"early_exit"`
 	// Multivariate contains variant definitions for multivariate flags.
 	Multivariate *Variants `json:"multivariate"`
 	// Payloads maps flag values or variant keys to raw JSON payloads.
@@ -1004,7 +1009,7 @@ func (poller *FeatureFlagsPoller) matchFeatureFlagProperties(
 			}
 		}
 
-		isMatch, err := poller.isConditionMatch(flag, distinctId, effectiveBucketingId, deviceId, condition, effectiveProperties, cohorts, flagsByKey, evaluationCache)
+		matchResult, err := poller.isConditionMatch(flag, distinctId, effectiveBucketingId, deviceId, condition, effectiveProperties, cohorts, flagsByKey, evaluationCache)
 		if err != nil {
 			// Use direct type switch instead of errors.As to avoid pointer escape allocations.
 			// Our error types are returned directly (not wrapped), so type assertion suffices.
@@ -1021,7 +1026,8 @@ func (poller *FeatureFlagsPoller) matchFeatureFlagProperties(
 			}
 		}
 
-		if isMatch {
+		switch matchResult {
+		case conditionMatch:
 			variantOverride := condition.Variant
 			multivariates := flag.Filters.Multivariate
 
@@ -1030,6 +1036,17 @@ func (poller *FeatureFlagsPoller) matchFeatureFlagProperties(
 			} else {
 				return getMatchingVariant(flag, effectiveBucketingId), nil
 			}
+		case conditionOutOfRolloutBound:
+			// The property filters matched (or there were none) but the rollout
+			// excluded the user. When early_exit is enabled, mirror the server
+			// engine by returning a definitive disabled result instead of
+			// falling through to later condition groups.
+			if flag.Filters.EarlyExit {
+				return false, nil
+			}
+		case conditionNoMatch:
+			// A property filter did not match: always fall through to the next
+			// condition group, even when early_exit is enabled.
 		}
 	}
 
@@ -1047,6 +1064,23 @@ func uint8PtrEqual(a, b *uint8) bool {
 	return *a == *b
 }
 
+// conditionMatchResult is the tri-state outcome of evaluating a single
+// condition group, mirroring the server-side (Rust) evaluation engine.
+type conditionMatchResult int
+
+const (
+	// conditionMatch means the property filters matched and the rollout
+	// included the user: the flag matches.
+	conditionMatch conditionMatchResult = iota
+	// conditionNoMatch means a property filter did not match: evaluation
+	// always falls through to the next condition group.
+	conditionNoMatch
+	// conditionOutOfRolloutBound means the property filters matched (or the
+	// group had none) but the rollout percentage excluded the user. With
+	// early_exit enabled this short-circuits the flag to disabled.
+	conditionOutOfRolloutBound
+)
+
 func (poller *FeatureFlagsPoller) isConditionMatch(
 	flag FeatureFlag,
 	distinctId string,
@@ -1057,7 +1091,7 @@ func (poller *FeatureFlagsPoller) isConditionMatch(
 	cohorts map[string]PropertyGroup,
 	flagsByKey map[string]FeatureFlag,
 	evaluationCache map[string]interface{},
-) (bool, error) {
+) (conditionMatchResult, error) {
 	if len(condition.Properties) > 0 {
 		var (
 			isMatch bool
@@ -1072,17 +1106,25 @@ func (poller *FeatureFlagsPoller) isConditionMatch(
 				isMatch, err = matchProperty(prop, properties)
 			}
 
-			if err != nil || !isMatch {
-				return false, err
+			if err != nil {
+				return conditionNoMatch, err
+			}
+			if !isMatch {
+				return conditionNoMatch, nil
 			}
 		}
 	}
 
 	if condition.RolloutPercentage != nil {
-		return checkIfSimpleFlagEnabled(flag.Key, bucketingId, *condition.RolloutPercentage), nil
+		if checkIfSimpleFlagEnabled(flag.Key, bucketingId, *condition.RolloutPercentage) {
+			return conditionMatch, nil
+		}
+		// Property filters matched (or there were none) but the rollout
+		// percentage excluded the user.
+		return conditionOutOfRolloutBound, nil
 	}
 
-	return true, nil
+	return conditionMatch, nil
 }
 
 func (poller *FeatureFlagsPoller) matchCohort(property FlagProperty, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {

--- a/fixtures/feature_flag/test-early-exit-false.json
+++ b/fixtures/feature_flag/test-early-exit-false.json
@@ -1,0 +1,29 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "flags": [
+        {
+            "id": 803,
+            "name": "Early Exit False Flag",
+            "key": "early-exit-flag",
+            "filters": {
+                "early_exit": false,
+                "groups": [
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 0
+                    },
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 100
+                    }
+                ]
+            },
+            "deleted": false,
+            "active": true,
+            "is_simple_flag": false,
+            "rollout_percentage": null
+        }
+    ]
+}

--- a/fixtures/feature_flag/test-early-exit-inconclusive-prior.json
+++ b/fixtures/feature_flag/test-early-exit-inconclusive-prior.json
@@ -1,0 +1,33 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "flags": [
+        {
+            "id": 801,
+            "name": "Early Exit Flag With Inconclusive Prior Group",
+            "key": "early-exit-inconclusive-prior-flag",
+            "filters": {
+                "early_exit": true,
+                "groups": [
+                    {
+                        "properties": [{"key": "email", "type": "person", "value": "missing@example.com", "operator": "exact"}],
+                        "rollout_percentage": 100
+                    },
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 0
+                    },
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 100
+                    }
+                ]
+            },
+            "deleted": false,
+            "active": true,
+            "is_simple_flag": false,
+            "rollout_percentage": null
+        }
+    ]
+}

--- a/fixtures/feature_flag/test-early-exit-property-mismatch.json
+++ b/fixtures/feature_flag/test-early-exit-property-mismatch.json
@@ -1,0 +1,29 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "flags": [
+        {
+            "id": 801,
+            "name": "Early Exit Property Mismatch Flag",
+            "key": "early-exit-property-mismatch-flag",
+            "filters": {
+                "early_exit": true,
+                "groups": [
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "Canada", "operator": "exact"}],
+                        "rollout_percentage": 0
+                    },
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 100
+                    }
+                ]
+            },
+            "deleted": false,
+            "active": true,
+            "is_simple_flag": false,
+            "rollout_percentage": null
+        }
+    ]
+}

--- a/fixtures/feature_flag/test-early-exit-unset.json
+++ b/fixtures/feature_flag/test-early-exit-unset.json
@@ -1,0 +1,28 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "flags": [
+        {
+            "id": 802,
+            "name": "Early Exit Unset Flag",
+            "key": "early-exit-flag",
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 0
+                    },
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 100
+                    }
+                ]
+            },
+            "deleted": false,
+            "active": true,
+            "is_simple_flag": false,
+            "rollout_percentage": null
+        }
+    ]
+}

--- a/fixtures/feature_flag/test-early-exit.json
+++ b/fixtures/feature_flag/test-early-exit.json
@@ -1,0 +1,29 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "flags": [
+        {
+            "id": 800,
+            "name": "Early Exit Flag",
+            "key": "early-exit-flag",
+            "filters": {
+                "early_exit": true,
+                "groups": [
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 0
+                    },
+                    {
+                        "properties": [{"key": "region", "type": "person", "value": "USA", "operator": "exact"}],
+                        "rollout_percentage": 100
+                    }
+                ]
+            },
+            "deleted": false,
+            "active": true,
+            "is_simple_flag": false,
+            "rollout_percentage": null
+        }
+    ]
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog added an "early exit" option to feature flags server-side (the Rust evaluation engine). When a flag's `filters.early_exit` is `true`, local condition evaluation must STOP and return a definitive disabled result as soon as a condition group's property filters match (or the group has no property filters) but the rollout percentage EXCLUDES the user — instead of falling through to evaluate later condition groups.

This was already ported to posthog-node and posthog-python. This PR ports the same behavior to the Go SDK's local evaluation.

### What changed

- Added an `EarlyExit bool` field (JSON tag `early_exit`) to the `Filter` struct.
- Refactored `isConditionMatch` to return a tri-state result (`conditionMatch` / `conditionNoMatch` / `conditionOutOfRolloutBound`) instead of a bare bool, so the rollout-exclusion path is distinguishable from a property mismatch. This mirrors the Python port's `MATCH` / `NO_MATCH` / `OUT_OF_ROLLOUT_BOUND` enum.
- In `matchFeatureFlagProperties`, when a group's outcome is `conditionOutOfRolloutBound` AND `filters.early_exit` is enabled, evaluation returns a definitive `false` immediately. Property mismatches (`conditionNoMatch`) always fall through, even with early_exit on. Behaviour is unchanged when `early_exit` is absent or `false`.

The change is intentionally minimal and focused on `early_exit`; no dependencies, workflows, or CODEOWNERS were touched.

## :green_heart: How did you test it?

Added a table-driven test `TestFeatureFlagEarlyExit` (in `feature_flags_local_test.go`) backed by four local-evaluation fixtures. Each fixture defines two condition groups that both match on `region=USA`: the first with `rollout_percentage: 0` (always out of rollout bound) and the second with `rollout_percentage: 100` (always in rollout). The cases cover:

1. `early_exit: true` → returns `false` WITHOUT evaluating the later group that would match.
2. `early_exit` unset → falls through to the later matching group (regression, `true`).
3. `early_exit: false` → falls through (`true`).
4. `early_exit: true` but the first group fails on a PROPERTY filter (not rollout) → does NOT early-exit, falls through to the matching group (`true`).

`go build ./...`, `go vet ./...`, `gofmt -l` (clean), and the full `go test ./...` suite all pass locally.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a `## Unreleased` entry to `CHANGELOG.md` describing the change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
