### PR TITLE
ci: Configure SDK compliance suite selection

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,20 +14,26 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests (capture v0)
-    # Pinned to the 0.8.0 tag (commit be8b8d5) of the reusable workflow + harness
-    # image so v0/v1 runs are reproducible and pick up the capture-v1 suites.
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    # Keep the harness image pinned so v0/v1 runs are reproducible and pick up
+    # the capture-v1 suites.
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
       test-harness-version: "0.8.0"
       report-name: "sdk-compliance-report-v0"
 
+      suite: "capture"
+      sdk-type: "server"
+      continue-on-error: false
   compliance-v1:
     name: PostHog SDK compliance tests (capture v1)
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile.v1"
       adapter-context: "."
       test-harness-version: "0.8.0"
       report-name: "sdk-compliance-report-v1"
+      suite: "capture_v1"
+      sdk-type: "server"
+      continue-on-error: false

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -19,14 +19,23 @@ services:
     networks:
       - test-network
 
-  # Test harness
+  # Test harness (capture v0)
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--suite", "capture"]
     networks:
       - test-network
     depends_on:
       - sdk-adapter
+
+  # Test harness (capture v1)
+  test-harness-v1:
+    image: ghcr.io/posthog/sdk-test-harness:0.8.0
+    command: ["run", "--adapter-url", "http://sdk-adapter-v1:8080", "--mock-url", "http://test-harness-v1:8081", "--sdk-type", "server", "--suite", "capture_v1"]
+    networks:
+      - test-network
+    depends_on:
+      - sdk-adapter-v1
 
 networks:
   test-network:


### PR DESCRIPTION
## Problem

SDK compliance workflows need explicit harness suite/sdk-type selection and configurable blocking behavior so CI only runs the intended contract checks.

## Changes

- Point both compliance jobs to the harness branch with new workflow inputs.
- Run v0 with `suite: capture` and v1 with `suite: capture_v1`.
- Make Go compliance blocking.
- Add a local v1 harness service alongside v0 compose coverage.

## Testing

- Parsed workflow YAML.
- Ran `docker compose config` for the adapter compose file.
- Ran `git diff --check`.

## Release / changeset

No SDK package changeset: CI/local compliance configuration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using dedicated git worktrees. The change was requested to align SDK compliance harness setup across SDK repositories while keeping non-ready SDKs non-blocking.
