### PR TITLE
fix: Stop sending ignored capture fields

### DIFF
--- a/.changeset/clean-capture-fields.md
+++ b/.changeset/clean-capture-fields.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Stop sending ignored top-level capture fields and rely on canonical event properties.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -191,16 +191,16 @@ func (msg Capture) APIfy() APIMessage
 func (msg Capture) Validate() error
 
 type CaptureInApi struct {
-	Type string `json:"type"`
+	Type string `json:"-"`
 	Uuid string `json:"uuid"`
-	Library string `json:"library"`
-	LibraryVersion string `json:"library_version"`
+	Library string `json:"-"`
+	LibraryVersion string `json:"-"`
 	Timestamp time.Time `json:"timestamp"`
 
 	DistinctId string `json:"distinct_id"`
 	Event string `json:"event"`
 	Properties Properties `json:"properties"`
-	SendFeatureFlags SendFeatureFlagsValue `json:"send_feature_flags"`
+	SendFeatureFlags SendFeatureFlagsValue `json:"-"`
 }
 
 type Client interface {

--- a/capture.go
+++ b/capture.go
@@ -84,6 +84,8 @@ var _ Message = (*Capture)(nil)
 // the event for a future batch upload.
 type Capture struct {
 	// Type is reserved for SDK serialization and is overwritten by Enqueue.
+	// Deprecated: PostHog ignores the top-level type field on capture events. Use Event for
+	// the captured event name.
 	Type string
 	// Uuid is an optional event UUID. If empty, Enqueue generates a random UUID.
 	// Set it only when you need idempotency, for example to prevent duplicate events.
@@ -102,6 +104,7 @@ type Capture struct {
 	Groups Groups
 	// SendFeatureFlags requests legacy feature flag enrichment on this event.
 	// Deprecated: Prefer Client.EvaluateFlags and pass the returned snapshot via Flags.
+	// Flags writes the canonical $feature/<key> and $active_feature_flags properties.
 	SendFeatureFlags SendFeatureFlagsValue
 	// Flags, when set, attaches $feature/<key> and $active_feature_flags
 	// properties from a snapshot returned by Client.EvaluateFlags. It is
@@ -130,13 +133,17 @@ func validateCaptureEvent(msg Capture) error {
 
 // CaptureInApi is the wire-format payload produced from a Capture message.
 type CaptureInApi struct {
-	// Type is the message type sent to the batch API.
+	// Type is the legacy message discriminator sent to the batch API.
+	// Deprecated: PostHog ignores this top-level field for capture events. Use Event
+	// for the captured event name.
 	Type string `json:"type"`
 	// Uuid is the event UUID sent to the batch API.
 	Uuid string `json:"uuid"`
-	// Library is the SDK name sent to the batch API.
+	// Library is the legacy top-level SDK name sent to the batch API.
+	// Deprecated: PostHog reads SDK identity from Properties["$lib"].
 	Library string `json:"library"`
-	// LibraryVersion is the SDK version sent to the batch API.
+	// LibraryVersion is the legacy top-level SDK version sent to the batch API.
+	// Deprecated: PostHog reads SDK version from Properties["$lib_version"].
 	LibraryVersion string `json:"library_version"`
 	// Timestamp is the event timestamp sent to the batch API.
 	Timestamp time.Time `json:"timestamp"`
@@ -148,6 +155,8 @@ type CaptureInApi struct {
 	// Properties contains event, SDK, system, group, and feature flag properties.
 	Properties Properties `json:"properties"`
 	// SendFeatureFlags carries the legacy send_feature_flags value for compatibility.
+	// Deprecated: PostHog ignores this top-level field. Use Capture.Flags to send
+	// the canonical $feature/<key> and $active_feature_flags properties.
 	SendFeatureFlags SendFeatureFlagsValue `json:"send_feature_flags"`
 }
 

--- a/capture.go
+++ b/capture.go
@@ -133,18 +133,20 @@ func validateCaptureEvent(msg Capture) error {
 
 // CaptureInApi is the wire-format payload produced from a Capture message.
 type CaptureInApi struct {
-	// Type is the legacy message discriminator sent to the batch API.
-	// Deprecated: PostHog ignores this top-level field for capture events. Use Event
-	// for the captured event name.
-	Type string `json:"type"`
+	// Type is the legacy message discriminator retained for callbacks.
+	// Deprecated: PostHog ignores this top-level field for capture events, so it
+	// is no longer serialized. Use Event for the captured event name.
+	Type string `json:"-"`
 	// Uuid is the event UUID sent to the batch API.
 	Uuid string `json:"uuid"`
-	// Library is the legacy top-level SDK name sent to the batch API.
-	// Deprecated: PostHog reads SDK identity from Properties["$lib"].
-	Library string `json:"library"`
-	// LibraryVersion is the legacy top-level SDK version sent to the batch API.
-	// Deprecated: PostHog reads SDK version from Properties["$lib_version"].
-	LibraryVersion string `json:"library_version"`
+	// Library is the legacy top-level SDK name retained for callbacks.
+	// Deprecated: PostHog reads SDK identity from Properties["$lib"], so this
+	// top-level field is no longer serialized.
+	Library string `json:"-"`
+	// LibraryVersion is the legacy top-level SDK version retained for callbacks.
+	// Deprecated: PostHog reads SDK version from Properties["$lib_version"], so
+	// this top-level field is no longer serialized.
+	LibraryVersion string `json:"-"`
 	// Timestamp is the event timestamp sent to the batch API.
 	Timestamp time.Time `json:"timestamp"`
 
@@ -154,10 +156,11 @@ type CaptureInApi struct {
 	Event string `json:"event"`
 	// Properties contains event, SDK, system, group, and feature flag properties.
 	Properties Properties `json:"properties"`
-	// SendFeatureFlags carries the legacy send_feature_flags value for compatibility.
-	// Deprecated: PostHog ignores this top-level field. Use Capture.Flags to send
-	// the canonical $feature/<key> and $active_feature_flags properties.
-	SendFeatureFlags SendFeatureFlagsValue `json:"send_feature_flags"`
+	// SendFeatureFlags carries the legacy send_feature_flags value for callbacks.
+	// Deprecated: PostHog ignores this top-level field, so it is no longer
+	// serialized. Use Capture.Flags to send the canonical $feature/<key> and
+	// $active_feature_flags properties.
+	SendFeatureFlags SendFeatureFlagsValue `json:"-"`
 }
 
 // APIfy converts a Capture message into the PostHog batch API representation.

--- a/capture_test.go
+++ b/capture_test.go
@@ -31,11 +31,18 @@ func TestCaptureAPIfyUsesCanonicalLibraryProperties(t *testing.T) {
 		t.Fatalf("expected CaptureInApi, got %T", apiMsg)
 	}
 
-	if got := apiMsg.Properties["$lib"]; got != SDKName {
-		t.Errorf("$lib: got %v, want %s", got, SDKName)
-	}
-	if got := apiMsg.Properties["$lib_version"]; got != getVersion() {
-		t.Errorf("$lib_version: got %v, want %s", got, getVersion())
+	for _, tt := range []struct {
+		key  string
+		want interface{}
+	}{
+		{key: "$lib", want: SDKName},
+		{key: "$lib_version", want: getVersion()},
+	} {
+		t.Run(tt.key, func(t *testing.T) {
+			if got := apiMsg.Properties[tt.key]; got != tt.want {
+				t.Errorf("%s: got %v, want %v", tt.key, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/capture_test.go
+++ b/capture_test.go
@@ -1,6 +1,9 @@
 package posthog
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestCaptureMissingEvent(t *testing.T) {
 	assertFieldError(t, Capture{DistinctId: "1"}, fieldError("posthog.Capture", "Event"))
@@ -32,6 +35,42 @@ func TestCaptureAPIfyUsesCanonicalLibraryProperties(t *testing.T) {
 		t.Errorf("$lib: got %v, want %s", got, SDKName)
 	}
 	if got := apiMsg.Properties["$lib_version"]; got != getVersion() {
+		t.Errorf("$lib_version: got %v, want %s", got, getVersion())
+	}
+}
+
+func TestCaptureAPIfyOmitsIgnoredTopLevelFieldsFromJSON(t *testing.T) {
+	apiMsg := Capture{
+		Type:             "capture",
+		Event:            "test-event",
+		DistinctId:       "user-123",
+		SendFeatureFlags: SendFeatureFlags(true),
+	}.APIfy()
+
+	data, err := json.Marshal(apiMsg)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var wire map[string]interface{}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	for _, key := range []string{"type", "library", "library_version", "send_feature_flags"} {
+		if _, ok := wire[key]; ok {
+			t.Errorf("%s should not be serialized on capture events", key)
+		}
+	}
+
+	props, ok := wire["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("properties field missing or wrong type")
+	}
+	if got := props["$lib"]; got != SDKName {
+		t.Errorf("$lib: got %v, want %s", got, SDKName)
+	}
+	if got := props["$lib_version"]; got != getVersion() {
 		t.Errorf("$lib_version: got %v, want %s", got, getVersion())
 	}
 }

--- a/capture_test.go
+++ b/capture_test.go
@@ -21,3 +21,17 @@ func TestCaptureAPIfyIncludesIsServerProperty(t *testing.T) {
 func TestCaptureAPIfyOmitsIsServerWhenFalse(t *testing.T) {
 	assertIsServerProperty(t, Capture{Event: "test-event", DistinctId: "user-123", IsServer: false}.APIfy(), false)
 }
+
+func TestCaptureAPIfyUsesCanonicalLibraryProperties(t *testing.T) {
+	apiMsg, ok := Capture{Event: "test-event", DistinctId: "user-123"}.APIfy().(CaptureInApi)
+	if !ok {
+		t.Fatalf("expected CaptureInApi, got %T", apiMsg)
+	}
+
+	if got := apiMsg.Properties["$lib"]; got != SDKName {
+		t.Errorf("$lib: got %v, want %s", got, SDKName)
+	}
+	if got := apiMsg.Properties["$lib_version"]; got != getVersion() {
+		t.Errorf("$lib_version: got %v, want %s", got, getVersion())
+	}
+}

--- a/fixtures/test-enqueue-capture-with-disable-geoip.json
+++ b/fixtures/test-enqueue-capture-with-disable-geoip.json
@@ -4,8 +4,6 @@
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -18,9 +16,7 @@
         "application": "PostHog Go",
         "version": "1.0.0"
       },
-      "send_feature_flags": false,
       "timestamp": "2009-11-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000011"
     }
   ]

--- a/fixtures/test-enqueue-capture-with-uuid.json
+++ b/fixtures/test-enqueue-capture-with-uuid.json
@@ -4,8 +4,6 @@
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -18,9 +16,7 @@
         "application": "PostHog Go",
         "version": "1.0.0"
       },
-      "send_feature_flags": false,
       "timestamp": "2009-11-10T23:00:00Z",
-      "type": "capture",
       "uuid": "11111111-1111-1111-1111-111111111111"
     }
   ]

--- a/fixtures/test-enqueue-capture.json
+++ b/fixtures/test-enqueue-capture.json
@@ -4,8 +4,6 @@
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$lib": "posthog-go",
         "$lib_version": "1.0.0",
@@ -17,9 +15,7 @@
         "application": "PostHog Go",
         "version": "1.0.0"
       },
-      "send_feature_flags": false,
       "timestamp": "2009-11-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000010"
     }
   ]

--- a/fixtures/test-interval-capture.json
+++ b/fixtures/test-interval-capture.json
@@ -4,8 +4,6 @@
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -18,9 +16,7 @@
         "application": "PostHog Go",
         "version": "1.0.0"
       },
-      "send_feature_flags": false,
       "timestamp": "2009-11-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000012"
     }
   ]

--- a/fixtures/test-many-capture.json
+++ b/fixtures/test-many-capture.json
@@ -4,8 +4,6 @@
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -18,16 +16,12 @@
         "application": "PostHog Go",
         "version": 0
       },
-      "send_feature_flags": false,
       "timestamp": "2009-11-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000015"
     },
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -40,16 +34,12 @@
         "application": "PostHog Go",
         "version": 1
       },
