### PR TITLE
fix: expose capture defaults to BeforeSend hooks

### DIFF
--- a/.changeset/slow-owls-observe.md
+++ b/.changeset/slow-owls-observe.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Expose capture default properties to BeforeSend hooks before serialization.

--- a/before_send_test.go
+++ b/before_send_test.go
@@ -196,6 +196,103 @@ func TestBeforeSendCaptureHook(t *testing.T) {
 	}
 }
 
+func TestBeforeSendCaptureReceivesDefaultProperties(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		mode CaptureMode
+	}{
+		{name: "legacy", mode: CaptureModeLegacy},
+		{name: "analytics-v1", mode: CaptureModeAnalyticsV1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			body := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				payload, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				body <- payload
+				w.WriteHeader(http.StatusOK)
+				if tt.mode == CaptureModeAnalyticsV1 {
+					_, _ = w.Write([]byte(`{"results":{}}`))
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewWithConfig("test-api-key", Config{
+				Endpoint:    server.URL,
+				BatchSize:   1,
+				now:         mockTime,
+				CaptureMode: tt.mode,
+				BeforeSend: func(msg Message) Message {
+					capture := msg.(Capture)
+					capture.Properties["hook_saw_is_server"] = capture.Properties[propertyIsServer]
+					capture.Properties["hook_saw_geoip_disable"] = capture.Properties[propertyGeoipDisable]
+					return capture
+				},
+			})
+			require.NoError(t, err)
+
+			require.NoError(t, client.Enqueue(Capture{
+				DistinctId: "user-123",
+				Event:      "test-event",
+			}))
+			require.NoError(t, client.Close())
+
+			properties := firstProperties(t, readBatch(t, body))
+			require.Equal(t, true, properties["hook_saw_is_server"])
+			require.Equal(t, true, properties["hook_saw_geoip_disable"])
+			require.Equal(t, true, properties[propertyIsServer])
+			require.Equal(t, true, properties[propertyGeoipDisable])
+		})
+	}
+}
+
+func TestBeforeSendCaptureCanRemoveDefaultIsServerProperty(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		mode CaptureMode
+	}{
+		{name: "legacy", mode: CaptureModeLegacy},
+		{name: "analytics-v1", mode: CaptureModeAnalyticsV1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			body := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				payload, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				body <- payload
+				w.WriteHeader(http.StatusOK)
+				if tt.mode == CaptureModeAnalyticsV1 {
+					_, _ = w.Write([]byte(`{"results":{}}`))
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewWithConfig("test-api-key", Config{
+				Endpoint:    server.URL,
+				BatchSize:   1,
+				now:         mockTime,
+				CaptureMode: tt.mode,
+				BeforeSend: func(msg Message) Message {
+					capture := msg.(Capture)
+					delete(capture.Properties, propertyIsServer)
+					return capture
+				},
+			})
+			require.NoError(t, err)
+
+			require.NoError(t, client.Enqueue(Capture{
+				DistinctId: "user-123",
+				Event:      "test-event",
+			}))
+			require.NoError(t, client.Close())
+
+			properties := firstProperties(t, readBatch(t, body))
+			require.NotContains(t, properties, propertyIsServer)
+			require.Equal(t, true, properties[propertyGeoipDisable])
+		})
+	}
+}
+
 func TestBeforeSendDoesNotMutateOriginalProperties(t *testing.T) {
 	body, server := mockServer()
 	defer server.Close()

--- a/posthog.go
+++ b/posthog.go
@@ -26,6 +26,7 @@ const (
 	CACHE_DEFAULT_SIZE = 300_000
 
 	propertyGeoipDisable = "$geoip_disable"
+	propertyIsServer     = "$is_server"
 
 	// DefaultIdleConns is the default max idle connections for the HTTP client.
 	DefaultIdleConns = 100
@@ -704,6 +705,9 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 			m.Properties = NewProperties()
 		}
 		m.Properties.Merge(c.DefaultEventProperties)
+		if m.IsServer {
+			m.Properties.Set(propertyIsServer, true)
+		}
 		if captureContext.personlessProcessProfileGuard {
 			m.Properties[propertyProcessPersonProfile] = false
 		}
@@ -712,6 +716,13 @@ func (c *client) EnqueueWithContext(ctx context.Context, msg Message) (err error
 			return nil
 		}
 		m = processed.(Capture)
+		// $is_server was materialized into Properties before BeforeSend;
+		// from this point, the hook's returned Properties are the source of truth.
+		if isServer, ok := m.Properties[propertyIsServer].(bool); ok {
+			m.IsServer = isServer
+		} else if m.Properties != nil {
+			m.IsServer = false
+		}
 		data, apiMsg, eventUuid, serErr := c.capture.prepare(m)
 		if serErr != nil {
 			c.notifyFailure([]APIMessage{apiMsg}, serErr)


### PR DESCRIPTION
## :bulb: Motivation and Context
BeforeSend hooks for capture events should observe the same default properties that are eventually sent on the wire. Previously Go set `Capture.IsServer` before the hook, but `$is_server` was only added during serialization, so hooks could not inspect or modify the final `$is_server` property the way the Rust SDK allows.

## :green_heart: How did you test it?
- `go test ./...`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The change materializes `$is_server` into capture properties before `BeforeSend`, matching existing `$geoip_disable` visibility and Rust hook semantics. After the hook returns, capture properties are treated as the source of truth so a hook can remove or alter `$is_server` before legacy or analytics-v1 serialization.
