### PR TITLE
feat(capture): route capture between legacy and v1 via CaptureMode

### DIFF
--- a/.changeset/capture-v1-typed-errors.md
+++ b/.changeset/capture-v1-typed-errors.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Enrich capture-v1 failure reporting with typed errors and verbose result logging. When `CaptureMode` is `CaptureModeAnalyticsV1`, `Callback.Failure` now receives either a `*CaptureEventError` (a single event the server dropped, or one still asking to retry once attempts are exhausted — exposing `EventUUID`, `Result`, `Details`, and `Exhausted`) or a `*CaptureRequestError` (a whole request that failed on a non-2xx status, transport error, or malformed body — exposing `StatusCode`, `Code`, `Description`, and unwrapping to the underlying error). Inspect them with `errors.As`. Additionally, with `Verbose: true` the SDK logs one debug line per 2xx response summarizing the per-event directive counts (ok/warning/drop/retry/other) so partial-submission outcomes are easy to debug. The legacy path and its callback errors are unchanged.

--- a/.changeset/opt-in-capture-v1.md
+++ b/.changeset/opt-in-capture-v1.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Add opt-in capture-v1 support via a new `Config.CaptureMode` option. It defaults to `CaptureModeLegacy` (the existing `POST /batch/` endpoint), so upgrading is transparent and requires no code changes. Set `CaptureMode: posthog.CaptureModeAnalyticsV1` to send events to `POST /i/v1/analytics/events` instead, which uses Bearer auth, per-event delivery results, and partial retry (only the events the server asks to retry are re-sent). For v1, the `Callback` interface is unchanged but outcomes become per-event: a `drop` result fails an individual event (and can fire `Failure` on an HTTP 200), `warning` counts as success, and a uuid missing from the results is silently dropped. All other configuration (host, API key, `Callback`, `Logger`, `MaxRetries`, `Compression`) is reused across both modes.

--- a/.changeset/v1-compression-codecs.md
+++ b/.changeset/v1-compression-codecs.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Add zstd, deflate, and brotli compression for the capture-v1 path, alongside the existing gzip. Select one via `Config.Compression` (`CompressionZstd`, `CompressionDeflate`, `CompressionBrotli`) and the SDK sets the matching `Content-Encoding` header (`zstd`, `deflate`, `br`). These three codecs require `CaptureMode: posthog.CaptureModeAnalyticsV1` — the legacy `POST /batch/` endpoint only understands gzip, so configuring them with `CaptureModeLegacy` returns a validation error. `CompressionGzip` and `CompressionNone` continue to work on both capture modes. All codecs use pure-Go libraries (stdlib `compress/zlib`, `github.com/klauspost/compress/zstd`, `github.com/andybalholm/brotli`), so `CGO_ENABLED=0` builds are unaffected.

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -13,9 +13,21 @@ on:
 
 jobs:
   compliance:
-    name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@39d05346c4638d24f94e591ab89c9c6fcdb52d6b
+    name: PostHog SDK compliance tests (capture v0)
+    # Pinned to the 0.8.0 tag (commit be8b8d5) of the reusable workflow + harness
+    # image so v0/v1 runs are reproducible and pick up the capture-v1 suites.
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "latest"
+      test-harness-version: "0.8.0"
+      report-name: "sdk-compliance-report-v0"
+
+  compliance-v1:
+    name: PostHog SDK compliance tests (capture v1)
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    with:
+      adapter-dockerfile: "sdk_compliance_adapter/Dockerfile.v1"
+      adapter-context: "."
+      test-harness-version: "0.8.0"
+      report-name: "sdk-compliance-report-v1"

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ examples/.env
 # Macos
 .DS_Store
 node_modules/
+
+# built compliance adapter binary
+sdk_compliance_adapter/sdk_compliance_adapter

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -254,7 +254,12 @@ type CompressionMode uint8
 const (
 	CompressionNone CompressionMode = 0
 	CompressionGzip CompressionMode = 1
+	CompressionZstd CompressionMode = 2
+	CompressionDeflate CompressionMode = 3
+	CompressionBrotli CompressionMode = 4
 )
