### PR TITLE
chore: use pnpm setup runtime action

### DIFF
--- a/.github/pnpm-setup-package.json
+++ b/.github/pnpm-setup-package.json
@@ -1,4 +1,0 @@
-{
-  "private": true,
-  "packageManager": "pnpm@11.7.0"
-}

--- a/.github/pnpm-setup-package.json
+++ b/.github/pnpm-setup-package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "packageManager": "pnpm@11.7.0"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,14 +92,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
         with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,9 @@ jobs:
         with:
           # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
           version: 11.7.0
+          # Use a setup-only manifest so pnpm/setup can bootstrap pnpm runtime with pnpm >=11
+          # without changing this repo's project packageManager version.
+          package-json-file: .github/pnpm-setup-package.json
           runtime: node@24
           cache: true
           install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,6 @@ jobs:
         with:
           # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
           version: 11.7.0
-          # Use a setup-only manifest so pnpm/setup can bootstrap pnpm runtime with pnpm >=11
-          # without changing this repo's project packageManager version.
-          package-json-file: .github/pnpm-setup-package.json
           runtime: node@24
           cache: true
           install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Setup pnpm and Node.js
         uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
         with:
+          # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
+          version: 11.7.0
           runtime: node@24
           cache: true
           install: false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Minimum age (in days) before a package version can be installed
+# 7 days
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.16.2",
   "private": true,
   "description": "Release metadata and changesets for the PostHog Go SDK",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.7.0",
   "scripts": {
     "changeset": "changeset"
   },


### PR DESCRIPTION
## :bulb: Motivation and Context

Simplify CI setup by replacing the separate `pnpm/action-setup` + `actions/setup-node` + pnpm cache wiring with the new pinned `pnpm/setup` action, which installs pnpm and the Node.js runtime in one step.

This also adds/keeps package-manager release-age gates at a total of 7 days:

- npm `.npmrc`: `min-release-age=7` because npm uses days.
- pnpm `minimumReleaseAge: 10080` because pnpm uses minutes.

Note: `pnpm/setup` does not currently read `.nvmrc`, so Node 24 is duplicated in the action config for now where the repo also has `.nvmrc`. Once https://github.com/jasongin/nvs/pull/315 lands, we can remove that duplicated runtime version and go back to a single `.nvmrc` source of truth.

## :green_heart: How did you test it?

- Parsed the changed GitHub Actions / pnpm YAML with PyYAML.
- Checked `.npmrc` files use npm's day-based `min-release-age=7` and pnpm files use minute-based `minimumReleaseAge: 10080`.
- Ran `git diff --check`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Updated the CI setup at the user's request after checking the new `pnpm/setup` action behavior. Chose `install: false` so existing explicit `pnpm install --frozen-lockfile` commands keep their current lockfile behavior, and pinned the action to the current `v1` commit SHA.
