### PR TITLE
fix: make TCP drop recovery test deterministic

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,9 +9,13 @@ on:
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@69336b569d22687f8982eea6ff7d450a885cda05
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets: inherit
+        # The central .github reusable workflow does not declare workflow_call.secrets,
+        # so explicit secret mapping makes GitHub reject this caller at startup.
+        # It gates fork/Dependabot PRs before using secrets; keep this scoped call
+        # as an intentional exception to the broad-inheritance Semgrep rule.
+        secrets: inherit # nosemgrep

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -7,6 +7,8 @@ on:
     pull_request:
         types: [opened, ready_for_review, review_requested, synchronize, converted_to_draft, reopened]
 
+permissions: {}
+
 jobs:
     call-flags-project:
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@69336b569d22687f8982eea6ff7d450a885cda05

--- a/extras/tcp_drop_test.go
+++ b/extras/tcp_drop_test.go
@@ -52,7 +52,6 @@ func TestTCPDropRecovery(t *testing.T) {
 
 			url, err := server.Start()
 			require.NoError(t, err, "Failed to start server")
-			defer server.Close()
 			t.Logf("TCP server started at %s", url)
 
 			callback := newTestCallback(t)
@@ -149,7 +148,6 @@ func TestTCPDropFailure(t *testing.T) {
 
 			url, err := server.Start()
 			require.NoError(t, err, "Failed to start server")
-			defer server.Close()
 			t.Logf("TCP server started at %s", url)
 
 			callback := newTestCallback(t)
@@ -188,6 +186,7 @@ func TestTCPDropFailure(t *testing.T) {
 			}
 
 			client.Close()
+			require.NoError(t, server.Close(), "Failed to close server")
 
 			success, failure := callback.GetCounts()
 			assert.Equal(t, 10, server.ConnCount())

--- a/extras/tcp_drop_test.go
+++ b/extras/tcp_drop_test.go
@@ -91,6 +91,7 @@ func TestTCPDropRecovery(t *testing.T) {
 			}
 
 			client.Close()
+			require.NoError(t, server.Close(), "Failed to close server")
 
 			success, failure := callback.GetCounts()
 			assert.Equal(t, 1, success, "Expected 1 success")


### PR DESCRIPTION
## :bulb: Motivation and Context

`TestTCPDropRecovery/DropAfterConnect` was flaky because the test asserted `server.SuccessCount()` immediately after the PostHog callback reported success. The TCP test server increments its success counter after writing the HTTP response, so the client callback can win that race and observe `0` successes even though delivery succeeded.

This change makes the test wait for the TCP server's connection handler to finish before asserting server-side counters. Review feedback also pointed out the same server-counter race in `TestTCPDropFailure`, so that test now closes the TCP server before reading connection counts as well.

Semgrep also flagged the feature-flags project-board caller for using `secrets: inherit`. This mirrors PostHog/posthog-python#717: the central reusable workflow requires inherited secrets because it does not declare `workflow_call.secrets`, so the workflow keeps `secrets: inherit` with a scoped `# nosemgrep` suppression and explanatory comments. The workflow now also declares `permissions: {}` to satisfy CodeQL's minimal-token-permissions recommendation.

## :green_heart: How did you test it?

- `docker run --rm -v "$PWD":/src -w /src golang:1.24 go test ./extras -run 'TestTCPDropRecovery/DropAfterConnect' -count=100`
- `docker run --rm -v "$PWD":/src -w /src golang:1.24 go test ./extras -count=20`
- `docker run --rm -v "$PWD":/src -w /src golang:1.24 go test -race ./extras -run 'TestTCPDropRecovery/DropAfterConnect' -count=20`
- `docker run --rm -v "$PWD":/src -w /src golang:1.24 go test ./extras -run 'TestTCPDrop' -count=50`
- `docker run --rm -v "$PWD":/src -w /src golang:1.24 go test ./...`
- Parsed `.github/workflows/call-flags-project-board.yml` with PyYAML and verified `permissions` resolves to `{}` and `secrets` resolves to `inherit`.
- `docker run --rm -v "$PWD":/src -v /tmp/posthog-dotgithub-semgrep:/dotgithub -w /src semgrep/semgrep:1.163.0 semgrep ... .github/`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the flaky TCP drop recovery test in a dedicated git worktree. The chosen test fix is intentionally small: close the flaky TCP server before reading its counters, because `Close` waits for handler goroutines and removes the race between the client callback and server-side bookkeeping. Review feedback was addressed by removing duplicate deferred closes and applying the same deterministic close-before-counter-read pattern to `TestTCPDropFailure`.

After CI reported a Semgrep failure, Pi inspected the job logs and aligned this repo's feature-flags project-board caller with PostHog/posthog-python#717: keep the required inherited secrets for the central reusable workflow and suppress only that intentional Semgrep finding inline with reviewer-facing context. CodeQL feedback was addressed by declaring minimal workflow permissions.
