### PR TITLE
fix: Dedupe feature flag called events by response

### DIFF
--- a/.changeset/quiet-flags-dedupe.md
+++ b/.changeset/quiet-flags-dedupe.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Dedupe `$feature_flag_called` events by feature flag response value.

--- a/feature_flag_evaluations.go
+++ b/feature_flag_evaluations.go
@@ -56,7 +56,7 @@ type evaluatedFlagRecord struct {
 // the SDK's Logger; users who want them silenced should pass a Logger that
 // drops Warnf calls.
 type featureFlagEvaluationsHost struct {
-	captureFlagCalledIfNeeded func(distinctId, key string, deviceId *string, properties Properties, groups Groups)
+	captureFlagCalledIfNeeded func(distinctId, key string, featureFlagResponse interface{}, deviceId *string, properties Properties, groups Groups)
 	logger                    Logger
 }
 
@@ -296,7 +296,7 @@ func (e *FeatureFlagEvaluations) recordAccess(key string) {
 	if alreadyAccessed {
 		return
 	}
-	e.host.captureFlagCalledIfNeeded(e.distinctId, key, e.deviceId, properties, e.groups)
+	e.host.captureFlagCalledIfNeeded(e.distinctId, key, response, e.deviceId, properties, e.groups)
 }
 
 // cloneWith builds a child snapshot with the given flag set. The accessed set

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -743,6 +743,7 @@ func TestCaptureFlagCalled_DedupesByFlagValue(t *testing.T) {
 				cli.captureFlagCalledIfNeeded(
 					"user-1",
 					"changing-flag",
+					tc.response,
 					nil,
 					NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", tc.response),
 					nil,

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -720,6 +720,52 @@ func TestRefactor_LegacyAndSnapshotPathsDedupeIdentically(t *testing.T) {
 	}
 }
 
+func TestCaptureFlagCalled_DedupesByFlagValue(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+
+	clientIface, capture, _ := newEvalClient(t, fs.server)
+	cli := clientIface.(*client)
+
+	cli.captureFlagCalledIfNeeded(
+		"user-1",
+		"changing-flag",
+		nil,
+		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", true),
+		nil,
+	)
+	cli.captureFlagCalledIfNeeded(
+		"user-1",
+		"changing-flag",
+		nil,
+		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", false),
+		nil,
+	)
+	cli.captureFlagCalledIfNeeded(
+		"user-1",
+		"changing-flag",
+		nil,
+		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", true),
+		nil,
+	)
+	cli.captureFlagCalledIfNeeded(
+		"user-1",
+		"changing-flag",
+		nil,
+		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", false),
+		nil,
+	)
+
+	_ = waitForEventCount(capture, 2, 5*time.Second)
+	time.Sleep(150 * time.Millisecond)
+	events := snapshotCapturedEvents(capture)
+
+	count := countFlagCalledEvents(events, "changing-flag")
+	if count != 2 {
+		t.Fatalf("expected exactly 2 $feature_flag_called events (true and false), got %d", count)
+	}
+}
+
 func TestCaptureFlagCalled_FiresPerGroupContext(t *testing.T) {
 	t.Parallel()
 	fs := newFlagsServer(t, "test-flags-v4.json")

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -727,42 +727,37 @@ func TestCaptureFlagCalled_DedupesByFlagValue(t *testing.T) {
 	clientIface, capture, _ := newEvalClient(t, fs.server)
 	cli := clientIface.(*client)
 
-	cli.captureFlagCalledIfNeeded(
-		"user-1",
-		"changing-flag",
-		nil,
-		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", true),
-		nil,
-	)
-	cli.captureFlagCalledIfNeeded(
-		"user-1",
-		"changing-flag",
-		nil,
-		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", false),
-		nil,
-	)
-	cli.captureFlagCalledIfNeeded(
-		"user-1",
-		"changing-flag",
-		nil,
-		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", true),
-		nil,
-	)
-	cli.captureFlagCalledIfNeeded(
-		"user-1",
-		"changing-flag",
-		nil,
-		NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", false),
-		nil,
-	)
+	testCases := []struct {
+		name     string
+		response interface{}
+	}{
+		{name: "bool true", response: true},
+		{name: "bool false", response: false},
+		{name: "string variant", response: "variant-a"},
+		{name: "nil", response: nil},
+	}
 
-	_ = waitForEventCount(capture, 2, 5*time.Second)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < 2; i++ {
+				cli.captureFlagCalledIfNeeded(
+					"user-1",
+					"changing-flag",
+					nil,
+					NewProperties().Set("$feature_flag", "changing-flag").Set("$feature_flag_response", tc.response),
+					nil,
+				)
+			}
+		})
+	}
+
+	_ = waitForEventCount(capture, len(testCases), 5*time.Second)
 	time.Sleep(150 * time.Millisecond)
 	events := snapshotCapturedEvents(capture)
 
 	count := countFlagCalledEvents(events, "changing-flag")
-	if count != 2 {
-		t.Fatalf("expected exactly 2 $feature_flag_called events (true and false), got %d", count)
+	if count != len(testCases) {
+		t.Fatalf("expected exactly %d $feature_flag_called events (one per response value), got %d", len(testCases), count)
 	}
 }
 

--- a/posthog.go
+++ b/posthog.go
@@ -900,7 +900,7 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 			properties.Set("$feature_flag_error", errorString)
 		}
 
