### PR TITLE
ci: add public API check canary

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -20,6 +20,9 @@ func NewProperties() Properties {
 	return newStringInterfaceMap[Properties]()
 }
 
+// PublicAPICanary is a temporary exported symbol used to verify the public API check.
+func PublicAPICanary() {}
+
 func newStringInterfaceMap[M ~map[string]interface{}]() M {
 	return make(M, 10)
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

This intentionally adds a temporary exported public API symbol without updating `api/public-api.txt`.

The goal is to verify the public API snapshot check added in #220 fails when the baseline is not patched.


## :green_heart: How did you test it?

- `go test ./...` passes
- `make api-diff` fails as expected and reports `func PublicAPICanary()` missing from `api/public-api.txt`


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
