### PR TITLE
chore: Template SDK version in API snapshot

### DIFF
--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -61,7 +61,7 @@ const (
 	HeaderPostHogDistinctID = "X-PostHog-Distinct-Id"
 	HeaderPostHogSessionID = "X-PostHog-Session-Id"
 )
-const Version = "1.15.0"
+const Version = "<version>"
 
 
 VARIABLES

--- a/bin/api-diff
+++ b/bin/api-diff
@@ -49,7 +49,7 @@ trap cleanup EXIT
                 awk '!/^[[:space:]]*\/\// && !/^    /'
             echo
         done
-} > "$tmp_file"
+} | sed -E 's/^(const Version = )"[^"]+"$/\1"<version>"/' > "$tmp_file"
 
 if $update; then
     mkdir -p "$(dirname "$snapshot_file")"


### PR DESCRIPTION
## :bulb: Motivation and Context

The public API snapshot includes the SDK `Version` constant, so release-only version bumps can make `bin/api-diff` fail for both older and newer released versions even when the public API shape has not changed.

This normalizes the SDK version in the generated snapshot to a stable `<version>` placeholder.

## :green_heart: How did you test it?

- [x] `bin/api-diff`
- [x] `make api-diff`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi using shell/read/edit tools. The snapshot now uses `<version>` for the SDK version constant, and `bin/api-diff` applies the same normalization to generated output before diffing or updating the snapshot.
