### PR TITLE
fix: preserve v1 caller system context

### DIFF
--- a/.changeset/calm-owls-merge.md
+++ b/.changeset/calm-owls-merge.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Preserve caller-provided system context values when building capture v1 event properties.

--- a/capture_local_eval_test.go
+++ b/capture_local_eval_test.go
@@ -15,6 +15,8 @@ import (
 // requests so capture-enrichment tests can assert whether a network /flags call
 // was made. A definitionsFixture of "" makes the definitions endpoint fail,
 // simulating definitions that never load.
+const captureLocalEvalWaitTimeout = 5 * time.Second
+
 type captureLocalEvalServer struct {
 	server      *httptest.Server
 	decideCalls atomic.Int32
@@ -165,7 +167,7 @@ func TestCaptureSendFeatureFlagsLocalEvaluation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			event := capture.waitForEvent(2 * time.Second)
+			event := capture.waitForEvent(captureLocalEvalWaitTimeout)
 			if event == nil {
 				t.Fatal("timed out waiting for captured event")
 			}
@@ -244,7 +246,7 @@ func assertCaptureFeatureFlagFallback(t *testing.T, definitions, flagsResponse, 
 	if err := client.Enqueue(Capture{Event: "test_event", DistinctId: "distinct-id", SendFeatureFlags: SendFeatureFlags(true)}); err != nil {
 		t.Fatal(err)
 	}
-	event := capture.waitForEvent(2 * time.Second)
+	event := capture.waitForEvent(captureLocalEvalWaitTimeout)
 	if event == nil {
 		t.Fatal("timed out waiting for captured event")
 	}

--- a/capture_v1.go
+++ b/capture_v1.go
@@ -270,7 +270,7 @@ func prepareForSendV1(msg Message, logger Logger) (json.RawMessage, APIMessage, 
 func (msg Capture) apifyEvent() apiEvent {
 	myProperties := baseV1Props(msg.IsServer, false).
 		Merge(msg.Properties).
-		Merge(getSystemContext().ToProperties())
+		mergeDefaults(getSystemContext().ToProperties())
 
 	if msg.Groups != nil {
 		myProperties.Set("$groups", msg.Groups)
@@ -289,7 +289,7 @@ func (msg Capture) apifyEvent() apiEvent {
 // properties are folded into properties.$set (v1 has no top-level $set).
 func (msg Identify) apifyEvent() apiEvent {
 	myProperties := baseV1Props(msg.IsServer, msg.DisableGeoIP).
-		Merge(getSystemContext().ToProperties())
+		mergeDefaults(getSystemContext().ToProperties())
 
 	if msg.Properties != nil {
 		myProperties.Set("$set", msg.Properties)
@@ -311,7 +311,7 @@ func (msg GroupIdentify) apifyEvent() apiEvent {
 	myProperties := baseV1Props(msg.IsServer, msg.DisableGeoIP).
 		Set("$group_type", msg.Type).
 		Set("$group_key", msg.Key).
-		Merge(getSystemContext().ToProperties())
+		mergeDefaults(getSystemContext().ToProperties())
 
 	if msg.Properties != nil {
 		myProperties.Set("$group_set", msg.Properties)
@@ -332,7 +332,7 @@ func (msg GroupIdentify) apifyEvent() apiEvent {
 // into properties.
 func (msg Alias) apifyEvent() apiEvent {
 	myProperties := baseV1Props(msg.IsServer, msg.DisableGeoIP).
-		Merge(getSystemContext().ToProperties()).
+		mergeDefaults(getSystemContext().ToProperties()).
 		Set("alias", msg.Alias)
 
 	return apiEvent{
@@ -350,7 +350,7 @@ func (msg Alias) apifyEvent() apiEvent {
 func (msg Exception) apifyEvent() apiEvent {
 	myProperties := baseV1Props(msg.IsServer, msg.DisableGeoIP).
 		Merge(msg.Properties).
-		Merge(getSystemContext().ToProperties()).
+		mergeDefaults(getSystemContext().ToProperties()).
 		Set("$exception_list", msg.ExceptionList)
 
 	if msg.ExceptionFingerprint != nil {

--- a/capture_v1_test.go
+++ b/capture_v1_test.go
@@ -96,13 +96,28 @@ func TestV1DropsLibFromProperties(t *testing.T) {
 
 func TestV1SystemContextAppliedAsDefaults(t *testing.T) {
 	sysCtx := getSystemContext().ToProperties()
-	ev := marshalV1(t, Capture{Uuid: "u", Event: "e", DistinctId: "d"})
-	props := wireProps(t, ev)
+	msgs := []struct {
+		name string
+		msg  Message
+	}{
+		{"capture", Capture{Uuid: "u", Event: "e", DistinctId: "d"}},
+		{"identify", Identify{Uuid: "u", DistinctId: "d"}},
+		{"groupidentify", GroupIdentify{Uuid: "u", Type: "company", Key: "acme"}},
+		{"alias", Alias{Uuid: "u", DistinctId: "d", Alias: "a"}},
+		{"exception", Exception{Uuid: "u", DistinctId: "d", ExceptionList: []ExceptionItem{{Type: "Error", Value: "boom"}}}},
+	}
 
-	for _, key := range []string{"$os", "$go_version"} {
-		if props[key] != sysCtx[key] {
-			t.Errorf("%s = %v, want system default %v", key, props[key], sysCtx[key])
-		}
+	for _, tc := range msgs {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := marshalV1(t, tc.msg)
+			props := wireProps(t, ev)
+
+			for _, key := range []string{"$os", "$go_version"} {
+				if props[key] != sysCtx[key] {
+					t.Errorf("%s = %v, want system default %v", key, props[key], sysCtx[key])
+				}
+			}
+		})
 	}
 }
 

--- a/capture_v1_test.go
+++ b/capture_v1_test.go
@@ -94,6 +94,62 @@ func TestV1DropsLibFromProperties(t *testing.T) {
 	}
 }
 
+func TestV1SystemContextAppliedAsDefaults(t *testing.T) {
+	sysCtx := getSystemContext().ToProperties()
+	ev := marshalV1(t, Capture{Uuid: "u", Event: "e", DistinctId: "d"})
+	props := wireProps(t, ev)
+
+	for _, key := range []string{"$os", "$go_version"} {
+		if props[key] != sysCtx[key] {
+			t.Errorf("%s = %v, want system default %v", key, props[key], sysCtx[key])
+		}
+	}
+}
+
+func TestV1SystemContextDoesNotOverwriteCallerProperties(t *testing.T) {
+	callerContext := Properties{
+		"$os":         "caller-os",
+		"$os_version": "caller-os-version",
+		"$os_distro":  "caller-os-distro",
+		"$go_version": "caller-go-version",
+	}
+	msgs := []struct {
+		name string
+		msg  Message
+	}{
+		{
+			name: "capture",
+			msg: Capture{
+				Uuid:       "u",
+				Event:      "e",
+				DistinctId: "d",
+				Properties: callerContext,
+			},
+		},
+		{
+			name: "exception",
+			msg: Exception{
+				Uuid:          "u",
+				DistinctId:    "d",
+				Properties:    callerContext,
+				ExceptionList: []ExceptionItem{{Type: "Error", Value: "boom"}},
+			},
+		},
+	}
+
+	for _, tc := range msgs {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := marshalV1(t, tc.msg)
+			props := wireProps(t, ev)
+			for key, want := range callerContext {
+				if props[key] != want {
+					t.Errorf("%s = %v, want caller value %v", key, props[key], want)
+				}
+			}
+		})
+	}
+}
+
 func TestV1OptionsExtractedOnlyWhenPresent(t *testing.T) {
 	// No magic props -> empty options object.
 	ev := marshalV1(t, Capture{Uuid: "u", Event: "e", DistinctId: "d"})

--- a/properties.go
+++ b/properties.go
@@ -47,3 +47,22 @@ func (p Properties) Merge(props Properties) Properties {
 
 	return p
 }
+
+// mergeDefaults adds properties from defaults only when the receiver does not
+// already contain the key.
+func (p Properties) mergeDefaults(defaults Properties) Properties {
+	if p == nil {
+		p = Properties{}
+	}
+	if defaults == nil {
+		return p
+	}
+
+	for k, v := range defaults {
+		if _, exists := p[k]; !exists {
+			p[k] = v
+		}
+	}
+
+	return p
+}


### PR DESCRIPTION
## :bulb: Motivation and Context
Capture v1 was merging Go system context after caller-provided properties, which meant values like `$os`, `$os_version`, `$os_distro`, and `$go_version` could overwrite explicit caller values. This differed from the Rust SDK behavior, where system context is applied only as defaults.

## :green_heart: How did you test it?

```bash
go test -race -count=1 -timeout=5m -run 'TestCaptureSendFeatureFlagsFallsBackForStaticCohort|TestCaptureSendFeatureFlagsLocalEvaluation' .
go test -count=1 -timeout=5m ./...
go test -race -count=1 -timeout=5m ./...
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent. The change introduces a default-only properties merge helper and uses it for capture v1 system context so explicit caller values are preserved while SDK defaults are still populated when absent. Tests cover both default population and preservation of caller-provided system context values.

A Go 1.21 race-test CI timeout in capture local-evaluation tests was also addressed by using the same 5-second event wait window used by related feature-flag capture tests.