-      "send_feature_flags": false,
       "timestamp": "2009-11-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000016"
     },
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -62,9 +52,7 @@
         "application": "PostHog Go",
         "version": 2
       },
-      "send_feature_flags": false,
       "timestamp": "2009-11-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000017"
     }
   ]

--- a/fixtures/test-merge-capture.json
+++ b/fixtures/test-merge-capture.json
@@ -4,8 +4,6 @@
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -19,9 +17,7 @@
         "service": "api",
         "version": "1.0.0"
       },
-      "send_feature_flags": false,
       "timestamp": "2015-07-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000014"
     }
   ]

--- a/fixtures/test-timestamp-capture.json
+++ b/fixtures/test-timestamp-capture.json
@@ -4,8 +4,6 @@
     {
       "distinct_id": "123456",
       "event": "Download",
-      "library": "posthog-go",
-      "library_version": "1.0.0",
       "properties": {
         "$geoip_disable": true,
         "$lib": "posthog-go",
@@ -18,9 +16,7 @@
         "application": "PostHog Go",
         "version": "1.0.0"
       },
-      "send_feature_flags": false,
       "timestamp": "2015-07-10T23:00:00Z",
-      "type": "capture",
       "uuid": "00000000-0000-0000-0000-000000000013"
     }
   ]