+func (m CompressionMode) String() string
+
 type Config struct {
 
 	Endpoint string

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -193,6 +193,16 @@ func (msg Capture) APIfy() APIMessage
 
 func (msg Capture) Validate() error
 
+type CaptureEventError struct {
+	EventUUID string
+	Result string
+	Details string
+	Exhausted bool
+}
+
+
+func (e *CaptureEventError) Error() string
+
 type CaptureInApi struct {
 	Type string `json:"-"`
 	Uuid string `json:"uuid"`
@@ -212,6 +222,18 @@ const (
 	CaptureModeLegacy CaptureMode = 0
 	CaptureModeAnalyticsV1 CaptureMode = 1
 )
+type CaptureRequestError struct {
+	StatusCode int
+	Code string
+	Description string
+	Err error
+}
+
+
+func (e *CaptureRequestError) Error() string
+
+func (e *CaptureRequestError) Unwrap() error
+
 type Client interface {
 	EnqueueClient
 

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -206,6 +206,12 @@ type CaptureInApi struct {
 	SendFeatureFlags SendFeatureFlagsValue `json:"-"`
 }
 
+type CaptureMode uint8
+
+const (
+	CaptureModeLegacy CaptureMode = 0
+	CaptureModeAnalyticsV1 CaptureMode = 1
+)
 type Client interface {
 	EnqueueClient
 
@@ -296,6 +302,8 @@ type Config struct {
 	MaxEnqueuedRequests int
 
 	Compression CompressionMode
+
+	CaptureMode CaptureMode
 
 }
 

--- a/capture_v1_errors.go
+++ b/capture_v1_errors.go
@@ -1,0 +1,72 @@
+package posthog
+
+import "fmt"
+
+// CaptureEventError is delivered to Callback.Failure for a single event that the
+// capture-v1 endpoint rejected: either a terminal "drop" result, or an event
+// still asking to "retry" once the attempt budget is exhausted. Callers can use
+// errors.As to inspect the per-event outcome.
+//
+// This error type is produced exclusively on the 200-with-partial-results path —
+// when the batch-level HTTP exchange succeeds but individual events within the
+// batch are rejected or not persisted. It is never returned for batch-level
+// transport failures (use CaptureRequestError for those via errors.As).
+type CaptureEventError struct {
+	// EventUUID is the uuid of the rejected event (matches Capture.Uuid etc.).
+	EventUUID string
+	// Result is the server's per-event directive, e.g. "drop" or "retry".
+	Result string
+	// Details is the server-supplied explanation, when present (may be empty).
+	Details string
+	// Exhausted is true when the event was still retryable but the SDK ran out
+	// of attempts, false for a server-directed terminal drop.
+	Exhausted bool
+}
+
+func (e *CaptureEventError) Error() string {
+	if e.Exhausted {
+		if e.Details != "" {
+			return fmt.Sprintf("capture event %s not persisted after retries: %s (%s)", e.EventUUID, e.Result, e.Details)
+		}
+		return fmt.Sprintf("capture event %s not persisted after retries: %s", e.EventUUID, e.Result)
+	}
+	if e.Details != "" {
+		return fmt.Sprintf("capture event %s: %s (%s)", e.EventUUID, e.Result, e.Details)
+	}
+	return fmt.Sprintf("capture event %s: %s", e.EventUUID, e.Result)
+}
+
+// CaptureRequestError is delivered to Callback.Failure when an entire capture-v1
+// request fails: a non-2xx status, a transport error, or a malformed 2xx body.
+// It carries the HTTP status and any structured error body the endpoint returned,
+// and unwraps to the underlying transport/parse error when there is one.
+//
+// This error type covers batch-level failures — transport errors, terminal HTTP
+// statuses (400/401/429/...), retryable statuses (5xx) whose retry budget is
+// exhausted, and 2xx responses with unparseable bodies. For per-event failures
+// within a successful batch response, see CaptureEventError.
+type CaptureRequestError struct {
+	// StatusCode is the HTTP status, or 0 if the request never got a response.
+	StatusCode int
+	// Code is the machine-readable error from the response body (may be empty).
+	Code string
+	// Description is the human-readable error from the response body (may be empty).
+	Description string
+	// Err is the underlying transport or body-parse error, if any.
+	Err error
+}
+
+func (e *CaptureRequestError) Error() string {
+	switch {
+	case e.Code != "" || e.Description != "":
+		return fmt.Sprintf("capture request failed: %d %s: %s", e.StatusCode, e.Code, e.Description)
+	case e.Err != nil && e.StatusCode != 0:
+		return fmt.Sprintf("capture request failed: %d: %s", e.StatusCode, e.Err)
+	case e.Err != nil:
+		return fmt.Sprintf("capture request failed: %s", e.Err)
+	default:
+		return fmt.Sprintf("capture request failed: %d", e.StatusCode)
+	}
+}
+
+func (e *CaptureRequestError) Unwrap() error { return e.Err }

--- a/capture_v1_errors_test.go
+++ b/capture_v1_errors_test.go
@@ -1,0 +1,192 @@
+package posthog
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestV1DropYieldsCaptureEventError(t *testing.T) {
+	cb := &recordingCallback{}
+	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+		details := "billing_limit_exceeded"
+		m := map[string]eventResult{uuids[0]: {Result: resultDrop, Details: &details}}
+		return http.StatusOK, resultsBody(t, m), ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	c := newV1TestClient(t, ts.URL, cb, 9, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var ee *CaptureEventError
+	if !errors.As(cb.failures[0].err, &ee) {
+		t.Fatalf("failure err = %T (%v), want *CaptureEventError", cb.failures[0].err, cb.failures[0].err)
+	}
+	if ee.EventUUID != uuidA || ee.Result != resultDrop || ee.Details != "billing_limit_exceeded" || ee.Exhausted {
+		t.Errorf("CaptureEventError = %+v", ee)
+	}
+}
+
+func TestV1ExhaustedRetryYieldsExhaustedEventError(t *testing.T) {
+	cb := &recordingCallback{}
+	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+		m := map[string]eventResult{uuids[0]: {Result: resultRetry}}
+		return http.StatusOK, resultsBody(t, m), ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	// maxRetries=0 => a single attempt, so the retry directive is never satisfied.
+	c := newV1TestClient(t, ts.URL, cb, 0, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var ee *CaptureEventError
+	if !errors.As(cb.failures[0].err, &ee) {
+		t.Fatalf("failure err = %T, want *CaptureEventError", cb.failures[0].err)
+	}
+	if !ee.Exhausted || ee.Result != resultRetry || ee.EventUUID != uuidA {
+		t.Errorf("CaptureEventError = %+v, want exhausted retry for %s", ee, uuidA)
+	}
+}
+
+func TestV1TerminalStatusYieldsRequestError(t *testing.T) {
+	cb := &recordingCallback{}
+	srv := &v1TestServer{respond: func(_ int, _ []string) (int, string, string) {
+		return http.StatusBadRequest, `{"error":"invalid_payload","error_description":"bad batch"}`, ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	c := newV1TestClient(t, ts.URL, cb, 9, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var re *CaptureRequestError
+	if !errors.As(cb.failures[0].err, &re) {
+		t.Fatalf("failure err = %T, want *CaptureRequestError", cb.failures[0].err)
+	}
+	if re.StatusCode != http.StatusBadRequest || re.Code != "invalid_payload" || re.Description != "bad batch" {
+		t.Errorf("CaptureRequestError = %+v", re)
+	}
+}
+
+func TestV1TransportErrorUnwraps(t *testing.T) {
+	cb := &recordingCallback{}
+	// Port 1 is unroutable; the POST fails at the transport layer.
+	c := newV1TestClient(t, "http://127.0.0.1:1", cb, 0, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var re *CaptureRequestError
+	if !errors.As(cb.failures[0].err, &re) {
+		t.Fatalf("failure err = %T, want *CaptureRequestError", cb.failures[0].err)
+	}
+	if re.StatusCode != 0 {
+		t.Errorf("StatusCode = %d, want 0 for transport error", re.StatusCode)
+	}
+	if errors.Unwrap(re) == nil {
+		t.Error("CaptureRequestError.Unwrap() = nil, want the underlying transport error")
+	}
+}
+
+// capturingLogger records Debugf format strings for assertions.
+type capturingLogger struct {
+	mu     sync.Mutex
+	debugf []string
+}
+
+func (l *capturingLogger) Debugf(f string, a ...interface{}) {
+	l.mu.Lock()
+	l.debugf = append(l.debugf, fmt.Sprintf(f, a...))
+	l.mu.Unlock()
+}
+func (l *capturingLogger) Logf(string, ...interface{})   {}
+func (l *capturingLogger) Warnf(string, ...interface{})  {}
+func (l *capturingLogger) Errorf(string, ...interface{}) {}
+
+func (l *capturingLogger) debugContains(sub string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, f := range l.debugf {
+		if strings.Contains(f, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestV1ResultSummaryLogged(t *testing.T) {
+	cb := &recordingCallback{}
+	log := &capturingLogger{}
+	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+		m := map[string]eventResult{}
+		for _, u := range uuids {
+			m[u] = eventResult{Result: resultOk}
+		}
+		return http.StatusOK, resultsBody(t, m), ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	c := newV1TestClient(t, ts.URL, cb, 9, func(cfg *Config) { cfg.Logger = log })
+	c.sendV1(v1Batch(t, cap1(uuidA), cap1(uuidB)))
+
+	if !log.debugContains("capture v1 response request_id=") {
+		t.Errorf("expected a per-response debug summary, got debugf=%v", log.debugf)
+	}
+}
+
+func TestCaptureEventErrorFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		err  CaptureEventError
+		want string
+	}{
+		{"drop_with_details", CaptureEventError{EventUUID: "u1", Result: "drop", Details: "billing"}, "capture event u1: drop (billing)"},
+		{"drop_no_details", CaptureEventError{EventUUID: "u2", Result: "drop"}, "capture event u2: drop"},
+		{"exhausted_with_details", CaptureEventError{EventUUID: "u3", Result: "retry", Details: "not_persisted", Exhausted: true}, "capture event u3 not persisted after retries: retry (not_persisted)"},
+		{"exhausted_no_details", CaptureEventError{EventUUID: "u4", Result: "retry", Exhausted: true}, "capture event u4 not persisted after retries: retry"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCaptureRequestErrorFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		err  CaptureRequestError
+		want string
+	}{
+		{"code_and_description", CaptureRequestError{StatusCode: 400, Code: "invalid_payload", Description: "bad shape"}, "capture request failed: 400 invalid_payload: bad shape"},
+		{"status_only", CaptureRequestError{StatusCode: 429}, "capture request failed: 429"},
+		{"err_with_status", CaptureRequestError{StatusCode: 502, Err: fmt.Errorf("connection reset")}, "capture request failed: 502: connection reset"},
+		{"err_no_status", CaptureRequestError{Err: fmt.Errorf("dial timeout")}, "capture request failed: dial timeout"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/capture_v1_integration_test.go
+++ b/capture_v1_integration_test.go
@@ -31,12 +31,12 @@ func TestV1ModeSelectionRoutesToV1Endpoint(t *testing.T) {
 	defer srv.Close()
 
 	cb := NewUnifiedCallback(t)
-	one := 0
+	zero := 0
 	c, err := NewWithConfig("phc_test", Config{
 		Endpoint:    srv.URL,
 		CaptureMode: CaptureModeAnalyticsV1,
 		Callback:    cb,
-		MaxRetries:  &one,
+		MaxRetries:  &zero,
 		Logger:      quietTestLogger{t},
 		Interval:    10 * time.Millisecond,
 		BatchSize:   1,
@@ -98,7 +98,7 @@ func TestV1IntegrationEnvelopeAndHeaders(t *testing.T) {
 	defer srv.Close()
 
 	cb := NewUnifiedCallback(t)
-	c, _ := NewWithConfig("phc_test", Config{
+	c, err := NewWithConfig("phc_test", Config{
 		Endpoint:    srv.URL,
 		CaptureMode: CaptureModeAnalyticsV1,
 		Callback:    cb,
@@ -107,6 +107,9 @@ func TestV1IntegrationEnvelopeAndHeaders(t *testing.T) {
 		BatchSize:   1,
 		Transport:   headerCaptureTransport{auth: &gotAuth, sdkInfo: &gotSdkInfo},
 	})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
 	_ = c.Enqueue(Capture{Event: "e", DistinctId: "d"})
 	waitForCounts(t, cb, 1)
 	_ = c.Close()
@@ -157,7 +160,7 @@ func TestV1IntegrationPartialRetryFiresPerEventCallbacks(t *testing.T) {
 
 	cb := NewUnifiedCallback(t)
 	nine := 9
-	c, _ := NewWithConfig("phc_test", Config{
+	c, err := NewWithConfig("phc_test", Config{
 		Endpoint:    srv.URL,
 		CaptureMode: CaptureModeAnalyticsV1,
 		Callback:    cb,
@@ -167,6 +170,9 @@ func TestV1IntegrationPartialRetryFiresPerEventCallbacks(t *testing.T) {
 		Interval:    10 * time.Millisecond,
 		BatchSize:   3,
 	})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
 	_ = c.Enqueue(Capture{Uuid: uuidA, Event: "e1", DistinctId: "d"})
 	_ = c.Enqueue(Capture{Uuid: uuidB, Event: "e2", DistinctId: "d"})
 	_ = c.Enqueue(Capture{Uuid: uuidC, Event: "e3", DistinctId: "d"})

--- a/capture_v1_integration_test.go
+++ b/capture_v1_integration_test.go
@@ -1,0 +1,197 @@
+package posthog
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+)
+
+// waitForCounts polls cb until success+failure reach total or it times out.
+func waitForCounts(t *testing.T, cb *UnifiedCallback, total int) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		s, f := cb.GetCounts()
+		if s+f >= total {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d callbacks, got success=%d failure=%d", total, s, f)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func TestV1ModeSelectionRoutesToV1Endpoint(t *testing.T) {
+	b := NewMockServerBuilder()
+	srv := b.Build()
+	defer srv.Close()
+
+	cb := NewUnifiedCallback(t)
+	one := 0
+	c, err := NewWithConfig("phc_test", Config{
+		Endpoint:    srv.URL,
+		CaptureMode: CaptureModeAnalyticsV1,
+		Callback:    cb,
+		MaxRetries:  &one,
+		Logger:      quietTestLogger{t},
+		Interval:    10 * time.Millisecond,
+		BatchSize:   1,
+	})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	if err := c.Enqueue(Capture{Event: "e", DistinctId: "d"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	waitForCounts(t, cb, 1)
+	_ = c.Close()
+
+	paths := b.GetPaths()
+	if len(paths) == 0 || paths[0] != captureV1Path {
+		t.Errorf("v1 mode hit %v, want first request to %s", paths, captureV1Path)
+	}
+	if s, f := cb.GetCounts(); s != 1 || f != 0 {
+		t.Errorf("callbacks success=%d failure=%d, want 1/0", s, f)
+	}
+}
+
+func TestDefaultModeRoutesToBatchEndpoint(t *testing.T) {
+	b := NewMockServerBuilder().WithBatchResponse("ok", 200)
+	srv := b.Build()
+	defer srv.Close()
+
+	cb := NewUnifiedCallback(t)
+	c, err := NewWithConfig("phc_test", Config{
+		Endpoint:  srv.URL,
+		Callback:  cb,
+		Logger:    quietTestLogger{t},
+		Interval:  10 * time.Millisecond,
+		BatchSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	if err := c.Enqueue(Capture{Event: "e", DistinctId: "d"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	waitForCounts(t, cb, 1)
+	_ = c.Close()
+
+	for _, p := range b.GetPaths() {
+		if p == captureV1Path {
+			t.Errorf("default mode must not hit %s; paths=%v", captureV1Path, b.GetPaths())
+		}
+	}
+}
+
+func TestV1IntegrationEnvelopeAndHeaders(t *testing.T) {
+	var gotAuth, gotSdkInfo string
+	var envelope eventBatch
+	srv := NewMockServerBuilder().WithCaptureV1Handler(func(body []byte) (int, string) {
+		_ = json.Unmarshal(body, &envelope)
+		return 200, allOkResultsBody(body)
+	}).Build()
+	defer srv.Close()
+
+	cb := NewUnifiedCallback(t)
+	c, _ := NewWithConfig("phc_test", Config{
+		Endpoint:    srv.URL,
+		CaptureMode: CaptureModeAnalyticsV1,
+		Callback:    cb,
+		Logger:      quietTestLogger{t},
+		Interval:    10 * time.Millisecond,
+		BatchSize:   1,
+		Transport:   headerCaptureTransport{auth: &gotAuth, sdkInfo: &gotSdkInfo},
+	})
+	_ = c.Enqueue(Capture{Event: "e", DistinctId: "d"})
+	waitForCounts(t, cb, 1)
+	_ = c.Close()
+
+	if envelope.CreatedAt == "" {
+		t.Error("envelope created_at missing")
+	}
+	if len(envelope.Batch) != 1 {
+		t.Errorf("envelope batch len = %d, want 1", len(envelope.Batch))
+	}
+	if gotAuth != "Bearer phc_test" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotSdkInfo != SDKName+"/"+getVersion() {
+		t.Errorf("PostHog-Sdk-Info = %q", gotSdkInfo)
+	}
+}
+
+func TestV1IntegrationPartialRetryFiresPerEventCallbacks(t *testing.T) {
+	attempts := 0
+	b := NewMockServerBuilder().WithCaptureV1Handler(func(body []byte) (int, string) {
+		attempts++
+		var env eventBatch
+		_ = json.Unmarshal(body, &env)
+		results := map[string]eventResult{}
+		for i, raw := range env.Batch {
+			var ev struct {
+				Uuid string `json:"uuid"`
+			}
+			_ = json.Unmarshal(raw, &ev)
+			switch {
+			case attempts == 1 && i == 0:
+				results[ev.Uuid] = eventResult{Result: resultOk}
+			case attempts == 1 && i == 1:
+				drop := "billing_limit_exceeded"
+				results[ev.Uuid] = eventResult{Result: resultDrop, Details: &drop}
+			case attempts == 1 && i == 2:
+				results[ev.Uuid] = eventResult{Result: resultRetry}
+			default:
+				results[ev.Uuid] = eventResult{Result: resultOk}
+			}
+		}
+		out, _ := json.Marshal(captureV1Response{Results: results})
+		return 200, string(out)
+	})
+	srv := b.Build()
+	defer srv.Close()
+
+	cb := NewUnifiedCallback(t)
+	nine := 9
+	c, _ := NewWithConfig("phc_test", Config{
+		Endpoint:    srv.URL,
+		CaptureMode: CaptureModeAnalyticsV1,
+		Callback:    cb,
+		MaxRetries:  &nine,
+		RetryAfter:  func(int) time.Duration { return time.Millisecond },
+		Logger:      quietTestLogger{t},
+		Interval:    10 * time.Millisecond,
+		BatchSize:   3,
+	})
+	_ = c.Enqueue(Capture{Uuid: uuidA, Event: "e1", DistinctId: "d"})
+	_ = c.Enqueue(Capture{Uuid: uuidB, Event: "e2", DistinctId: "d"})
+	_ = c.Enqueue(Capture{Uuid: uuidC, Event: "e3", DistinctId: "d"})
+
+	// 3 events: a ok, b drop, c retry->ok = 2 success, 1 failure.
+	waitForCounts(t, cb, 3)
+	_ = c.Close()
+
+	if s, f := cb.GetCounts(); s != 2 || f != 1 {
+		t.Errorf("callbacks success=%d failure=%d, want 2/1", s, f)
+	}
+	if attempts < 2 {
+		t.Errorf("expected at least 2 attempts (partial retry), got %d", attempts)
+	}
+}
+
+// headerCaptureTransport records the auth + sdk-info headers then delegates to
+// the default transport.
+type headerCaptureTransport struct {
+	auth    *string
+	sdkInfo *string
+}
+
+func (t headerCaptureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	*t.auth = r.Header.Get("Authorization")
+	*t.sdkInfo = r.Header.Get("PostHog-Sdk-Info")
+	return http.DefaultTransport.RoundTrip(r)
+}

--- a/capture_v1_send.go
+++ b/capture_v1_send.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/andybalholm/brotli"
@@ -17,16 +18,14 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-// zstdEncoder is shared across all clients: klauspost's EncodeAll is safe for
-// concurrent use and the library recommends reusing one encoder over
-// allocating per call. The options are static so NewWriter cannot fail here.
-var zstdEncoder = func() *zstd.Encoder {
-	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
-	if err != nil {
-		panic(fmt.Sprintf("posthog: zstd encoder init: %v", err))
-	}
-	return enc
-}()
+// getZstdEncoder returns a shared zstd encoder, lazily initialized on first
+// call. klauspost's EncodeAll is safe for concurrent use and the library
+// recommends reusing one encoder over allocating per call. The init is
+// practically infallible with static options, but returning an error keeps
+// SDK setup graceful (no panic on load).
+var getZstdEncoder = sync.OnceValues(func() (*zstd.Encoder, error) {
+	return zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+})
 
 // v1Result is the parsed outcome of a single capture-v1 HTTP attempt.
 type v1Result struct {
@@ -239,7 +238,11 @@ func compressV1Body(mode CompressionMode, raw []byte) ([]byte, string, error) {
 		}
 		return buf.Bytes(), "deflate", nil
 	case CompressionZstd:
-		return zstdEncoder.EncodeAll(raw, make([]byte, 0, len(raw))), "zstd", nil
+		enc, err := getZstdEncoder()
+		if err != nil {
+			return nil, "", fmt.Errorf("zstd encoder init: %w", err)
+		}
+		return enc.EncodeAll(raw, make([]byte, 0, len(raw))), "zstd", nil
 	case CompressionBrotli:
 		var buf bytes.Buffer
 		bw := brotli.NewWriter(&buf)

--- a/capture_v1_send.go
+++ b/capture_v1_send.go
@@ -3,6 +3,7 @@ package posthog
 import (
 	"bytes"
 	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"fmt"
 	"io"
@@ -10,9 +11,22 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/andybalholm/brotli"
 	json "github.com/goccy/go-json"
 	"github.com/google/uuid"
+	"github.com/klauspost/compress/zstd"
 )
+
+// zstdEncoder is shared across all clients: klauspost's EncodeAll is safe for
+// concurrent use and the library recommends reusing one encoder over
+// allocating per call. The options are static so NewWriter cannot fail here.
+var zstdEncoder = func() *zstd.Encoder {
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		panic(fmt.Sprintf("posthog: zstd encoder init: %v", err))
+	}
+	return enc
+}()
 
 // v1Result is the parsed outcome of a single capture-v1 HTTP attempt.
 type v1Result struct {
@@ -191,23 +205,64 @@ func (c *client) dropMessages(msgs []APIMessage, err error) {
 	c.notifyFailure(msgs, err)
 }
 
+// compressV1Body compresses the v1 request body per the configured mode and
+// returns the body plus the Content-Encoding wire token ("" when uncompressed,
+// "br" for brotli). gzip/deflate/brotli use per-call writers; zstd reuses the
+// shared concurrency-safe encoder. The codecs other than gzip are gated to
+// CaptureModeAnalyticsV1 by Config.Validate, so this is only reached for modes
+// the backend can decode via Content-Encoding.
+func compressV1Body(mode CompressionMode, raw []byte) ([]byte, string, error) {
+	switch mode {
+	case CompressionNone:
+		return raw, "", nil
+	case CompressionGzip:
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		if _, err := gw.Write(raw); err != nil {
+			return nil, "", fmt.Errorf("gzip compression: %w", err)
+		}
+		if err := gw.Close(); err != nil {
+			return nil, "", fmt.Errorf("gzip close: %w", err)
+		}
+		return buf.Bytes(), "gzip", nil
+	case CompressionDeflate:
+		// zlib (RFC 1950) wraps the deflate stream so it begins with 0x78; the
+		// backend sniffs that byte to route Content-Encoding: deflate to its
+		// zlib decoder, avoiding ambiguity with raw (headerless) deflate.
+		var buf bytes.Buffer
+		zw := zlib.NewWriter(&buf)
+		if _, err := zw.Write(raw); err != nil {
+			return nil, "", fmt.Errorf("deflate compression: %w", err)
+		}
+		if err := zw.Close(); err != nil {
+			return nil, "", fmt.Errorf("deflate close: %w", err)
+		}
+		return buf.Bytes(), "deflate", nil
+	case CompressionZstd:
+		return zstdEncoder.EncodeAll(raw, make([]byte, 0, len(raw))), "zstd", nil
+	case CompressionBrotli:
+		var buf bytes.Buffer
+		bw := brotli.NewWriter(&buf)
+		if _, err := bw.Write(raw); err != nil {
+			return nil, "", fmt.Errorf("brotli compression: %w", err)
+		}
+		if err := bw.Close(); err != nil {
+			return nil, "", fmt.Errorf("brotli close: %w", err)
+		}
+		return buf.Bytes(), "br", nil
+	default:
+		return nil, "", fmt.Errorf("unsupported compression mode %s", mode)
+	}
+}
+
 // uploadV1 performs a single capture-v1 POST. It reuses c.http (which already
 // carries BatchUploadTimeout) and the caller's ctx; it does not add a separate
 // per-request timeout.
 func (c *client) uploadV1(ctx context.Context, b []byte, requestId string, attempt int) (*v1Result, error) {
-	body := b
-	if c.Compression == CompressionGzip {
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		if _, err := gw.Write(b); err != nil {
-			c.Errorf("gzip compression - %s", err)
-			return nil, fmt.Errorf("gzip compression: %w", err)
-		}
-		if err := gw.Close(); err != nil {
-			c.Errorf("gzip close - %s", err)
-			return nil, fmt.Errorf("gzip close: %w", err)
-		}
-		body = buf.Bytes()
+	body, encoding, err := compressV1Body(c.Compression, b)
+	if err != nil {
+		c.Errorf("compressing v1 body (%s) - %s", c.Compression, err)
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint+captureV1Path, bytes.NewReader(body))
@@ -225,8 +280,8 @@ func (c *client) uploadV1(ctx context.Context, b []byte, requestId string, attem
 	req.Header.Set("PostHog-Request-Id", requestId)
 	req.Header.Set("PostHog-Request-Timestamp", c.now().UTC().Format(time.RFC3339))
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
-	if c.Compression == CompressionGzip {
-		req.Header.Set("Content-Encoding", "gzip")
+	if encoding != "" {
+		req.Header.Set("Content-Encoding", encoding)
 	}
 
 	res, err := c.http.Do(req)

--- a/capture_v1_send.go
+++ b/capture_v1_send.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,16 +73,17 @@ func (c *client) sendV1(pb preparedBatch) {
 		})
 		if err != nil {
 			c.Errorf("marshalling v1 batch wrapper - %s", err)
-			c.notifyFailure(pendingMsgs, err)
+			c.notifyFailure(pendingMsgs, &CaptureRequestError{Err: err})
 			return
 		}
 
 		res, err := c.uploadV1(c.ctx, body, requestId, attempt)
 		if err != nil {
+			reqErr := newCaptureRequestError(res, err)
 			// A 2xx with an unparseable body is terminal for this batch -
 			// retrying a malformed success would loop forever.
 			if res != nil && isSuccessStatus(res.statusCode) {
-				c.notifyFailure(pendingMsgs, err)
+				c.notifyFailure(pendingMsgs, reqErr)
 				return
 			}
 			// A terminal non-retryable status (400/401/429/...) whose body
@@ -94,32 +96,40 @@ func (c *client) sendV1(pb preparedBatch) {
 			// Transport error: retry unless shutting down or exhausted.
 			if c.ctx.Err() != nil {
 				c.Errorf("%d messages dropped: shutdown timeout", len(pendingMsgs))
-				c.notifyFailure(pendingMsgs, err)
+				c.notifyFailure(pendingMsgs, reqErr)
 				return
 			}
 			if lastAttempt {
-				c.dropMessages(pendingMsgs, err)
+				c.dropMessages(pendingMsgs, reqErr)
 				return
 			}
 			if !c.backoffV1(i, res) {
-				c.notifyFailure(pendingMsgs, err)
+				c.notifyFailure(pendingMsgs, reqErr)
 				return
 			}
 			continue
 		}
 
 		if isSuccessStatus(res.statusCode) {
+			c.logV1ResultSummary(requestId, attempt, res.results)
 			nextData, nextMsgs, nextUuids := c.partitionV1Results(res, pendingData, pendingMsgs, pendingUuids)
 			if len(nextUuids) == 0 {
 				return
 			}
 			if lastAttempt {
-				c.dropMessages(nextMsgs, fmt.Errorf("capture v1: %d events not persisted after %d attempts", len(nextMsgs), c.maxAttempts))
+				c.Errorf("%d messages dropped after %d attempts", len(nextMsgs), c.maxAttempts)
+				for idx, id := range nextUuids {
+					var details string
+					if r, ok := res.results[id]; ok && r.Details != nil {
+						details = *r.Details
+					}
+					c.notifyFailure([]APIMessage{nextMsgs[idx]}, &CaptureEventError{EventUUID: id, Result: resultRetry, Details: details, Exhausted: true})
+				}
 				return
 			}
 			pendingData, pendingMsgs, pendingUuids = nextData, nextMsgs, nextUuids
 			if !c.backoffV1(i, res) {
-				c.notifyFailure(pendingMsgs, fmt.Errorf("capture v1: shutdown during retry backoff"))
+				c.notifyFailure(pendingMsgs, &CaptureRequestError{Err: errShutdownDuringBackoff})
 				return
 			}
 			continue
@@ -332,20 +342,59 @@ func isSuccessStatus(code int) bool {
 	return code >= 200 && code <= 299
 }
 
-// eventErrorV1 builds the per-event failure error for a "drop" result (or an
-// exhausted "retry"). PR5 replaces this with the typed CaptureEventError.
+// errShutdownDuringBackoff is the underlying cause when retries are abandoned
+// because the client is shutting down mid-backoff.
+var errShutdownDuringBackoff = errors.New("shutdown during retry backoff")
+
+// eventErrorV1 builds the per-event CaptureEventError for a terminal "drop".
 func eventErrorV1(eventUuid string, r eventResult) error {
-	if r.Details != nil && *r.Details != "" {
-		return fmt.Errorf("capture event %s: %s (%s)", eventUuid, r.Result, *r.Details)
+	details := ""
+	if r.Details != nil {
+		details = *r.Details
 	}
-	return fmt.Errorf("capture event %s: %s", eventUuid, r.Result)
+	return &CaptureEventError{EventUUID: eventUuid, Result: r.Result, Details: details}
 }
 
-// requestErrorV1 builds the batch-level failure error for a non-2xx response.
-// PR5 replaces this with the typed CaptureRequestError.
+// requestErrorV1 builds the batch-level CaptureRequestError for a non-2xx response.
 func requestErrorV1(res *v1Result) error {
-	if res.errResp != nil {
-		return fmt.Errorf("capture request failed: %d %s: %s", res.statusCode, res.errResp.Error, res.errResp.ErrorDescription)
+	return newCaptureRequestError(res, nil)
+}
+
+// newCaptureRequestError assembles a *CaptureRequestError from an optional parsed
+// result (status + structured error body) and an optional underlying error.
+func newCaptureRequestError(res *v1Result, underlying error) *CaptureRequestError {
+	e := &CaptureRequestError{Err: underlying}
+	if res != nil {
+		e.StatusCode = res.statusCode
+		if res.errResp != nil {
+			e.Code = res.errResp.Error
+			e.Description = res.errResp.ErrorDescription
+		}
 	}
-	return fmt.Errorf("capture request failed: %d", res.statusCode)
+	return e
+}
+
+// logV1ResultSummary emits a single verbose debug line per 2xx response that
+// tallies per-event directives (ok/warning/drop/retry/other), so operators can
+// debug partial-submission outcomes without diffing the raw response body.
+func (c *client) logV1ResultSummary(requestId string, attempt int, results map[string]eventResult) {
+	var ok, warning, drop, retry, other int
+	for _, r := range results {
+		switch r.Result {
+		case resultOk:
+			ok++
+		case resultWarning:
+			warning++
+		case resultDrop:
+			drop++
+		case resultRetry:
+			retry++
+		default:
+			other++
+		}
+	}
+	c.debugf(
+		"capture v1 response request_id=%s attempt=%d events=%d ok=%d warning=%d drop=%d retry=%d other=%d",
+		requestId, attempt, len(results), ok, warning, drop, retry, other,
+	)
 }

--- a/capture_v1_send_test.go
+++ b/capture_v1_send_test.go
@@ -3,6 +3,7 @@ package posthog
 import (
 	"bytes"
 	"compress/gzip"
+	"compress/zlib"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,8 +12,58 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andybalholm/brotli"
 	json "github.com/goccy/go-json"
+	"github.com/klauspost/compress/zstd"
 )
+
+// decodeV1Body decompresses a recorded request body per its Content-Encoding,
+// mirroring what the capture-v1 backend does. Reaching valid JSON proves the
+// SDK emitted a well-formed stream for that codec.
+func decodeV1Body(t *testing.T, encoding string, raw []byte) []byte {
+	t.Helper()
+	switch encoding {
+	case "":
+		return raw
+	case "gzip":
+		gr, err := gzip.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			t.Errorf("gzip reader: %v", err)
+			return raw
+		}
+		defer gr.Close()
+		out, _ := io.ReadAll(gr)
+		return out
+	case "deflate":
+		zr, err := zlib.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			t.Errorf("zlib reader: %v", err)
+			return raw
+		}
+		defer zr.Close()
+		out, _ := io.ReadAll(zr)
+		return out
+	case "zstd":
+		zr, err := zstd.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			t.Errorf("zstd reader: %v", err)
+			return raw
+		}
+		defer zr.Close()
+		out, _ := io.ReadAll(zr)
+		return out
+	case "br":
+		out, err := io.ReadAll(brotli.NewReader(bytes.NewReader(raw)))
+		if err != nil {
+			t.Errorf("brotli reader: %v", err)
+			return raw
+		}
+		return out
+	default:
+		t.Errorf("unexpected Content-Encoding %q", encoding)
+		return raw
+	}
+}
 
 // recordedRequest captures what the server saw for one attempt.
 type recordedRequest struct {
@@ -37,16 +88,7 @@ func (s *v1TestServer) handler(t *testing.T) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		raw, _ := io.ReadAll(r.Body)
-		body := raw
-		if r.Header.Get("Content-Encoding") == "gzip" {
-			gr, err := gzip.NewReader(bytes.NewReader(raw))
-			if err != nil {
-				t.Errorf("gzip reader: %v", err)
-			} else {
-				body, _ = io.ReadAll(gr)
-				_ = gr.Close()
-			}
-		}
+		body := decodeV1Body(t, r.Header.Get("Content-Encoding"), raw)
 		var env eventBatch
 		if err := json.Unmarshal(body, &env); err != nil {
 			t.Errorf("server: unmarshal envelope: %v (body=%s)", err, string(body))
@@ -456,35 +498,98 @@ func TestV1SendMalformed200IsTerminal(t *testing.T) {
 	}
 }
 
-func TestV1SendGzipCompression(t *testing.T) {
-	cb := &recordingCallback{}
-	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
-		m := map[string]eventResult{}
-		for _, u := range uuids {
-			m[u] = eventResult{Result: resultOk}
-		}
-		return http.StatusOK, resultsBody(t, m), ""
-	}}
-	ts := httptest.NewServer(srv.handler(t))
-	defer ts.Close()
+// TestV1SendCompressionCodecs exercises the full v1 send path for every
+// supported codec: the request carries the right Content-Encoding token and
+// the server (decoding per that token) recovers the original batch.
+func TestV1SendCompressionCodecs(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     CompressionMode
+		encoding string // expected Content-Encoding header ("" = uncompressed)
+	}{
+		{"none", CompressionNone, ""},
+		{"gzip", CompressionGzip, "gzip"},
+		{"zstd", CompressionZstd, "zstd"},
+		{"deflate", CompressionDeflate, "deflate"},
+		{"brotli", CompressionBrotli, "br"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := &recordingCallback{}
+			srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+				m := map[string]eventResult{}
+				for _, u := range uuids {
+					m[u] = eventResult{Result: resultOk}
+				}
+				return http.StatusOK, resultsBody(t, m), ""
+			}}
+			ts := httptest.NewServer(srv.handler(t))
+			defer ts.Close()
 
-	c := newV1TestClient(t, ts.URL, cb, 9, func(cfg *Config) { cfg.Compression = CompressionGzip })
-	c.sendV1(v1Batch(t, cap1(uuidA)))
+			c := newV1TestClient(t, ts.URL, cb, 9, func(cfg *Config) {
+				cfg.CaptureMode = CaptureModeAnalyticsV1
+				cfg.Compression = tc.mode
+			})
+			c.sendV1(v1Batch(t, cap1(uuidA)))
 
-	reqs := srv.snapshot()
-	if len(reqs) != 1 {
-		t.Fatalf("expected 1 request, got %d", len(reqs))
+			reqs := srv.snapshot()
+			if len(reqs) != 1 {
+				t.Fatalf("expected 1 request, got %d", len(reqs))
+			}
+			if reqs[0].encoding != tc.encoding {
+				t.Errorf("Content-Encoding = %q, want %q", reqs[0].encoding, tc.encoding)
+			}
+			// The handler decoded the body per Content-Encoding and parsed the
+			// uuid; reaching here with it recorded proves the body round-trips.
+			if len(reqs[0].uuids) != 1 || reqs[0].uuids[0] != uuidA {
+				t.Errorf("decoded uuids = %v, want [%s]", reqs[0].uuids, uuidA)
+			}
+			if s, _ := cb.counts(); s != 1 {
+				t.Errorf("success callbacks = %d, want 1", s)
+			}
+		})
 	}
-	if reqs[0].encoding != "gzip" {
-		t.Errorf("Content-Encoding = %q, want gzip", reqs[0].encoding)
+}
+
+// TestCompressV1Body checks the codec helper directly: correct wire token,
+// real size reduction on compressible input, and a clean round-trip. This
+// catches encoder regressions the send-path test cannot (size, error path).
+func TestCompressV1Body(t *testing.T) {
+	// Large, highly compressible payload so every codec yields real savings.
+	raw := bytes.Repeat([]byte(`{"event":"e","distinct_id":"d"},`), 512)
+
+	cases := []struct {
+		name     string
+		mode     CompressionMode
+		token    string
+		compress bool // expect output smaller than raw
+	}{
+		{"none", CompressionNone, "", false},
+		{"gzip", CompressionGzip, "gzip", true},
+		{"zstd", CompressionZstd, "zstd", true},
+		{"deflate", CompressionDeflate, "deflate", true},
+		{"brotli", CompressionBrotli, "br", true},
 	}
-	// The handler already decoded the gzip body and parsed the uuid; reaching
-	// here with the event uuid recorded proves the body was valid gzip.
-	if len(reqs[0].uuids) != 1 || reqs[0].uuids[0] != uuidA {
-		t.Errorf("decoded uuids = %v, want [%s]", reqs[0].uuids, uuidA)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, token, err := compressV1Body(tc.mode, raw)
+			if err != nil {
+				t.Fatalf("compressV1Body: %v", err)
+			}
+			if token != tc.token {
+				t.Errorf("token = %q, want %q", token, tc.token)
+			}
+			if tc.compress && len(body) >= len(raw) {
+				t.Errorf("%s output %d bytes did not shrink raw %d", tc.name, len(body), len(raw))
+			}
+			if got := decodeV1Body(t, token, body); !bytes.Equal(got, raw) {
+				t.Errorf("%s round-trip mismatch: got %d bytes, want %d", tc.name, len(got), len(raw))
+			}
+		})
 	}
-	if s, _ := cb.counts(); s != 1 {
-		t.Errorf("success callbacks = %d, want 1", s)
+
+	if _, _, err := compressV1Body(CompressionMode(99), raw); err == nil {
+		t.Error("expected error for unknown compression mode")
 	}
 }
 

--- a/capturer.go
+++ b/capturer.go
@@ -32,7 +32,7 @@ func (l legacyCapturer) send(pb preparedBatch) { l.c.send(pb) }
 type analyticsV1Capturer struct{ c *client }
 
 func (v analyticsV1Capturer) prepare(m Message) (json.RawMessage, APIMessage, string, error) {
-	return prepareForSendV1(m)
+	return prepareForSendV1(m, v.c.Logger)
 }
 
 func (v analyticsV1Capturer) send(pb preparedBatch) { v.c.sendV1(pb) }

--- a/capturer.go
+++ b/capturer.go
@@ -1,0 +1,38 @@
+package posthog
+
+import (
+	json "github.com/goccy/go-json"
+)
+
+// capturer isolates every legacy-vs-v1 divergence: both the per-message wire
+// serialization and the batch send/retry semantics. The client picks one
+// implementation once at construction from Config.CaptureMode, so the public
+// API and the queue/batching machinery stay protocol-agnostic.
+type capturer interface {
+	// prepare serializes one message into this mode's wire bytes, returning the
+	// raw JSON, the original APIMessage (for callbacks), and the event uuid (used
+	// for v1 per-event result correlation; "" for legacy).
+	prepare(msg Message) (json.RawMessage, APIMessage, string, error)
+	// send delivers a prepared batch using this mode's endpoint, headers, and
+	// retry policy.
+	send(pb preparedBatch)
+}
+
+// legacyCapturer wraps the existing /batch/ serialization and send path.
+type legacyCapturer struct{ c *client }
+
+func (l legacyCapturer) prepare(m Message) (json.RawMessage, APIMessage, string, error) {
+	data, apiMsg, err := prepareForSend(m)
+	return data, apiMsg, "", err
+}
+
+func (l legacyCapturer) send(pb preparedBatch) { l.c.send(pb) }
+
+// analyticsV1Capturer wraps the capture-v1 serialization and send path.
+type analyticsV1Capturer struct{ c *client }
+
+func (v analyticsV1Capturer) prepare(m Message) (json.RawMessage, APIMessage, string, error) {
+	return prepareForSendV1(m)
+}
+
+func (v analyticsV1Capturer) send(pb preparedBatch) { v.c.sendV1(pb) }

--- a/compression_test.go
+++ b/compression_test.go
@@ -232,9 +232,13 @@ func TestCompressionGzipReducesPayloadSize(t *testing.T) {
 }
 
 func TestCompressionModeConstants(t *testing.T) {
-	// Verify constant values are as documented
+	// Verify constant values are as documented (wire-stable: external callers
+	// may persist these as ints).
 	require.Equal(t, CompressionMode(0), CompressionNone)
 	require.Equal(t, CompressionMode(1), CompressionGzip)
+	require.Equal(t, CompressionMode(2), CompressionZstd)
+	require.Equal(t, CompressionMode(3), CompressionDeflate)
+	require.Equal(t, CompressionMode(4), CompressionBrotli)
 }
 
 func TestCompressionGzipWithCallback(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -17,6 +17,18 @@ const (
 	CompressionGzip CompressionMode = 1
 )
 
+// CaptureMode selects the capture wire protocol used for event ingestion.
+type CaptureMode uint8
+
+const (
+	// CaptureModeLegacy sends events to the legacy POST /batch/ endpoint. This
+	// is the default, so upgrading is transparent to existing callers.
+	CaptureModeLegacy CaptureMode = 0
+	// CaptureModeAnalyticsV1 opts into POST /i/v1/analytics/events (Bearer auth,
+	// per-event results, partial retry).
+	CaptureModeAnalyticsV1 CaptureMode = 1
+)
+
 // Config carries configuration options used when constructing a Client with NewWithConfig.
 //
 // Each exported field's zero value is either meaningful or replaced by the
@@ -136,6 +148,11 @@ type Config struct {
 	// it defaults to CompressionNone.
 	Compression CompressionMode
 
+	// CaptureMode selects the capture wire protocol. It defaults to
+	// CaptureModeLegacy (POST /batch/). Set CaptureModeAnalyticsV1 to opt into
+	// POST /i/v1/analytics/events.
+	CaptureMode CaptureMode
+
 	// A function called by the client to get the current time, `time.Now` is
 	// used by default.
 	// This field is not exported and only exposed internally to control concurrency.
@@ -238,6 +255,14 @@ func (c *Config) Validate() error {
 			Reason: "invalid compression mode",
 			Field:  "Compression",
 			Value:  c.Compression,
+		}
+	}
+
+	if c.CaptureMode > CaptureModeAnalyticsV1 {
+		return ConfigError{
+			Reason: "invalid capture mode",
+			Field:  "CaptureMode",
+			Value:  c.CaptureMode,
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package posthog
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -13,9 +14,39 @@ type CompressionMode uint8
 const (
 	// CompressionNone disables compression (default).
 	CompressionNone CompressionMode = 0
-	// CompressionGzip enables GZIP compression for batch payloads.
+	// CompressionGzip enables GZIP compression for batch payloads. Valid on
+	// both capture modes.
 	CompressionGzip CompressionMode = 1
+	// CompressionZstd enables Zstandard compression. Requires
+	// CaptureModeAnalyticsV1 (the legacy /batch/ endpoint cannot decode it).
+	CompressionZstd CompressionMode = 2
+	// CompressionDeflate enables zlib (RFC 1950) compression, sent as
+	// Content-Encoding: deflate. Requires CaptureModeAnalyticsV1.
+	CompressionDeflate CompressionMode = 3
+	// CompressionBrotli enables Brotli compression, sent as
+	// Content-Encoding: br. Requires CaptureModeAnalyticsV1.
+	CompressionBrotli CompressionMode = 4
 )
+
+// String returns a human-readable codec name, used in config validation
+// errors and debug logs. It is not the on-the-wire Content-Encoding token
+// (brotli's token is "br"); see compressV1Body for wire tokens.
+func (m CompressionMode) String() string {
+	switch m {
+	case CompressionNone:
+		return "none"
+	case CompressionGzip:
+		return "gzip"
+	case CompressionZstd:
+		return "zstd"
+	case CompressionDeflate:
+		return "deflate"
+	case CompressionBrotli:
+		return "brotli"
+	default:
+		return fmt.Sprintf("CompressionMode(%d)", uint8(m))
+	}
+}
 
 // CaptureMode selects the capture wire protocol used for event ingestion.
 type CaptureMode uint8
@@ -250,7 +281,20 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	if c.Compression > CompressionGzip {
+	switch c.Compression {
+	case CompressionNone, CompressionGzip:
+		// Valid on both legacy and v1 capture modes.
+	case CompressionZstd, CompressionDeflate, CompressionBrotli:
+		// Only the v1 endpoint decodes these; the legacy /batch/ endpoint
+		// understands gzip/lz64/base64 only, so reject them up front.
+		if c.CaptureMode != CaptureModeAnalyticsV1 {
+			return ConfigError{
+				Reason: c.Compression.String() + " compression requires CaptureModeAnalyticsV1",
+				Field:  "Compression",
+				Value:  c.Compression,
+			}
+		}
+	default:
 		return ConfigError{
 			Reason: "invalid compression mode",
 			Field:  "Compression",

--- a/config_test.go
+++ b/config_test.go
@@ -117,27 +117,42 @@ func assertConfigBoolDefaultTrue(t *testing.T, set func(*Config, *bool), get fun
 }
 
 func TestConfigCompression(t *testing.T) {
-	// CompressionNone (0) should be valid
-	c := Config{Compression: CompressionNone}
-	require.NoError(t, c.Validate())
-
-	// CompressionGzip (1) should be valid
-	c = Config{Compression: CompressionGzip}
-	require.NoError(t, c.Validate())
-
-	// Values > CompressionGzip should be invalid
-	c = Config{Compression: 2}
-	err := c.Validate()
-	require.Error(t, err)
-	configErr, ok := err.(ConfigError)
-	require.True(t, ok, "expected ConfigError")
-	require.Equal(t, "Compression", configErr.Field)
-	require.Equal(t, CompressionMode(2), configErr.Value)
-	require.Contains(t, configErr.Reason, "invalid compression mode")
-
-	// Higher invalid values should also fail
-	c = Config{Compression: 255}
-	err = c.Validate()
-	require.Error(t, err)
-	require.ErrorContains(t, err, "invalid compression mode")
+	// gzip and none are valid on both capture modes; zstd/deflate/brotli are
+	// v1-only (legacy /batch/ cannot decode them); unknown values are rejected.
+	cases := []struct {
+		name        string
+		compression CompressionMode
+		captureMode CaptureMode
+		wantErr     string // reason substring; "" means valid
+		wantValue   CompressionMode
+	}{
+		{"none legacy", CompressionNone, CaptureModeLegacy, "", 0},
+		{"none v1", CompressionNone, CaptureModeAnalyticsV1, "", 0},
+		{"gzip legacy", CompressionGzip, CaptureModeLegacy, "", 0},
+		{"gzip v1", CompressionGzip, CaptureModeAnalyticsV1, "", 0},
+		{"zstd legacy rejected", CompressionZstd, CaptureModeLegacy, "zstd compression requires CaptureModeAnalyticsV1", CompressionZstd},
+		{"zstd v1 ok", CompressionZstd, CaptureModeAnalyticsV1, "", 0},
+		{"deflate legacy rejected", CompressionDeflate, CaptureModeLegacy, "deflate compression requires CaptureModeAnalyticsV1", CompressionDeflate},
+		{"deflate v1 ok", CompressionDeflate, CaptureModeAnalyticsV1, "", 0},
+		{"brotli legacy rejected", CompressionBrotli, CaptureModeLegacy, "brotli compression requires CaptureModeAnalyticsV1", CompressionBrotli},
+		{"brotli v1 ok", CompressionBrotli, CaptureModeAnalyticsV1, "", 0},
+		{"unknown legacy", CompressionMode(255), CaptureModeLegacy, "invalid compression mode", CompressionMode(255)},
+		{"unknown v1", CompressionMode(255), CaptureModeAnalyticsV1, "invalid compression mode", CompressionMode(255)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{Compression: tc.compression, CaptureMode: tc.captureMode}
+			err := c.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			configErr, ok := err.(ConfigError)
+			require.True(t, ok, "expected ConfigError")
+			require.Equal(t, "Compression", configErr.Field)
+			require.Equal(t, tc.wantValue, configErr.Value)
+			require.Contains(t, configErr.Reason, tc.wantErr)
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/posthog/posthog-go
 go 1.21
 
 require (
+	github.com/andybalholm/brotli v1.1.1
 	github.com/goccy/go-json v0.10.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/joho/godotenv v1.5.1
+	github.com/klauspost/compress v1.17.11
 	github.com/orian/flakyhttp v0.1.1
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli v1.22.17

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
+github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -14,6 +16,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/orian/flakyhttp v0.1.1 h1:eugGUI9r6WL7i9z21hga+dnD+hamJ6h08MpAGIVX6wE=
 github.com/orian/flakyhttp v0.1.1/go.mod h1:EojnO3DIOCGMzg4fIccrMUZDApR0+ObfX1/8RhCysK8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -32,6 +36,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/posthog.go
+++ b/posthog.go
@@ -129,6 +129,9 @@ type Client interface {
 type preparedMessage struct {
 	data json.RawMessage // pre-serialized JSON for batch submission
 	msg  APIMessage      // original message for callbacks
+	// uuid is the per-event UUID, used by the capture-v1 path to correlate
+	// per-event results. Empty on the legacy path.
+	uuid string
 }
 
 // preparedBatch holds both raw data for efficient serialization and
@@ -190,6 +193,10 @@ type client struct {
 
 	// Decider for feature flag methods
 	decider decider
+
+	// capture is the wire-protocol strategy (legacy /batch/ or analytics-v1),
+	// chosen once in NewWithConfig from Config.CaptureMode.
+	capture capturer
 }
 
 type flagUser struct {
@@ -255,6 +262,12 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 		cancel:                          cancel,
 		http:                            makeHttpClient(config.Transport, config.BatchUploadTimeout),
 		distinctIdsFeatureFlagsReported: reportedCache,
+	}
+
+	if config.CaptureMode == CaptureModeAnalyticsV1 {
+		c.capture = analyticsV1Capturer{c}
+	} else {
+		c.capture = legacyCapturer{c}
 	}
 
 	c.decider, err = newFlagsClient(apiKey, config.Endpoint, c.http, config.FeatureFlagRequestTimeout, c.Logger)
@@ -570,12 +583,12 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 			return nil
 		}
 		m = processed.(Alias)
-		data, apiMsg, serErr := prepareForSend(m)
+		data, apiMsg, eventUuid, serErr := c.capture.prepare(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)
 			return
 		}
-		sendPrepared(preparedMessage{data: data, msg: apiMsg})
+		sendPrepared(preparedMessage{data: data, msg: apiMsg, uuid: eventUuid})
 		return
 
 	case Identify:
@@ -592,12 +605,12 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 			return nil
 		}
 		m = processed.(Identify)
-		data, apiMsg, serErr := prepareForSend(m)
+		data, apiMsg, eventUuid, serErr := c.capture.prepare(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)
 			return
 		}
-		sendPrepared(preparedMessage{data: data, msg: apiMsg})
+		sendPrepared(preparedMessage{data: data, msg: apiMsg, uuid: eventUuid})
 		return
 
 	case GroupIdentify:
@@ -613,12 +626,12 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 			return nil
 		}
 		m = processed.(GroupIdentify)
-		data, apiMsg, serErr := prepareForSend(m)
+		data, apiMsg, eventUuid, serErr := c.capture.prepare(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)
 			return
 		}
-		sendPrepared(preparedMessage{data: data, msg: apiMsg})
+		sendPrepared(preparedMessage{data: data, msg: apiMsg, uuid: eventUuid})
 		return
 
 	case Capture:
@@ -699,12 +712,12 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 			return nil
 		}
 		m = processed.(Capture)
-		data, apiMsg, serErr := prepareForSend(m)
+		data, apiMsg, eventUuid, serErr := c.capture.prepare(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)
 			return
 		}
-		sendPrepared(preparedMessage{data: data, msg: apiMsg})
+		sendPrepared(preparedMessage{data: data, msg: apiMsg, uuid: eventUuid})
 		return
 
 	case Exception:
@@ -728,12 +741,12 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 			return nil
 		}
 		m = processed.(Exception)
-		data, apiMsg, serErr := prepareForSend(m)
+		data, apiMsg, eventUuid, serErr := c.capture.prepare(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)
 			return
 		}
-		sendPrepared(preparedMessage{data: data, msg: apiMsg})
+		sendPrepared(preparedMessage{data: data, msg: apiMsg, uuid: eventUuid})
 		return
 
 	default:
@@ -1390,7 +1403,7 @@ func (c *client) processBatch() {
 		}
 	}()
 
-	c.send(batch)
+	c.capture.send(batch)
 }
 
 // sendBatch attempts to enqueue a batch for processing.
@@ -1639,6 +1652,7 @@ func (c *client) loop() {
 
 	var batchData []json.RawMessage
 	var batchMsgs []APIMessage
+	var batchUuids []string
 	var batchSize int
 
 	tick := time.NewTicker(c.Interval)
@@ -1649,7 +1663,7 @@ func (c *client) loop() {
 		if len(batchData) == 0 {
 			return true
 		}
-		batch := preparedBatch{data: batchData, msgs: batchMsgs}
+		batch := preparedBatch{data: batchData, msgs: batchMsgs, uuids: batchUuids}
 		if !c.sendBatch(batch) {
 			c.Errorf("sending batch failed - %s", ErrTooManyRequests)
 			c.notifyFailure(batchMsgs, ErrTooManyRequests)
@@ -1660,7 +1674,7 @@ func (c *client) loop() {
 
 	// Helper to reset batch state
 	resetBatch := func() {
-		batchData, batchMsgs, batchSize = nil, nil, 0
+		batchData, batchMsgs, batchUuids, batchSize = nil, nil, nil, 0
 	}
 
 	// Helper to process a single message: validate, batch, flush if needed.
@@ -1681,6 +1695,7 @@ func (c *client) loop() {
 
 		batchData = append(batchData, prepared.data)
 		batchMsgs = append(batchMsgs, prepared.msg)
+		batchUuids = append(batchUuids, prepared.uuid)
 		batchSize += msgSize
 
 		if len(batchData) >= c.BatchSize {

--- a/posthog.go
+++ b/posthog.go
@@ -1695,7 +1695,9 @@ func (c *client) loop() {
 
 		batchData = append(batchData, prepared.data)
 		batchMsgs = append(batchMsgs, prepared.msg)
-		batchUuids = append(batchUuids, prepared.uuid)
+		if c.CaptureMode == CaptureModeAnalyticsV1 {
+			batchUuids = append(batchUuids, prepared.uuid)
+		}
 		batchSize += msgSize
 
 		if len(batchData) >= c.BatchSize {

--- a/sdk_compliance_adapter/CONTRIBUTING.md
+++ b/sdk_compliance_adapter/CONTRIBUTING.md
@@ -6,6 +6,12 @@ This package contains the PostHog Go SDK compliance adapter used with the PostHo
 
 Tests run automatically in CI via GitHub Actions.
 
+CI runs two jobs: `compliance` (capture v0, `Dockerfile`) and `compliance-v1`
+(capture v1, `Dockerfile.v1`). The only difference between the images is the
+`CAPTURE_MODE=v1` env var, which flips the adapter's `/health` capabilities and
+selects `posthog.CaptureModeAnalyticsV1` at init. Both jobs pin the harness to
+`0.8.0`.
+
 ### Locally with Docker Compose
 
 Run the full compliance suite from the `sdk_compliance_adapter` directory:
@@ -16,10 +22,14 @@ docker-compose up --build --abort-on-container-exit
 
 This will:
 
-1. Build the Go SDK adapter
+1. Build the Go SDK adapters (v0 on `:8080`, v1 on `:8082`)
 2. Pull the test harness image
-3. Run all compliance tests
-4. Show the results
+3. Run the capture v0 compliance tests against the v0 adapter
+
+> **Note:** `docker-compose` currently targets the v0 adapter only. The v1
+> adapter image is built to verify it compiles, but v1 compliance tests run in
+> CI via the separate `compliance-v1` workflow job. To run v1 locally, use the
+> manual Docker instructions below with `Dockerfile.v1`.
 
 ### Manually with Docker
 
@@ -27,7 +37,7 @@ This will:
 # Create network
 docker network create test-network
 
-# Build and run adapter
+# Build and run adapter (use Dockerfile.v1 to exercise capture v1)
 docker build -f sdk_compliance_adapter/Dockerfile -t posthog-go-adapter .
 docker run -d --name sdk-adapter --network test-network -p 8080:8080 posthog-go-adapter
 
@@ -35,7 +45,7 @@ docker run -d --name sdk-adapter --network test-network -p 8080:8080 posthog-go-
 docker run --rm \
   --name test-harness \
   --network test-network \
-  ghcr.io/posthog/sdk-test-harness:latest \
+  ghcr.io/posthog/sdk-test-harness:0.8.0 \
   run --adapter-url http://sdk-adapter:8080 --mock-url http://test-harness:8081
 
 # Cleanup

--- a/sdk_compliance_adapter/Dockerfile.v1
+++ b/sdk_compliance_adapter/Dockerfile.v1
@@ -1,0 +1,29 @@
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Copy the SDK source
+COPY go.mod go.sum ./
+COPY *.go ./
+
+# Copy adapter
+COPY sdk_compliance_adapter/main.go /app/adapter/
+
+# Download dependencies
+RUN go mod download
+
+# Build adapter
+RUN cd /app/adapter && go build -o /app/adapter-server main.go
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/adapter-server /app/adapter-server
+
+# Select the capture-v1 protocol; same binary, different runtime mode.
+ENV CAPTURE_MODE=v1
+
+EXPOSE 8080
+
+CMD ["/app/adapter-server"]

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 
 services:
-  # PostHog Go SDK adapter
+  # PostHog Go SDK adapter (capture v0)
   sdk-adapter:
     build:
       context: ..
@@ -11,9 +11,19 @@ services:
     networks:
       - test-network
 
+  # PostHog Go SDK adapter (capture v1)
+  sdk-adapter-v1:
+    build:
+      context: ..
+      dockerfile: sdk_compliance_adapter/Dockerfile.v1
+    ports:
+      - "8082:8080"
+    networks:
+      - test-network
+
   # Test harness
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:latest
+    image: ghcr.io/posthog/sdk-test-harness:0.8.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network

--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +16,14 @@ import (
 )
 
 const VERSION = "1.0.0"
+
+// captureMode selects which capture protocol this adapter process speaks. It is
+// baked at build time via the CAPTURE_MODE env var ("v1" => capture-v1, anything
+// else => legacy v0), mirroring the v0/v1 Dockerfile split. One process speaks
+// one mode and advertises it via /health capabilities.
+var captureMode = os.Getenv("CAPTURE_MODE")
+
+func isV1() bool { return captureMode == "v1" }
 
 // TrackedTransport wraps http.RoundTripper to track requests
 type TrackedTransport struct {
@@ -32,43 +41,83 @@ func (t *TrackedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	// Make the request
 	resp, err := t.base.RoundTrip(req)
-
-	// Track the request
-	if resp != nil {
-		// Parse batch to get UUIDs
-		var batch struct {
-			Batch []struct {
-				UUID string `json:"uuid"`
-			} `json:"batch"`
-		}
-		uuids := []string{}
-		if len(bodyBytes) > 0 {
-			json.Unmarshal(bodyBytes, &batch)
-			for _, event := range batch.Batch {
-				if event.UUID != "" {
-					uuids = append(uuids, event.UUID)
-				}
-			}
-		}
-
-		t.state.mu.Lock()
-		t.state.requestsMade = append(t.state.requestsMade, RequestInfo{
-			TimestampMs:  time.Now().UnixMilli(),
-			StatusCode:   resp.StatusCode,
-			RetryAttempt: 0, // TODO: Track retries
-			EventCount:   len(batch.Batch),
-			UUIDList:     uuids,
-		})
-
-		if resp.StatusCode == 200 {
-			t.state.totalEventsSent += len(batch.Batch)
-			t.state.pendingEvents -= len(batch.Batch)
-			if t.state.pendingEvents < 0 {
-				t.state.pendingEvents = 0
-			}
-		}
-		t.state.mu.Unlock()
+	if resp == nil {
+		return resp, err
 	}
+
+	// Parse batch to get UUIDs. The request body shape is the same for v0 and
+	// v1 ({"batch":[{"uuid":...}]}), so extraction is unchanged.
+	var batch struct {
+		Batch []struct {
+			UUID string `json:"uuid"`
+		} `json:"batch"`
+	}
+	uuids := []string{}
+	if len(bodyBytes) > 0 {
+		json.Unmarshal(bodyBytes, &batch)
+		for _, event := range batch.Batch {
+			if event.UUID != "" {
+				uuids = append(uuids, event.UUID)
+			}
+		}
+	}
+
+	// PostHog-Attempt is 1-based and only set on the v1 path. attempt-1 is the
+	// retry index; attempt > 1 means this request is a retry.
+	attempt := 1
+	if a := req.Header.Get("PostHog-Attempt"); a != "" {
+		if n, e := strconv.Atoi(a); e == nil && n > 0 {
+			attempt = n
+		}
+	}
+
+	// For v1, a 200 no longer means "all sent": read+restore the body and count
+	// only terminal results (anything other than "retry") as sent.
+	terminal := len(batch.Batch)
+	if isV1() {
+		var respBytes []byte
+		if resp.Body != nil {
+			respBytes, _ = io.ReadAll(resp.Body)
+			resp.Body = io.NopCloser(bytes.NewBuffer(respBytes))
+		}
+		if resp.StatusCode == 200 {
+			var parsed struct {
+				Results map[string]struct {
+					Result string `json:"result"`
+				} `json:"results"`
+			}
+			terminal = 0
+			if err := json.Unmarshal(respBytes, &parsed); err == nil {
+				for _, r := range parsed.Results {
+					if r.Result != "retry" {
+						terminal++
+					}
+				}
+			} else {
+				log.Printf("[adapter] v1 response body unmarshal failed: %v (terminal=0, pending events may appear stuck)", err)
+			}
+		}
+	}
+
+	t.state.mu.Lock()
+	t.state.requestsMade = append(t.state.requestsMade, RequestInfo{
+		TimestampMs:  time.Now().UnixMilli(),
+		StatusCode:   resp.StatusCode,
+		RetryAttempt: attempt - 1,
+		EventCount:   len(batch.Batch),
+		UUIDList:     uuids,
+	})
+	if attempt > 1 {
+		t.state.totalRetries++
+	}
+	if resp.StatusCode == 200 {
+		t.state.totalEventsSent += terminal
+		t.state.pendingEvents -= terminal
+		if t.state.pendingEvents < 0 {
+			t.state.pendingEvents = 0
+		}
+	}
+	t.state.mu.Unlock()
 
 	return resp, err
 }
@@ -109,12 +158,14 @@ type HealthResponse struct {
 
 // InitRequest represents /init endpoint request
 type InitRequest struct {
-	APIKey            string `json:"api_key"`
-	Host              string `json:"host"`
-	FlushAt           *int   `json:"flush_at,omitempty"`
-	FlushIntervalMs   *int   `json:"flush_interval_ms,omitempty"`
-	MaxRetries        *int   `json:"max_retries,omitempty"`
-	EnableCompression *bool  `json:"enable_compression,omitempty"`
+	APIKey              string `json:"api_key"`
+	Host                string `json:"host"`
+	FlushAt             *int   `json:"flush_at,omitempty"`
+	FlushIntervalMs     *int   `json:"flush_interval_ms,omitempty"`
+	MaxRetries          *int   `json:"max_retries,omitempty"`
+	EnableCompression   *bool  `json:"enable_compression,omitempty"`
+	DisableGeoIP        *bool  `json:"disable_geoip,omitempty"`
+	HistoricalMigration *bool  `json:"historical_migration,omitempty"`
 }
 
 // CaptureRequest represents /capture endpoint request
@@ -123,6 +174,11 @@ type CaptureRequest struct {
 	Event      string                 `json:"event"`
 	Properties map[string]interface{} `json:"properties,omitempty"`
 	Timestamp  *string                `json:"timestamp,omitempty"`
+	// Options carries capture-v1 event options (cookieless_mode,
+	// disable_skew_correction, process_person_profile, product_tour_id, ...).
+	// The adapter folds them back into magic event properties so the SDK lifts
+	// them onto the wire options object.
+	Options map[string]interface{} `json:"options,omitempty"`
 }
 
 // FeatureFlagRequest represents /get_feature_flag endpoint request
@@ -152,11 +208,15 @@ func jsonResponse(w http.ResponseWriter, data interface{}) {
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {
+	capabilities := []string{"capture_v0", "encoding_gzip"}
+	if isV1() {
+		capabilities = []string{"capture_v1", "encoding_gzip"}
+	}
 	response := HealthResponse{
 		SDKName:        "posthog-go",
 		SDKVersion:     posthog.Version,
 		AdapterVersion: VERSION,
-		Capabilities:   []string{"capture_v0", "encoding_gzip"},
+		Capabilities:   capabilities,
 	}
 	jsonResponse(w, response)
 }
@@ -193,6 +253,10 @@ func initHandler(w http.ResponseWriter, r *http.Request) {
 		Interval:  100 * time.Millisecond, // Short interval for tests
 	}
 
+	if isV1() {
+		config.CaptureMode = posthog.CaptureModeAnalyticsV1
+	}
+
 	// Override with request params if provided
 	if req.FlushAt != nil {
 		config.BatchSize = *req.FlushAt
@@ -209,6 +273,12 @@ func initHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			config.Compression = posthog.CompressionNone
 		}
+	}
+	if req.DisableGeoIP != nil {
+		config.DisableGeoIP = req.DisableGeoIP
+	}
+	if req.HistoricalMigration != nil {
+		config.HistoricalMigration = *req.HistoricalMigration
 	}
 
 	client, err := posthog.NewWithConfig(req.APIKey, config)
@@ -243,6 +313,28 @@ func captureHandler(w http.ResponseWriter, r *http.Request) {
 		DistinctId: req.DistinctID,
 		Event:      req.Event,
 		Properties: req.Properties,
+	}
+
+	// Fold capture-v1 options back into magic event properties; the SDK lifts
+	// them onto the wire options object. Unknown keys get a "$" prefix.
+	if len(req.Options) > 0 {
+		if capture.Properties == nil {
+			capture.Properties = posthog.Properties{}
+		}
+		for k, v := range req.Options {
+			switch k {
+			case "cookieless_mode":
+				capture.Properties["$cookieless_mode"] = v
+			case "disable_skew_correction":
+				capture.Properties["$ignore_sent_at"] = v
+			case "process_person_profile":
+				capture.Properties["$process_person_profile"] = v
+			case "product_tour_id":
+				capture.Properties["$product_tour_id"] = v
+			default:
+				capture.Properties["$"+k] = v
+			}
+		}
 	}
 
 	if req.Timestamp != nil {

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	json "github.com/goccy/go-json"
 )
 
 // TestScenario defines common test scenarios for transport mocking
@@ -102,12 +104,17 @@ type MockServerConfig struct {
 	BatchHandler     func(body []byte)
 	FlagsHandler     func(w http.ResponseWriter, r *http.Request)
 	LocalEvalHandler func(w http.ResponseWriter, r *http.Request)
+	// CaptureV1Handler handles the capture-v1 endpoint, returning (status, body).
+	// When nil, the server replies 200 with an all-"ok" results map derived from
+	// the request batch.
+	CaptureV1Handler func(body []byte) (int, string)
 }
 
 // MockServerBuilder builds configurable mock servers
 type MockServerBuilder struct {
 	config       MockServerConfig
 	requestCount int
+	paths        []string
 	mu           sync.Mutex
 }
 
@@ -145,6 +152,20 @@ func (b *MockServerBuilder) WithBatchHandler(handler func(body []byte)) *MockSer
 	return b
 }
 
+func (b *MockServerBuilder) WithCaptureV1Handler(handler func(body []byte) (int, string)) *MockServerBuilder {
+	b.config.CaptureV1Handler = handler
+	return b
+}
+
+// GetPaths returns the request paths the server has seen, in order.
+func (b *MockServerBuilder) GetPaths() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.paths))
+	copy(out, b.paths)
+	return out
+}
+
 func (b *MockServerBuilder) WithFailAfterN(n int) *MockServerBuilder {
 	b.config.FailAfterN = n
 	return b
@@ -164,6 +185,7 @@ func (b *MockServerBuilder) Build() *httptest.Server {
 		b.mu.Lock()
 		b.requestCount++
 		count := b.requestCount
+		b.paths = append(b.paths, r.URL.Path)
 		b.mu.Unlock()
 
 		// Check if we should fail
@@ -174,6 +196,19 @@ func (b *MockServerBuilder) Build() *httptest.Server {
 
 		// Route to appropriate handler
 		switch {
+		case strings.HasPrefix(r.URL.Path, captureV1Path):
+			body, _ := io.ReadAll(r.Body)
+			status, resp := http.StatusOK, ""
+			if b.config.CaptureV1Handler != nil {
+				status, resp = b.config.CaptureV1Handler(body)
+			} else {
+				status, resp = http.StatusOK, allOkResultsBody(body)
+			}
+			w.WriteHeader(status)
+			if resp != "" {
+				w.Write([]byte(resp))
+			}
+
 		case strings.HasPrefix(r.URL.Path, "/batch"):
 			if b.config.BatchHandler != nil {
 				body, _ := io.ReadAll(r.Body)
@@ -208,6 +243,25 @@ func (b *MockServerBuilder) Build() *httptest.Server {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
+}
+
+// allOkResultsBody parses a capture-v1 request envelope and returns a results
+// body marking every event uuid as "ok".
+func allOkResultsBody(body []byte) string {
+	var env eventBatch
+	if err := json.Unmarshal(body, &env); err != nil {
+		return `{"results":{}}`
+	}
+	results := map[string]eventResult{}
+	for _, raw := range env.Batch {
+		var ev struct {
+			Uuid string `json:"uuid"`
+		}
+		_ = json.Unmarshal(raw, &ev)
+		results[ev.Uuid] = eventResult{Result: resultOk}
+	}
+	out, _ := json.Marshal(captureV1Response{Results: results})
+	return string(out)
 }
 
 // NewTestTransport creates a transport for the given test scenario


### PR DESCRIPTION
## :bulb: Motivation and Context

Third PR in the opt-in capture-v1 stack (stacked on #236). This is the **wire-in**: it makes the v1 serialization (#235) and send engine (#236) reachable from the live path, gated by a new `Config.CaptureMode` that **defaults to legacy**. Merging the stack is transparent to existing callers and ships as a **minor** release; the major bump / default flip / legacy removal remain a separate future workstream.

What's here:
- `CaptureMode` enum (`CaptureModeLegacy` = 0 default, `CaptureModeAnalyticsV1` = 1) + `Config.CaptureMode`, validated in `Config.Validate`
- a `capturer` strategy interface with `legacyCapturer` (the existing `/batch/` serialize + send) and `analyticsV1Capturer` (the PR1 serialization + PR2 send engine); the client picks one in `NewWithConfig` from `CaptureMode`
- `Enqueue` now serializes via `c.capture.prepare` and threads the per-event uuid through `preparedMessage`/`preparedBatch` and the batching loop; `processBatch` dispatches via `c.capture.send`
- `MockServerBuilder` gains a capture-v1 route + request-path recording for tests

### Compression codecs (zstd / deflate / brotli)

The v1 endpoint decodes four `Content-Encoding` codecs; previously the SDK only emitted gzip. This PR adds the other three:
- `CompressionZstd` (2), `CompressionDeflate` (3), `CompressionBrotli` (4) on the existing `CompressionMode`, plus a `String()` helper for log/error readability (config.go).
- a `compressV1Body` helper in capture_v1_send.go that emits the matching wire token (`gzip` / `deflate` / `zstd` / `br`); `uploadV1` sets `Content-Encoding` from it.
- **Deflate is emitted as zlib (RFC 1950)** so the stream starts with `0x78`; the backend sniffs that first byte to route it to its zlib decoder deterministically (server-side first-byte sniffing landed in posthog/posthog#62827), sidestepping raw-vs-zlib ambiguity.
- **Gating:** the three new codecs require `CaptureModeAnalyticsV1`. The legacy `/batch/` endpoint only understands gzip/lz64/base64, so `Config.Validate` rejects zstd/deflate/brotli under `CaptureModeLegacy`. gzip and none stay valid on both modes.

**Dependencies (pure Go, no cgo):** stdlib `compress/zlib` (deflate); `github.com/klauspost/compress/zstd` v1.17.11 (zstd, shared concurrency-safe encoder via `EncodeAll`); `github.com/andybalholm/brotli` v1.1.1 (brotli). klauspost is pinned to v1.17.x deliberately to keep the module `go 1.21` floor (v1.18+ needs Go 1.22). `CGO_ENABLED=0 go build` verified.

The public API gains only additive symbols (`CaptureMode`, the three `Compression*` constants, `CompressionMode.String`); two `minor` changesets are included.

## :green_heart: How did you test it?

New `capture_v1_integration_test.go`: mode selection (default `Config{}` hits `/batch/`, `CaptureModeAnalyticsV1` hits `/i/v1/analytics/events`), the v1 envelope + `Authorization: Bearer` / `PostHog-Sdk-Info` headers end-to-end through `Enqueue`, and partial retry firing per-event `Success`/`Failure` (3 events: ok / drop / retry to ok = 2 success, 1 failure). Legacy tests are untouched and still assert `/batch/`.

Compression coverage:
- `TestV1SendCompressionCodecs` (table-driven) drives the full send path for none/gzip/zstd/deflate/brotli and asserts the right `Content-Encoding`; the test server decodes per that header and recovers the original batch.
- `TestCompressV1Body` checks the codec helper directly: correct wire token, real size reduction on compressible input, clean round-trip, and the unknown-mode error path.
- `TestConfigCompression` (table-driven) covers each codec x capture mode: valid / v1-only-rejected / unknown-invalid.

Cross-language decode proof: the `capture-v1-go-smoke` and `capture-v1-rs-smoke` rigs compress with the same libraries used here (klauspost zstd, andybalholm brotli, stdlib zlib) and assert `result: ok` against a live v1 backend, including the zlib-wrapped-deflate case.

Full `make test` (vet + `-race`) green; `make api-diff` clean after `make api-update`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Cursor (Claude Opus 4.8); stacked on #236. The `capturer` interface is the single encapsulation point for every legacy-vs-v1 divergence (both serialization shape and send/retry semantics), chosen once at construction so the public API, queue, and batching machinery stay protocol-agnostic. Building v1 behind this seam means the eventual major-version cutover is mostly deletion (drop `legacyCapturer`, hardcode v1, remove the enum branch).

The compression codecs were added in this PR (rather than a later one) because it is the earliest layer where `CaptureMode` exists, so the v1-only gating can be enforced atomically with the codecs themselves. #238 and #239 were rebased on top; their content is unchanged (range-diff verified).