-		c.captureFlagCalledIfNeeded(flagConfig.DistinctId, flagConfig.Key, flagConfig.DeviceId, properties, flagConfig.Groups)
+		c.captureFlagCalledIfNeeded(flagConfig.DistinctId, flagConfig.Key, flagValue, flagConfig.DeviceId, properties, flagConfig.Groups)
 	}
 
 	if flagValue == nil {
@@ -946,11 +946,11 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 // dedup and enqueue. It is shared by the legacy per-flag evaluation path and
 // the FeatureFlagEvaluations snapshot path so both dedupe identically against
 // the same per-distinct_id LRU cache.
-func (c *client) captureFlagCalledIfNeeded(distinctId, key string, deviceId *string, properties Properties, groups Groups) {
-	c.captureFlagCalledIfNeededWithContext(context.Background(), distinctId, key, deviceId, properties, groups)
+func (c *client) captureFlagCalledIfNeeded(distinctId, key string, featureFlagResponse interface{}, deviceId *string, properties Properties, groups Groups) {
+	c.captureFlagCalledIfNeededWithContext(context.Background(), distinctId, key, featureFlagResponse, deviceId, properties, groups)
 }
 
-func (c *client) captureFlagCalledIfNeededWithContext(ctx context.Context, distinctId, key string, deviceId *string, properties Properties, groups Groups) {
+func (c *client) captureFlagCalledIfNeededWithContext(ctx context.Context, distinctId, key string, featureFlagResponse interface{}, deviceId *string, properties Properties, groups Groups) {
 	deviceIDStr := ""
 	if deviceId != nil {
 		deviceIDStr = *deviceId
@@ -958,7 +958,7 @@ func (c *client) captureFlagCalledIfNeededWithContext(ctx context.Context, disti
 	cacheKey := flagUser{
 		distinctID: distinctId,
 		flagKey:    key,
-		flagValue:  featureFlagResponseCacheKey(properties["$feature_flag_response"]),
+		flagValue:  featureFlagResponseCacheKey(featureFlagResponse),
 		deviceID:   deviceIDStr,
 		groupsRepr: canonicalGroupsRepr(groups),
 	}
@@ -1305,8 +1305,8 @@ func ptrString(s string) *string { return &s }
 // featureFlagEvaluationsHostWithContext wires the snapshot's callbacks to this client.
 func (c *client) featureFlagEvaluationsHostWithContext(ctx context.Context) featureFlagEvaluationsHost {
 	return featureFlagEvaluationsHost{
-		captureFlagCalledIfNeeded: func(distinctId, key string, deviceId *string, properties Properties, groups Groups) {
-			c.captureFlagCalledIfNeededWithContext(ctx, distinctId, key, deviceId, properties, groups)
+		captureFlagCalledIfNeeded: func(distinctId, key string, featureFlagResponse interface{}, deviceId *string, properties Properties, groups Groups) {
+			c.captureFlagCalledIfNeededWithContext(ctx, distinctId, key, featureFlagResponse, deviceId, properties, groups)
 		},
 		logger: c.Logger,
 	}

--- a/posthog.go
+++ b/posthog.go
@@ -975,14 +975,16 @@ func (c *client) captureFlagCalledIfNeededWithContext(ctx context.Context, disti
 	}
 }
 
-// canonicalGroupsRepr returns a JSON string of the sorted key/value pairs of
-// the groups map. Two equal maps that were built with keys inserted in a
-// different order produce the same string, so they dedupe to one cache entry.
-// Empty / nil groups produce an empty string.
+// featureFlagResponseCacheKey returns a stable type-qualified representation
+// of a feature flag response value for exposure deduplication.
 func featureFlagResponseCacheKey(value interface{}) string {
 	return fmt.Sprintf("%T:%v", value, value)
 }
 
+// canonicalGroupsRepr returns a JSON string of the sorted key/value pairs of
+// the groups map. Two equal maps that were built with keys inserted in a
+// different order produce the same string, so they dedupe to one cache entry.
+// Empty / nil groups produce an empty string.
 func canonicalGroupsRepr(groups Groups) string {
 	if len(groups) == 0 {
 		return ""
@@ -1353,8 +1355,6 @@ func (c *client) CloseWithContext(ctx context.Context) error {
 			// Wait for shutdown to acknowledge cancellation
 			<-c.shutdown
 		}
-
-		c.distinctIdsFeatureFlagsReported.Purge()
 	})
 
 	if alreadyClosed {

--- a/posthog.go
+++ b/posthog.go
@@ -191,9 +191,10 @@ type client struct {
 type flagUser struct {
 	distinctID string
 	flagKey    string
+	flagValue  string
 	deviceID   string
 	// canonical JSON of the groups map (keys sorted) — empty when no groups
-	// were passed. Lets the same `(user, flag)` fire a separate
+	// were passed. Lets the same `(user, flag, value)` fire a separate
 	// `$feature_flag_called` event for each distinct group context, so
 	// group-scoped flags don't undercount exposures when a user is evaluated
 	// under multiple groups in the same process.
@@ -938,8 +939,8 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 }
 
 // captureFlagCalledIfNeeded fires a $feature_flag_called event if the
-// (distinctId, key, deviceId, groups) tuple has not already been reported on
-// this client. Group context is included so group-scoped flags fire a
+// (distinctId, key, value, deviceId, groups) tuple has not already been reported
+// on this client. Group context is included so group-scoped flags fire a
 // separate event for each group a user is evaluated under. The caller is
 // responsible for building the full properties dict; this helper only handles
 // dedup and enqueue. It is shared by the legacy per-flag evaluation path and
@@ -957,6 +958,7 @@ func (c *client) captureFlagCalledIfNeededWithContext(ctx context.Context, disti
 	cacheKey := flagUser{
 		distinctID: distinctId,
 		flagKey:    key,
+		flagValue:  featureFlagResponseCacheKey(properties["$feature_flag_response"]),
 		deviceID:   deviceIDStr,
 		groupsRepr: canonicalGroupsRepr(groups),
 	}
@@ -977,6 +979,10 @@ func (c *client) captureFlagCalledIfNeededWithContext(ctx context.Context, disti
 // the groups map. Two equal maps that were built with keys inserted in a
 // different order produce the same string, so they dedupe to one cache entry.
 // Empty / nil groups produce an empty string.
+func featureFlagResponseCacheKey(value interface{}) string {
+	return fmt.Sprintf("%T:%v", value, value)
+}
+
 func canonicalGroupsRepr(groups Groups) string {
 	if len(groups) == 0 {
 		return ""
@@ -1347,6 +1353,8 @@ func (c *client) CloseWithContext(ctx context.Context) error {
 			// Wait for shutdown to acknowledge cancellation
 			<-c.shutdown
 		}
+
+		c.distinctIdsFeatureFlagsReported.Purge()
 	})
 
 	if alreadyClosed {


### PR DESCRIPTION
## :bulb: Motivation and Context
`$feature_flag_called` events were deduped only by user, flag, device, and group context. If the same user saw the same flag with different response values in one client process, later exposures could be suppressed incorrectly.

This change includes the feature flag response value in the dedupe cache key so exposures are tracked separately per returned value, while preserving existing device and group-context dedupe behavior.

## :green_heart: How did you test it?
- `go test ./...`
- `pnpm changeset status --since=origin/main` (failed locally because `node_modules` is not installed; changeset file is included)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Changeset file included for this patch fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent helped prepare this human-directed PR from the existing `fix/ff-called-value-dedupe` worktree. The agent inspected the diff, added the required patch changeset, ran Go tests, committed, pushed, and opened this draft PR for human review.