--- a/message.go
+++ b/message.go
@@ -70,6 +70,10 @@ type batch struct {
 }
 
 // APIMessage is a wire-format message produced by Message.APIfy and passed to callbacks.
+// Legacy API message structs may still expose top-level fields such as type,
+// library, library_version, and send_feature_flags for compatibility. Capture
+// ingestion uses event plus properties such as $lib, $lib_version,
+// $feature/<key>, and $active_feature_flags instead.
 type APIMessage interface{}
 
 // prepareForSend creates the API message and serializes it to JSON.

--- a/stress_test.go
+++ b/stress_test.go
@@ -189,7 +189,11 @@ func TestStress_CardinalityDistribution(t *testing.T) {
 
 			client, err := NewWithConfig("test-key", Config{
 				Endpoint: server.URL,
-				// Uses production defaults for BatchSize, MaxEnqueuedRequests
+				// The race detector can make large high-cardinality batches slow enough
+				// to hit the production 100ms submit timeout on CI. This test is about
+				// cardinality handling, not queue backpressure, so allow extra time for
+				// workers to dequeue batches.
+				BatchSubmitTimeout: 5 * time.Second,
 			})
 			require.NoError(t, err)
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Capture payloads still exposed legacy top-level fields (`type`, `library`, `library_version`, and `send_feature_flags`) that the backend ignores for captured events. This removes those fields from serialized capture JSON while keeping the exported `CaptureInApi` fields populated for callback compatibility.

The SDK already normalizes SDK identity into the canonical event properties (`$lib` and `$lib_version`), and feature flag enrichment continues to use the canonical `$feature/<key>` and `$active_feature_flags` properties.

## :green_heart: How did you test it?

- `go test ./...`
- `go test -race -count=1 -timeout=5m ./...`
- `make api-diff`
- `pnpm changeset status --since main`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent cross-checked the Go SDK fields against the PostHog capture backend and confirmed that backend ingestion relies on the canonical event/properties shape rather than the legacy top-level capture fields. The change now stops serializing the ignored fields, keeps callback compatibility, and updates fixtures/tests to lock in the normalized payload shape.

Review feedback was addressed by making the canonical property assertion table-driven. The race-test failure was in a high-cardinality stress test hitting the production 100ms batch submit timeout under race-detector overhead on CI; the test now uses a longer submit timeout because it is validating cardinality handling rather than queue backpressure.
