### PR TITLE
fix: fall back to uncompressed on compression failure

### DIFF
--- a/.changeset/compression-fallback-uncompressed.md
+++ b/.changeset/compression-fallback-uncompressed.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Send capture batches uncompressed when request-body compression fails instead of failing the batch.

--- a/capture_v1_send.go
+++ b/capture_v1_send.go
@@ -2,8 +2,6 @@ package posthog
 
 import (
 	"bytes"
-	"compress/gzip"
-	"compress/zlib"
 	"context"
 	"errors"
 	"fmt"
@@ -13,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/andybalholm/brotli"
 	json "github.com/goccy/go-json"
 	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
@@ -216,53 +213,42 @@ func (c *client) dropMessages(msgs []APIMessage, err error) {
 
 // compressV1Body compresses the v1 request body per the configured mode and
 // returns the body plus the Content-Encoding wire token ("" when uncompressed,
-// "br" for brotli). gzip/deflate/brotli use per-call writers; zstd reuses the
-// shared concurrency-safe encoder. The codecs other than gzip are gated to
-// CaptureModeAnalyticsV1 by Config.Validate, so this is only reached for modes
-// the backend can decode via Content-Encoding.
+// "br" for brotli). If a configured codec fails, the raw body is returned
+// without a Content-Encoding token so the batch can still be sent
+// uncompressed. zstd reuses the shared concurrency-safe encoder. The codecs
+// other than gzip are gated to CaptureModeAnalyticsV1 by Config.Validate, so
+// this is only reached for modes the backend can decode via Content-Encoding.
 func compressV1Body(mode CompressionMode, raw []byte) ([]byte, string, error) {
 	switch mode {
 	case CompressionNone:
 		return raw, "", nil
 	case CompressionGzip:
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		if _, err := gw.Write(raw); err != nil {
-			return nil, "", fmt.Errorf("gzip compression: %w", err)
+		body, err := compressGzip(raw)
+		if err != nil {
+			return raw, "", nil
 		}
-		if err := gw.Close(); err != nil {
-			return nil, "", fmt.Errorf("gzip close: %w", err)
-		}
-		return buf.Bytes(), "gzip", nil
+		return body, "gzip", nil
 	case CompressionDeflate:
 		// zlib (RFC 1950) wraps the deflate stream so it begins with 0x78; the
 		// backend sniffs that byte to route Content-Encoding: deflate to its
 		// zlib decoder, avoiding ambiguity with raw (headerless) deflate.
-		var buf bytes.Buffer
-		zw := zlib.NewWriter(&buf)
-		if _, err := zw.Write(raw); err != nil {
-			return nil, "", fmt.Errorf("deflate compression: %w", err)
+		body, err := deflateCompress(raw)
+		if err != nil {
+			return raw, "", nil
 		}
-		if err := zw.Close(); err != nil {
-			return nil, "", fmt.Errorf("deflate close: %w", err)
-		}
-		return buf.Bytes(), "deflate", nil
+		return body, "deflate", nil
 	case CompressionZstd:
 		enc, err := getZstdEncoder()
 		if err != nil {
-			return nil, "", fmt.Errorf("zstd encoder init: %w", err)
+			return raw, "", nil
 		}
 		return enc.EncodeAll(raw, make([]byte, 0, len(raw))), "zstd", nil
 	case CompressionBrotli:
-		var buf bytes.Buffer
-		bw := brotli.NewWriter(&buf)
-		if _, err := bw.Write(raw); err != nil {
-			return nil, "", fmt.Errorf("brotli compression: %w", err)
+		body, err := brotliCompress(raw)
+		if err != nil {
+			return raw, "", nil
 		}
-		if err := bw.Close(); err != nil {
-			return nil, "", fmt.Errorf("brotli close: %w", err)
-		}
-		return buf.Bytes(), "br", nil
+		return body, "br", nil
 	default:
 		return nil, "", fmt.Errorf("unsupported compression mode %s", mode)
 	}
@@ -276,6 +262,9 @@ func (c *client) uploadV1(ctx context.Context, b []byte, requestId string, attem
 	if err != nil {
 		c.Errorf("compressing v1 body (%s) - %s", c.Compression, err)
 		return nil, err
+	}
+	if c.Compression != CompressionNone && encoding == "" {
+		c.Warnf("compressing v1 body (%s) failed; sending uncompressed", c.Compression)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint+captureV1Path, bytes.NewReader(body))

--- a/capture_v1_send.go
+++ b/capture_v1_send.go
@@ -214,10 +214,11 @@ func (c *client) dropMessages(msgs []APIMessage, err error) {
 // compressV1Body compresses the v1 request body per the configured mode and
 // returns the body plus the Content-Encoding wire token ("" when uncompressed,
 // "br" for brotli). If a configured codec fails, the raw body is returned
-// without a Content-Encoding token so the batch can still be sent
-// uncompressed. zstd reuses the shared concurrency-safe encoder. The codecs
-// other than gzip are gated to CaptureModeAnalyticsV1 by Config.Validate, so
-// this is only reached for modes the backend can decode via Content-Encoding.
+// without a Content-Encoding token plus the compression error so callers can
+// log it while still sending the batch uncompressed. zstd reuses the shared
+// concurrency-safe encoder. The codecs other than gzip are gated to
+// CaptureModeAnalyticsV1 by Config.Validate, so this is only reached for modes
+// the backend can decode via Content-Encoding.
 func compressV1Body(mode CompressionMode, raw []byte) ([]byte, string, error) {
 	switch mode {
 	case CompressionNone:
@@ -225,7 +226,7 @@ func compressV1Body(mode CompressionMode, raw []byte) ([]byte, string, error) {
 	case CompressionGzip:
 		body, err := compressGzip(raw)
 		if err != nil {
-			return raw, "", nil
+			return raw, "", err
 		}
 		return body, "gzip", nil
 	case CompressionDeflate:
@@ -234,19 +235,19 @@ func compressV1Body(mode CompressionMode, raw []byte) ([]byte, string, error) {
 		// zlib decoder, avoiding ambiguity with raw (headerless) deflate.
 		body, err := deflateCompress(raw)
 		if err != nil {
-			return raw, "", nil
+			return raw, "", err
 		}
 		return body, "deflate", nil
 	case CompressionZstd:
 		enc, err := getZstdEncoder()
 		if err != nil {
-			return raw, "", nil
+			return raw, "", fmt.Errorf("zstd encoder init: %w", err)
 		}
 		return enc.EncodeAll(raw, make([]byte, 0, len(raw))), "zstd", nil
 	case CompressionBrotli:
 		body, err := brotliCompress(raw)
 		if err != nil {
-			return raw, "", nil
+			return raw, "", err
 		}
 		return body, "br", nil
 	default:
@@ -260,11 +261,11 @@ func compressV1Body(mode CompressionMode, raw []byte) ([]byte, string, error) {
 func (c *client) uploadV1(ctx context.Context, b []byte, requestId string, attempt int) (*v1Result, error) {
 	body, encoding, err := compressV1Body(c.Compression, b)
 	if err != nil {
-		c.Errorf("compressing v1 body (%s) - %s", c.Compression, err)
-		return nil, err
-	}
-	if c.Compression != CompressionNone && encoding == "" {
-		c.Warnf("compressing v1 body (%s) failed; sending uncompressed", c.Compression)
+		if body == nil {
+			c.Errorf("compressing v1 body (%s) - %s", c.Compression, err)
+			return nil, err
+		}
+		c.Warnf("compressing v1 body (%s) failed; sending uncompressed - %s", c.Compression, err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint+captureV1Path, bytes.NewReader(body))

--- a/capture_v1_send_test.go
+++ b/capture_v1_send_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -555,7 +556,7 @@ func TestV1SendCompressionCodecs(t *testing.T) {
 func TestV1SendCompressionFailureFallsBackToUncompressed(t *testing.T) {
 	originalCompressGzip := compressGzip
 	compressGzip = func([]byte) ([]byte, error) {
-		return nil, errors.New("compression unavailable")
+		return nil, errors.New("gzip unavailable")
 	}
 	defer func() { compressGzip = originalCompressGzip }()
 
@@ -588,6 +589,87 @@ func TestV1SendCompressionFailureFallsBackToUncompressed(t *testing.T) {
 	}
 	if s, f := cb.counts(); s != 1 || f != 0 {
 		t.Errorf("callbacks: success=%d failure=%d, want 1/0", s, f)
+	}
+}
+
+func TestCompressV1BodyFailureFallsBackToUncompressed(t *testing.T) {
+	raw := []byte(`{"event":"e","distinct_id":"d"}`)
+
+	cases := []struct {
+		name    string
+		mode    CompressionMode
+		stubErr string
+		stub    func() func()
+	}{
+		{
+			name:    "gzip",
+			mode:    CompressionGzip,
+			stubErr: "gzip unavailable",
+			stub: func() func() {
+				original := compressGzip
+				compressGzip = func([]byte) ([]byte, error) {
+					return nil, errors.New("gzip unavailable")
+				}
+				return func() { compressGzip = original }
+			},
+		},
+		{
+			name:    "zstd",
+			mode:    CompressionZstd,
+			stubErr: "zstd unavailable",
+			stub: func() func() {
+				original := getZstdEncoder
+				getZstdEncoder = func() (*zstd.Encoder, error) {
+					return nil, errors.New("zstd unavailable")
+				}
+				return func() { getZstdEncoder = original }
+			},
+		},
+		{
+			name:    "deflate",
+			mode:    CompressionDeflate,
+			stubErr: "deflate unavailable",
+			stub: func() func() {
+				original := deflateCompress
+				deflateCompress = func([]byte) ([]byte, error) {
+					return nil, errors.New("deflate unavailable")
+				}
+				return func() { deflateCompress = original }
+			},
+		},
+		{
+			name:    "brotli",
+			mode:    CompressionBrotli,
+			stubErr: "brotli unavailable",
+			stub: func() func() {
+				original := brotliCompress
+				brotliCompress = func([]byte) ([]byte, error) {
+					return nil, errors.New("brotli unavailable")
+				}
+				return func() { brotliCompress = original }
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restore := tc.stub()
+			defer restore()
+
+			body, token, err := compressV1Body(tc.mode, raw)
+			if err == nil {
+				t.Fatal("expected compression error")
+			}
+			if !strings.Contains(err.Error(), tc.stubErr) {
+				t.Fatalf("error = %v, want to contain %q", err, tc.stubErr)
+			}
+			if token != "" {
+				t.Errorf("token = %q, want empty fallback", token)
+			}
+			if !bytes.Equal(body, raw) {
+				t.Errorf("body = %q, want raw", body)
+			}
+		})
 	}
 }
 

--- a/capture_v1_send_test.go
+++ b/capture_v1_send_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -548,6 +549,45 @@ func TestV1SendCompressionCodecs(t *testing.T) {
 				t.Errorf("success callbacks = %d, want 1", s)
 			}
 		})
+	}
+}
+
+func TestV1SendCompressionFailureFallsBackToUncompressed(t *testing.T) {
+	originalCompressGzip := compressGzip
+	compressGzip = func([]byte) ([]byte, error) {
+		return nil, errors.New("compression unavailable")
+	}
+	defer func() { compressGzip = originalCompressGzip }()
+
+	cb := &recordingCallback{}
+	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {
+		m := map[string]eventResult{}
+		for _, u := range uuids {
+			m[u] = eventResult{Result: resultOk}
+		}
+		return http.StatusOK, resultsBody(t, m), ""
+	}}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	c := newV1TestClient(t, ts.URL, cb, 9, func(cfg *Config) {
+		cfg.CaptureMode = CaptureModeAnalyticsV1
+		cfg.Compression = CompressionGzip
+	})
+	c.sendV1(v1Batch(t, cap1(uuidA)))
+
+	reqs := srv.snapshot()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	if reqs[0].encoding != "" {
+		t.Errorf("Content-Encoding = %q, want empty fallback", reqs[0].encoding)
+	}
+	if len(reqs[0].uuids) != 1 || reqs[0].uuids[0] != uuidA {
+		t.Errorf("decoded uuids = %v, want [%s]", reqs[0].uuids, uuidA)
+	}
+	if s, f := cb.counts(); s != 1 || f != 0 {
+		t.Errorf("callbacks: success=%d failure=%d, want 1/0", s, f)
 	}
 }
 

--- a/compression_test.go
+++ b/compression_test.go
@@ -2,6 +2,7 @@ package posthog
 
 import (
 	"compress/gzip"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -239,6 +240,56 @@ func TestCompressionModeConstants(t *testing.T) {
 	require.Equal(t, CompressionMode(2), CompressionZstd)
 	require.Equal(t, CompressionMode(3), CompressionDeflate)
 	require.Equal(t, CompressionMode(4), CompressionBrotli)
+}
+
+func TestCompressionGzipFailureFallsBackToUncompressed(t *testing.T) {
+	originalCompressGzip := compressGzip
+	compressGzip = func([]byte) ([]byte, error) {
+		return nil, errors.New("compression unavailable")
+	}
+	defer func() { compressGzip = originalCompressGzip }()
+
+	var receivedContentEncoding string
+	var receivedURL string
+	var receivedBody []byte
+	var successCount, failureCount int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/batch") {
+			receivedContentEncoding = r.Header.Get("Content-Encoding")
+			receivedURL = r.URL.String()
+			receivedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(200)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewWithConfig("test-key", Config{
+		Endpoint:    server.URL,
+		Compression: CompressionGzip,
+		BatchSize:   1,
+		Callback: testCallback{
+			success: func(m APIMessage) { successCount++ },
+			failure: func(m APIMessage, e error) { failureCount++ },
+		},
+	})
+	require.NoError(t, err)
+
+	err = client.Enqueue(Capture{
+		DistinctId: "user-1",
+		Event:      "test-event",
+	})
+	require.NoError(t, err)
+	client.Close()
+
+	require.Equal(t, "/batch/", receivedURL)
+	require.Empty(t, receivedContentEncoding)
+	var batch map[string]interface{}
+	err = json.Unmarshal(receivedBody, &batch)
+	require.NoError(t, err, "fallback body should be uncompressed JSON")
+	require.Contains(t, batch, "batch")
+	require.Equal(t, 1, successCount, "batch should not fail when compression fails")
+	require.Equal(t, 0, failureCount)
 }
 
 func TestCompressionGzipWithCallback(t *testing.T) {

--- a/posthog.go
+++ b/posthog.go
@@ -2,7 +2,6 @@ package posthog
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -1529,20 +1528,17 @@ func (c *client) send(pb preparedBatch) {
 func (c *client) upload(ctx context.Context, b []byte) error {
 	url := c.Endpoint + "/batch/"
 	body := b
+	encoding := ""
 
 	if c.Compression == CompressionGzip {
-		url += "?compression=gzip"
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		if _, err := gw.Write(b); err != nil {
-			c.Errorf("gzip compression - %s", err)
-			return fmt.Errorf("gzip compression: %w", err)
+		compressed, err := compressGzip(b)
+		if err != nil {
+			c.Warnf("gzip compression failed; sending uncompressed - %s", err)
+		} else {
+			url += "?compression=gzip"
+			body = compressed
+			encoding = "gzip"
 		}
-		if err := gw.Close(); err != nil {
-			c.Errorf("gzip close - %s", err)
-			return fmt.Errorf("gzip close: %w", err)
-		}
-		body = buf.Bytes()
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
@@ -1556,8 +1552,8 @@ func (c *client) upload(ctx context.Context, b []byte) error {
 	req.Header.Add("User-Agent", SDKName+"/"+version)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Content-Length", fmt.Sprintf("%d", len(body)))
-	if c.Compression == CompressionGzip {
-		req.Header.Add("Content-Encoding", "gzip")
+	if encoding != "" {
+		req.Header.Add("Content-Encoding", encoding)
 	}
 
 	res, err := c.http.Do(req)

--- a/request_compression.go
+++ b/request_compression.go
@@ -9,7 +9,11 @@ import (
 	"github.com/andybalholm/brotli"
 )
 
-var compressGzip = gzipCompress
+var (
+	compressGzip    = gzipCompress
+	deflateCompress = zlibCompress
+	brotliCompress  = brotliEncode
+)
 
 func gzipCompress(raw []byte) ([]byte, error) {
 	var buf bytes.Buffer
@@ -23,7 +27,7 @@ func gzipCompress(raw []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func deflateCompress(raw []byte) ([]byte, error) {
+func zlibCompress(raw []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	zw := zlib.NewWriter(&buf)
 	if _, err := zw.Write(raw); err != nil {
@@ -35,7 +39,7 @@ func deflateCompress(raw []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func brotliCompress(raw []byte) ([]byte, error) {
+func brotliEncode(raw []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	bw := brotli.NewWriter(&buf)
 	if _, err := bw.Write(raw); err != nil {

--- a/request_compression.go
+++ b/request_compression.go
@@ -1,0 +1,48 @@
+package posthog
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"fmt"
+
+	"github.com/andybalholm/brotli"
+)
+
+var compressGzip = gzipCompress
+
+func gzipCompress(raw []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(raw); err != nil {
+		return nil, fmt.Errorf("gzip compression: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return nil, fmt.Errorf("gzip close: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func deflateCompress(raw []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		return nil, fmt.Errorf("deflate compression: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("deflate close: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func brotliCompress(raw []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	bw := brotli.NewWriter(&buf)
+	if _, err := bw.Write(raw); err != nil {
+		return nil, fmt.Errorf("brotli compression: %w", err)
+	}
+	if err := bw.Close(); err != nil {
+		return nil, fmt.Errorf("brotli close: %w", err)
+	}
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Go treated request-body compression failures as batch upload failures. The Rust SDK falls back to sending the original uncompressed payload instead, which avoids dropping/retrying an otherwise valid batch when compression is unavailable.

## :green_heart: How did you test it?

- `go test ./...`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi. The change matches Rust SDK behavior by using uncompressed request bodies when compression fails, rather than failing the batch. Compression helpers are shared between legacy and v1 paths so both code paths get the fallback behavior; v1 fallback preserves the underlying compression error in warning logs. Regression tests cover legacy gzip fallback and parameterized v1 fallback across gzip, zstd, deflate, and brotli.
