### PR TITLE
feat(capture): typed v1 errors and verbose result logging

### DIFF
--- a/.changeset/capture-v1-typed-errors.md
+++ b/.changeset/capture-v1-typed-errors.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Enrich capture-v1 failure reporting with typed errors and verbose result logging. When `CaptureMode` is `CaptureModeAnalyticsV1`, `Callback.Failure` now receives either a `*CaptureEventError` (a single event the server dropped, or one still asking to retry once attempts are exhausted — exposing `EventUUID`, `Result`, `Details`, and `Exhausted`) or a `*CaptureRequestError` (a whole request that failed on a non-2xx status, transport error, or malformed body — exposing `StatusCode`, `Code`, `Description`, and unwrapping to the underlying error). Inspect them with `errors.As`. Additionally, with `Verbose: true` the SDK logs one debug line per 2xx response summarizing the per-event directive counts (ok/warning/drop/retry/other) so partial-submission outcomes are easy to debug. The legacy path and its callback errors are unchanged.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -193,6 +193,16 @@ func (msg Capture) APIfy() APIMessage
 
 func (msg Capture) Validate() error
 
+type CaptureEventError struct {
+	EventUUID string
+	Result string
+	Details string
+	Exhausted bool
+}
+
+
+func (e *CaptureEventError) Error() string
+
 type CaptureInApi struct {
 	Type string `json:"-"`
 	Uuid string `json:"uuid"`
@@ -212,6 +222,18 @@ const (
 	CaptureModeLegacy CaptureMode = 0
 	CaptureModeAnalyticsV1 CaptureMode = 1
 )
+type CaptureRequestError struct {
+	StatusCode int
+	Code string
+	Description string
+	Err error
+}
+
+
+func (e *CaptureRequestError) Error() string
+
+func (e *CaptureRequestError) Unwrap() error
+
 type Client interface {
 	EnqueueClient
 

--- a/capture_v1_errors.go
+++ b/capture_v1_errors.go
@@ -1,0 +1,62 @@
+package posthog
+
+import "fmt"
+
+// CaptureEventError is delivered to Callback.Failure for a single event that the
+// capture-v1 endpoint rejected: either a terminal "drop" result, or an event
+// still asking to "retry" once the attempt budget is exhausted. Callers can use
+// errors.As to inspect the per-event outcome.
+type CaptureEventError struct {
+	// EventUUID is the uuid of the rejected event (matches Capture.Uuid etc.).
+	EventUUID string
+	// Result is the server's per-event directive, e.g. "drop" or "retry".
+	Result string
+	// Details is the server-supplied explanation, when present (may be empty).
+	Details string
+	// Exhausted is true when the event was still retryable but the SDK ran out
+	// of attempts, false for a server-directed terminal drop.
+	Exhausted bool
+}
+
+func (e *CaptureEventError) Error() string {
+	if e.Exhausted {
+		if e.Details != "" {
+			return fmt.Sprintf("capture event %s not persisted after retries: %s (%s)", e.EventUUID, e.Result, e.Details)
+		}
+		return fmt.Sprintf("capture event %s not persisted after retries: %s", e.EventUUID, e.Result)
+	}
+	if e.Details != "" {
+		return fmt.Sprintf("capture event %s: %s (%s)", e.EventUUID, e.Result, e.Details)
+	}
+	return fmt.Sprintf("capture event %s: %s", e.EventUUID, e.Result)
+}
+
+// CaptureRequestError is delivered to Callback.Failure when an entire capture-v1
+// request fails: a non-2xx status, a transport error, or a malformed 2xx body.
+// It carries the HTTP status and any structured error body the endpoint returned,
+// and unwraps to the underlying transport/parse error when there is one.
+type CaptureRequestError struct {
+	// StatusCode is the HTTP status, or 0 if the request never got a response.
+	StatusCode int
+	// Code is the machine-readable error from the response body (may be empty).
+	Code string
+	// Description is the human-readable error from the response body (may be empty).
+	Description string
+	// Err is the underlying transport or body-parse error, if any.
+	Err error
+}
+
+func (e *CaptureRequestError) Error() string {
+	switch {
+	case e.Code != "" || e.Description != "":
+		return fmt.Sprintf("capture request failed: %d %s: %s", e.StatusCode, e.Code, e.Description)
+	case e.Err != nil && e.StatusCode != 0:
+		return fmt.Sprintf("capture request failed: %d: %s", e.StatusCode, e.Err)
+	case e.Err != nil:
+		return fmt.Sprintf("capture request failed: %s", e.Err)
+	default:
+		return fmt.Sprintf("capture request failed: %d", e.StatusCode)
+	}
+}
+
+func (e *CaptureRequestError) Unwrap() error { return e.Err }

--- a/capture_v1_errors.go
+++ b/capture_v1_errors.go
@@ -6,6 +6,11 @@ import "fmt"
 // capture-v1 endpoint rejected: either a terminal "drop" result, or an event
 // still asking to "retry" once the attempt budget is exhausted. Callers can use
 // errors.As to inspect the per-event outcome.
+//
+// This error type is produced exclusively on the 200-with-partial-results path —
+// when the batch-level HTTP exchange succeeds but individual events within the
+// batch are rejected or not persisted. It is never returned for batch-level
+// transport failures (use CaptureRequestError for those via errors.As).
 type CaptureEventError struct {
 	// EventUUID is the uuid of the rejected event (matches Capture.Uuid etc.).
 	EventUUID string
@@ -35,6 +40,11 @@ func (e *CaptureEventError) Error() string {
 // request fails: a non-2xx status, a transport error, or a malformed 2xx body.
 // It carries the HTTP status and any structured error body the endpoint returned,
 // and unwraps to the underlying transport/parse error when there is one.
+//
+// This error type covers batch-level failures — transport errors, terminal HTTP
+// statuses (400/401/429/...), retryable statuses (5xx) whose retry budget is
+// exhausted, and 2xx responses with unparseable bodies. For per-event failures
+// within a successful batch response, see CaptureEventError.
 type CaptureRequestError struct {
 	// StatusCode is the HTTP status, or 0 if the request never got a response.
 	StatusCode int

--- a/capture_v1_errors_test.go
+++ b/capture_v1_errors_test.go
@@ -150,3 +150,43 @@ func TestV1ResultSummaryLogged(t *testing.T) {
 		t.Errorf("expected a per-response debug summary, got debugf=%v", log.debugf)
 	}
 }
+
+func TestCaptureEventErrorFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		err  CaptureEventError
+		want string
+	}{
+		{"drop_with_details", CaptureEventError{EventUUID: "u1", Result: "drop", Details: "billing"}, "capture event u1: drop (billing)"},
+		{"drop_no_details", CaptureEventError{EventUUID: "u2", Result: "drop"}, "capture event u2: drop"},
+		{"exhausted_with_details", CaptureEventError{EventUUID: "u3", Result: "retry", Details: "not_persisted", Exhausted: true}, "capture event u3 not persisted after retries: retry (not_persisted)"},
+		{"exhausted_no_details", CaptureEventError{EventUUID: "u4", Result: "retry", Exhausted: true}, "capture event u4 not persisted after retries: retry"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCaptureRequestErrorFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		err  CaptureRequestError
+		want string
+	}{
+		{"code_and_description", CaptureRequestError{StatusCode: 400, Code: "invalid_payload", Description: "bad shape"}, "capture request failed: 400 invalid_payload: bad shape"},
+		{"status_only", CaptureRequestError{StatusCode: 429}, "capture request failed: 429"},
+		{"err_with_status", CaptureRequestError{StatusCode: 502, Err: fmt.Errorf("connection reset")}, "capture request failed: 502: connection reset"},
+		{"err_no_status", CaptureRequestError{Err: fmt.Errorf("dial timeout")}, "capture request failed: dial timeout"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/capture_v1_errors_test.go
+++ b/capture_v1_errors_test.go
@@ -1,0 +1,152 @@
+package posthog
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestV1DropYieldsCaptureEventError(t *testing.T) {
+	cb := &recordingCallback{}
+	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+		details := "billing_limit_exceeded"
+		m := map[string]eventResult{uuids[0]: {Result: resultDrop, Details: &details}}
+		return http.StatusOK, resultsBody(t, m), ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	c := newV1TestClient(t, ts.URL, cb, 9, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var ee *CaptureEventError
+	if !errors.As(cb.failures[0].err, &ee) {
+		t.Fatalf("failure err = %T (%v), want *CaptureEventError", cb.failures[0].err, cb.failures[0].err)
+	}
+	if ee.EventUUID != uuidA || ee.Result != resultDrop || ee.Details != "billing_limit_exceeded" || ee.Exhausted {
+		t.Errorf("CaptureEventError = %+v", ee)
+	}
+}
+
+func TestV1ExhaustedRetryYieldsExhaustedEventError(t *testing.T) {
+	cb := &recordingCallback{}
+	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+		m := map[string]eventResult{uuids[0]: {Result: resultRetry}}
+		return http.StatusOK, resultsBody(t, m), ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	// maxRetries=0 => a single attempt, so the retry directive is never satisfied.
+	c := newV1TestClient(t, ts.URL, cb, 0, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var ee *CaptureEventError
+	if !errors.As(cb.failures[0].err, &ee) {
+		t.Fatalf("failure err = %T, want *CaptureEventError", cb.failures[0].err)
+	}
+	if !ee.Exhausted || ee.Result != resultRetry || ee.EventUUID != uuidA {
+		t.Errorf("CaptureEventError = %+v, want exhausted retry for %s", ee, uuidA)
+	}
+}
+
+func TestV1TerminalStatusYieldsRequestError(t *testing.T) {
+	cb := &recordingCallback{}
+	srv := &v1TestServer{respond: func(_ int, _ []string) (int, string, string) {
+		return http.StatusBadRequest, `{"error":"invalid_payload","error_description":"bad batch"}`, ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	c := newV1TestClient(t, ts.URL, cb, 9, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var re *CaptureRequestError
+	if !errors.As(cb.failures[0].err, &re) {
+		t.Fatalf("failure err = %T, want *CaptureRequestError", cb.failures[0].err)
+	}
+	if re.StatusCode != http.StatusBadRequest || re.Code != "invalid_payload" || re.Description != "bad batch" {
+		t.Errorf("CaptureRequestError = %+v", re)
+	}
+}
+
+func TestV1TransportErrorUnwraps(t *testing.T) {
+	cb := &recordingCallback{}
+	// Port 1 is unroutable; the POST fails at the transport layer.
+	c := newV1TestClient(t, "http://127.0.0.1:1", cb, 0, nil)
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	if s, f := cb.counts(); s != 0 || f != 1 {
+		t.Fatalf("callbacks success=%d failure=%d, want 0/1", s, f)
+	}
+	var re *CaptureRequestError
+	if !errors.As(cb.failures[0].err, &re) {
+		t.Fatalf("failure err = %T, want *CaptureRequestError", cb.failures[0].err)
+	}
+	if re.StatusCode != 0 {
+		t.Errorf("StatusCode = %d, want 0 for transport error", re.StatusCode)
+	}
+	if errors.Unwrap(re) == nil {
+		t.Error("CaptureRequestError.Unwrap() = nil, want the underlying transport error")
+	}
+}
+
+// capturingLogger records Debugf format strings for assertions.
+type capturingLogger struct {
+	mu     sync.Mutex
+	debugf []string
+}
+
+func (l *capturingLogger) Debugf(f string, a ...interface{}) {
+	l.mu.Lock()
+	l.debugf = append(l.debugf, fmt.Sprintf(f, a...))
+	l.mu.Unlock()
+}
+func (l *capturingLogger) Logf(string, ...interface{})   {}
+func (l *capturingLogger) Warnf(string, ...interface{})  {}
+func (l *capturingLogger) Errorf(string, ...interface{}) {}
+
+func (l *capturingLogger) debugContains(sub string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, f := range l.debugf {
+		if strings.Contains(f, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestV1ResultSummaryLogged(t *testing.T) {
+	cb := &recordingCallback{}
+	log := &capturingLogger{}
+	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+		m := map[string]eventResult{}
+		for _, u := range uuids {
+			m[u] = eventResult{Result: resultOk}
+		}
+		return http.StatusOK, resultsBody(t, m), ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	c := newV1TestClient(t, ts.URL, cb, 9, func(cfg *Config) { cfg.Logger = log })
+	c.sendV1(v1Batch(t, cap1(uuidA), cap1(uuidB)))
+
+	if !log.debugContains("capture v1 response request_id=") {
+		t.Errorf("expected a per-response debug summary, got debugf=%v", log.debugf)
+	}
+}

--- a/capture_v1_send.go
+++ b/capture_v1_send.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,16 +73,17 @@ func (c *client) sendV1(pb preparedBatch) {
 		})
 		if err != nil {
 			c.Errorf("marshalling v1 batch wrapper - %s", err)
-			c.notifyFailure(pendingMsgs, err)
+			c.notifyFailure(pendingMsgs, &CaptureRequestError{Err: err})
 			return
 		}
 
 		res, err := c.uploadV1(c.ctx, body, requestId, attempt)
 		if err != nil {
+			reqErr := newCaptureRequestError(res, err)
 			// A 2xx with an unparseable body is terminal for this batch -
 			// retrying a malformed success would loop forever.
 			if res != nil && isSuccessStatus(res.statusCode) {
-				c.notifyFailure(pendingMsgs, err)
+				c.notifyFailure(pendingMsgs, reqErr)
 				return
 			}
 			// A terminal non-retryable status (400/401/429/...) whose body
@@ -94,32 +96,40 @@ func (c *client) sendV1(pb preparedBatch) {
 			// Transport error: retry unless shutting down or exhausted.
 			if c.ctx.Err() != nil {
 				c.Errorf("%d messages dropped: shutdown timeout", len(pendingMsgs))
-				c.notifyFailure(pendingMsgs, err)
+				c.notifyFailure(pendingMsgs, reqErr)
 				return
 			}
 			if lastAttempt {
-				c.dropMessages(pendingMsgs, err)
+				c.dropMessages(pendingMsgs, reqErr)
 				return
 			}
 			if !c.backoffV1(i, res) {
-				c.notifyFailure(pendingMsgs, err)
+				c.notifyFailure(pendingMsgs, reqErr)
 				return
 			}
 			continue
 		}
 
 		if isSuccessStatus(res.statusCode) {
+			c.logV1ResultSummary(requestId, attempt, res.results)
 			nextData, nextMsgs, nextUuids := c.partitionV1Results(res, pendingData, pendingMsgs, pendingUuids)
 			if len(nextUuids) == 0 {
 				return
 			}
 			if lastAttempt {
-				c.dropMessages(nextMsgs, fmt.Errorf("capture v1: %d events not persisted after %d attempts", len(nextMsgs), c.maxAttempts))
+				c.Errorf("%d messages dropped after %d attempts", len(nextMsgs), c.maxAttempts)
+				for idx, id := range nextUuids {
+					var details string
+					if r, ok := res.results[id]; ok && r.Details != nil {
+						details = *r.Details
+					}
+					c.notifyFailure([]APIMessage{nextMsgs[idx]}, &CaptureEventError{EventUUID: id, Result: resultRetry, Details: details, Exhausted: true})
+				}
 				return
 			}
 			pendingData, pendingMsgs, pendingUuids = nextData, nextMsgs, nextUuids
 			if !c.backoffV1(i, res) {
-				c.notifyFailure(pendingMsgs, fmt.Errorf("capture v1: shutdown during retry backoff"))
+				c.notifyFailure(pendingMsgs, &CaptureRequestError{Err: errShutdownDuringBackoff})
 				return
 			}
 			continue
@@ -332,20 +342,59 @@ func isSuccessStatus(code int) bool {
 	return code >= 200 && code <= 299
 }
 
-// eventErrorV1 builds the per-event failure error for a "drop" result (or an
-// exhausted "retry"). PR5 replaces this with the typed CaptureEventError.
+// errShutdownDuringBackoff is the underlying cause when retries are abandoned
+// because the client is shutting down mid-backoff.
+var errShutdownDuringBackoff = errors.New("shutdown during retry backoff")
+
+// eventErrorV1 builds the per-event CaptureEventError for a terminal "drop".
 func eventErrorV1(eventUuid string, r eventResult) error {
-	if r.Details != nil && *r.Details != "" {
-		return fmt.Errorf("capture event %s: %s (%s)", eventUuid, r.Result, *r.Details)
+	details := ""
+	if r.Details != nil {
+		details = *r.Details
 	}
-	return fmt.Errorf("capture event %s: %s", eventUuid, r.Result)
+	return &CaptureEventError{EventUUID: eventUuid, Result: r.Result, Details: details}
 }
 
-// requestErrorV1 builds the batch-level failure error for a non-2xx response.
-// PR5 replaces this with the typed CaptureRequestError.
+// requestErrorV1 builds the batch-level CaptureRequestError for a non-2xx response.
 func requestErrorV1(res *v1Result) error {
-	if res.errResp != nil {
-		return fmt.Errorf("capture request failed: %d %s: %s", res.statusCode, res.errResp.Error, res.errResp.ErrorDescription)
+	return newCaptureRequestError(res, nil)
+}
+
+// newCaptureRequestError assembles a *CaptureRequestError from an optional parsed
+// result (status + structured error body) and an optional underlying error.
+func newCaptureRequestError(res *v1Result, underlying error) *CaptureRequestError {
+	e := &CaptureRequestError{Err: underlying}
+	if res != nil {
+		e.StatusCode = res.statusCode
+		if res.errResp != nil {
+			e.Code = res.errResp.Error
+			e.Description = res.errResp.ErrorDescription
+		}
 	}
-	return fmt.Errorf("capture request failed: %d", res.statusCode)
+	return e
+}
+
+// logV1ResultSummary emits a single verbose debug line per 2xx response that
+// tallies per-event directives (ok/warning/drop/retry/other), so operators can
+// debug partial-submission outcomes without diffing the raw response body.
+func (c *client) logV1ResultSummary(requestId string, attempt int, results map[string]eventResult) {
+	var ok, warning, drop, retry, other int
+	for _, r := range results {
+		switch r.Result {
+		case resultOk:
+			ok++
+		case resultWarning:
+			warning++
+		case resultDrop:
+			drop++
+		case resultRetry:
+			retry++
+		default:
+			other++
+		}
+	}
+	c.debugf(
+		"capture v1 response request_id=%s attempt=%d events=%d ok=%d warning=%d drop=%d retry=%d other=%d",
+		requestId, attempt, len(results), ok, warning, drop, retry, other,
+	)
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

Final PR in the opt-in capture-v1 stack (stacked on #238). PR1–PR4 built and wired the v1 path but reported failures with plain `fmt.Errorf`. This swaps in **public typed errors** so callers can react to partial-submission outcomes programmatically, and adds the **verbose per-response summary** requested for debugging partial fails.

What's here:
- `CaptureEventError` (`EventUUID`, `Result`, `Details`, `Exhausted`) is delivered to `Callback.Failure` for a terminal `drop`, and for a still-`retry` event once the attempt budget is exhausted (`Exhausted: true`)
- `CaptureRequestError` (`StatusCode`, `Code`, `Description`, `Err`) covers non-2xx statuses, transport errors, and malformed 2xx bodies, and `Unwrap`s to the underlying error; both are inspectable with `errors.As`
- with `Verbose: true`, one debug line per 2xx tallies the per-event directive counts (`ok`/`warning`/`drop`/`retry`/`other`) keyed by request id + attempt

Only the v1 path changes — legacy callback errors are byte-for-byte unchanged. The public API gains only the additive error types; a `minor` changeset is included.

## :green_heart: How did you test it?

New `capture_v1_errors_test.go`: `drop` → `*CaptureEventError` with details and `Exhausted=false`; exhausted `retry` → `*CaptureEventError` with `Exhausted=true`; a 400 with a structured error body → `*CaptureRequestError` carrying status/code/description; a transport failure (unroutable port) → `*CaptureRequestError` with `StatusCode==0` that unwraps to the dial error; and a capturing logger asserts the per-response debug summary is emitted. Core package `go test -race` green; `go build ./...` + `go vet ./...` clean across the module; `make api-diff` clean after `make api-update`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Cursor (Claude Opus 4.8); top of the stack on #238. Errors were intentionally untyped through #236/#237 so each PR stayed small and reviewers could see the engine, the wire-in, and the public error surface separately. With this merged, the full opt-in capture-v1 path (serialize → send/retry → route → typed failures + verbose logging) is complete behind `CaptureMode`, defaulting to legacy. The future major-version workstream flips the default and deletes `legacyCapturer`.
