### PR TITLE
ci: skip heavy CI for non-impacting changes

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -15,36 +15,174 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_go_checks: ${{ steps.classify.outputs.run_go_checks }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        continue-on-error: true
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        env:
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+
+          run_go_checks=true
+          reason="Unable to determine changed files; running Go checks."
+          changed_files="$(mktemp)"
+
+          finish() {
+            echo "run_go_checks=${run_go_checks}" >> "${GITHUB_OUTPUT}"
+            echo "reason=${reason}" >> "${GITHUB_OUTPUT}"
+            echo "run_go_checks=${run_go_checks}"
+            echo "${reason}"
+          }
+
+          if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            reason="Checkout was unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          base=""
+          head="${GITHUB_SHA}"
+
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request)
+              base="${PULL_REQUEST_BASE_SHA}"
+              ;;
+            push)
+              base="${PUSH_BEFORE_SHA}"
+              if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+                reason="Push base SHA is unavailable; running Go checks."
+                finish
+                exit 0
+              fi
+              ;;
+            merge_group)
+              base="${MERGE_GROUP_BASE_SHA}"
+              ;;
+            *)
+              reason="Unsupported event ${GITHUB_EVENT_NAME}; running Go checks."
+              finish
+              exit 0
+              ;;
+          esac
+
+          if [[ -z "${base}" || -z "${head}" ]]; then
+            reason="Diff base or head SHA is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+            reason="Base commit ${base} is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if ! git rev-parse --verify "${head}^{commit}" >/dev/null 2>&1; then
+            reason="Head commit ${head} is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if ! git diff --name-only "${base}" "${head}" > "${changed_files}"; then
+            reason="Unable to diff ${base}..${head}; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if [[ ! -s "${changed_files}" ]]; then
+            reason="No changed files detected; running Go checks."
+            finish
+            exit 0
+          fi
+
+          run_go_checks=false
+          reason="Only non-impacting files changed; skipping Go checks."
+
+          echo "Changed files:"
+          while IFS= read -r file; do
+            [[ -z "${file}" ]] && continue
+            echo " - ${file}"
+
+            case "${file}" in
+              *.md|docs/**|.changeset/*.md|.github/ISSUE_TEMPLATE/**|.github/PULL_REQUEST_TEMPLATE/**|.github/pull_request_template.md|.github/workflows/release.yml|.github/workflows/stale.yaml|.github/workflows/lint-pr.yml|.github/workflows/call-flags-project-board.yml)
+                ;;
+              *)
+                run_go_checks=true
+                reason="Found SDK/build-impacting or unknown file: ${file}; running Go checks."
+                break
+                ;;
+            esac
+          done < "${changed_files}"
+
+          finish
+
   fmt:
     name: Check formatting
+    needs: changes
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      - name: Skip non-impacting changes
+        if: needs.changes.outputs.run_go_checks == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "${SKIP_REASON}"
+
       - name: Set up Go 1.21
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.21
 
       - name: Check out source code
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check formatting
+        if: needs.changes.outputs.run_go_checks != 'false'
         run: |
           go fmt ./...
           git diff --exit-code || (echo "Files are not formatted. Run \`go fmt ./...\` locally and commit the changes." && exit 1)
 
   mod-tidy:
     name: Check go.mod is tidy
+    needs: changes
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      - name: Skip non-impacting changes
+        if: needs.changes.outputs.run_go_checks == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "${SKIP_REASON}"
+
       - name: Set up Go 1.21
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.21
 
       - name: Check out source code
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check go.mod/go.sum
+        if: needs.changes.outputs.run_go_checks != 'false'
         run: |
           go mod tidy
           git diff --exit-code || (echo "go.mod/go.sum are not tidy. Run \`go mod tidy\` locally and commit the changes." && exit 1)

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,6 +2,7 @@ name: Check Formatting
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -22,25 +23,18 @@ jobs:
       run_go_checks: ${{ steps.classify.outputs.run_go_checks }}
       reason: ${{ steps.classify.outputs.reason }}
     steps:
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        continue-on-error: true
-        with:
-          fetch-depth: 0
-
       - name: Classify changed files
         id: classify
         shell: bash
         env:
-          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
-          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
           run_go_checks=true
           reason="Unable to determine changed files; running Go checks."
-          changed_files="$(mktemp)"
+          files_json="$(mktemp)"
 
           finish() {
             echo "run_go_checks=${run_go_checks}" >> "${GITHUB_OUTPUT}"
@@ -49,85 +43,99 @@ jobs:
             echo "${reason}"
           }
 
-          if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            reason="Checkout was unavailable; running Go checks."
+          is_safe_file() {
+            local file="$1"
+
+            case "${file}" in
+              *.md|docs/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE/*|.github/pull_request_template.md|.github/CODEOWNERS|CODEOWNERS|.github/dependabot.yml)
+                return 0
+                ;;
+            esac
+
+            [[ "${file}" =~ ^\.github/workflows/(release|publish|stale|lint-pr|call-flags-project-board|changeset-hygiene|dependabot-changeset|validate-versioning|new-pr|generated-files-notice|posthog-upgrade|posthog-watcher-.*)\.ya?ml$ ]]
+          }
+
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            reason="${GITHUB_EVENT_NAME} event; running Go checks."
             finish
             exit 0
           fi
 
-          base=""
-          head="${GITHUB_SHA}"
+          if [[ -z "${PULL_REQUEST_NUMBER}" ]]; then
+            reason="Pull request number is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
 
-          case "${GITHUB_EVENT_NAME}" in
-            pull_request)
-              base="${PULL_REQUEST_BASE_SHA}"
-              ;;
-            push)
-              base="${PUSH_BEFORE_SHA}"
-              if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
-                reason="Push base SHA is unavailable; running Go checks."
-                finish
-                exit 0
-              fi
-              ;;
-            merge_group)
-              base="${MERGE_GROUP_BASE_SHA}"
-              ;;
-            *)
-              reason="Unsupported event ${GITHUB_EVENT_NAME}; running Go checks."
+          api_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/files?per_page=100"
+          page=1
+          printf '[]' > "${files_json}"
+
+          while :; do
+            page_json="$(mktemp)"
+            if ! curl --fail --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "${api_url}&page=${page}" > "${page_json}"; then
+              reason="Unable to fetch pull request files from GitHub API; running Go checks."
               finish
               exit 0
-              ;;
-          esac
+            fi
 
-          if [[ -z "${base}" || -z "${head}" ]]; then
-            reason="Diff base or head SHA is unavailable; running Go checks."
-            finish
-            exit 0
-          fi
+            if ! jq -e 'type == "array"' "${page_json}" >/dev/null; then
+              reason="GitHub API returned an unexpected pull request files payload; running Go checks."
+              finish
+              exit 0
+            fi
 
-          if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
-            reason="Base commit ${base} is unavailable; running Go checks."
-            finish
-            exit 0
-          fi
+            page_count="$(jq 'length' "${page_json}")"
+            jq -s '.[0] + .[1]' "${files_json}" "${page_json}" > "${files_json}.next"
+            mv "${files_json}.next" "${files_json}"
 
-          if ! git rev-parse --verify "${head}^{commit}" >/dev/null 2>&1; then
-            reason="Head commit ${head} is unavailable; running Go checks."
-            finish
-            exit 0
-          fi
+            if [[ "${page_count}" -lt 100 ]]; then
+              break
+            fi
 
-          if ! git diff --name-only "${base}" "${head}" > "${changed_files}"; then
-            reason="Unable to diff ${base}..${head}; running Go checks."
-            finish
-            exit 0
-          fi
+            page=$((page + 1))
+          done
 
-          if [[ ! -s "${changed_files}" ]]; then
-            reason="No changed files detected; running Go checks."
+          if [[ "$(jq 'length' "${files_json}")" -eq 0 ]]; then
+            reason="No changed files detected by GitHub API; running Go checks."
             finish
             exit 0
           fi
 
           run_go_checks=false
-          reason="Only non-impacting files changed; skipping Go checks."
+          reason="Only globally safe files changed; skipping Go checks."
 
           echo "Changed files:"
-          while IFS= read -r file; do
-            [[ -z "${file}" ]] && continue
-            echo " - ${file}"
+          while IFS= read -r file_entry; do
+            filename="$(jq -r '.filename // empty' <<< "${file_entry}")"
+            previous_filename="$(jq -r '.previous_filename // empty' <<< "${file_entry}")"
 
-            case "${file}" in
-              *.md|docs/**|.changeset/*.md|.github/ISSUE_TEMPLATE/**|.github/PULL_REQUEST_TEMPLATE/**|.github/pull_request_template.md|.github/workflows/release.yml|.github/workflows/stale.yaml|.github/workflows/lint-pr.yml|.github/workflows/call-flags-project-board.yml)
-                ;;
-              *)
+            if [[ -z "${filename}" ]]; then
+              run_go_checks=true
+              reason="Found pull request file entry without a filename; running Go checks."
+              break
+            fi
+
+            echo " - ${filename}"
+            if ! is_safe_file "${filename}"; then
+              run_go_checks=true
+              reason="Found CI-impacting or unknown file: ${filename}; running Go checks."
+              break
+            fi
+
+            if [[ -n "${previous_filename}" ]]; then
+              echo "   previous: ${previous_filename}"
+              if ! is_safe_file "${previous_filename}"; then
                 run_go_checks=true
-                reason="Found SDK/build-impacting or unknown file: ${file}; running Go checks."
+                reason="Found CI-impacting or unknown previous filename: ${previous_filename}; running Go checks."
                 break
-                ;;
-            esac
-          done < "${changed_files}"
+              fi
+            fi
+          done < <(jq -c '.[]' "${files_json}")
 
           finish
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -22,25 +23,18 @@ jobs:
       run_go_checks: ${{ steps.classify.outputs.run_go_checks }}
       reason: ${{ steps.classify.outputs.reason }}
     steps:
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        continue-on-error: true
-        with:
-          fetch-depth: 0
-
       - name: Classify changed files
         id: classify
         shell: bash
         env:
-          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
-          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
           run_go_checks=true
           reason="Unable to determine changed files; running Go checks."
-          changed_files="$(mktemp)"
+          files_json="$(mktemp)"
 
           finish() {
             echo "run_go_checks=${run_go_checks}" >> "${GITHUB_OUTPUT}"
@@ -49,85 +43,99 @@ jobs:
             echo "${reason}"
           }
 
-          if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            reason="Checkout was unavailable; running Go checks."
+          is_safe_file() {
+            local file="$1"
+
+            case "${file}" in
+              *.md|docs/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE/*|.github/pull_request_template.md|.github/CODEOWNERS|CODEOWNERS|.github/dependabot.yml)
+                return 0
+                ;;
+            esac
+
+            [[ "${file}" =~ ^\.github/workflows/(release|publish|stale|lint-pr|call-flags-project-board|changeset-hygiene|dependabot-changeset|validate-versioning|new-pr|generated-files-notice|posthog-upgrade|posthog-watcher-.*)\.ya?ml$ ]]
+          }
+
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            reason="${GITHUB_EVENT_NAME} event; running Go checks."
             finish
             exit 0
           fi
 
-          base=""
-          head="${GITHUB_SHA}"
+          if [[ -z "${PULL_REQUEST_NUMBER}" ]]; then
+            reason="Pull request number is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
 
-          case "${GITHUB_EVENT_NAME}" in
-            pull_request)
-              base="${PULL_REQUEST_BASE_SHA}"
-              ;;
-            push)
-              base="${PUSH_BEFORE_SHA}"
-              if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
-                reason="Push base SHA is unavailable; running Go checks."
-                finish
-                exit 0
-              fi
-              ;;
-            merge_group)
-              base="${MERGE_GROUP_BASE_SHA}"
-              ;;
-            *)
-              reason="Unsupported event ${GITHUB_EVENT_NAME}; running Go checks."
+          api_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/files?per_page=100"
+          page=1
+          printf '[]' > "${files_json}"
+
+          while :; do
+            page_json="$(mktemp)"
+            if ! curl --fail --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "${api_url}&page=${page}" > "${page_json}"; then
+              reason="Unable to fetch pull request files from GitHub API; running Go checks."
               finish
               exit 0
-              ;;
-          esac
+            fi
 
-          if [[ -z "${base}" || -z "${head}" ]]; then
-            reason="Diff base or head SHA is unavailable; running Go checks."
-            finish
-            exit 0
-          fi
+            if ! jq -e 'type == "array"' "${page_json}" >/dev/null; then
+              reason="GitHub API returned an unexpected pull request files payload; running Go checks."
+              finish
+              exit 0
+            fi
 
-          if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
-            reason="Base commit ${base} is unavailable; running Go checks."
-            finish
-            exit 0
-          fi
+            page_count="$(jq 'length' "${page_json}")"
+            jq -s '.[0] + .[1]' "${files_json}" "${page_json}" > "${files_json}.next"
+            mv "${files_json}.next" "${files_json}"
 
-          if ! git rev-parse --verify "${head}^{commit}" >/dev/null 2>&1; then
-            reason="Head commit ${head} is unavailable; running Go checks."
-            finish
-            exit 0
-          fi
+            if [[ "${page_count}" -lt 100 ]]; then
+              break
+            fi
 
-          if ! git diff --name-only "${base}" "${head}" > "${changed_files}"; then
-            reason="Unable to diff ${base}..${head}; running Go checks."
-            finish
-            exit 0
-          fi
+            page=$((page + 1))
+          done
 
-          if [[ ! -s "${changed_files}" ]]; then
-            reason="No changed files detected; running Go checks."
+          if [[ "$(jq 'length' "${files_json}")" -eq 0 ]]; then
+            reason="No changed files detected by GitHub API; running Go checks."
             finish
             exit 0
           fi
 
           run_go_checks=false
-          reason="Only non-impacting files changed; skipping Go checks."
+          reason="Only globally safe files changed; skipping Go checks."
 
           echo "Changed files:"
-          while IFS= read -r file; do
-            [[ -z "${file}" ]] && continue
-            echo " - ${file}"
+          while IFS= read -r file_entry; do
+            filename="$(jq -r '.filename // empty' <<< "${file_entry}")"
+            previous_filename="$(jq -r '.previous_filename // empty' <<< "${file_entry}")"
 
-            case "${file}" in
-              *.md|docs/**|.changeset/*.md|.github/ISSUE_TEMPLATE/**|.github/PULL_REQUEST_TEMPLATE/**|.github/pull_request_template.md|.github/workflows/release.yml|.github/workflows/stale.yaml|.github/workflows/lint-pr.yml|.github/workflows/call-flags-project-board.yml)
-                ;;
-              *)
+            if [[ -z "${filename}" ]]; then
+              run_go_checks=true
+              reason="Found pull request file entry without a filename; running Go checks."
+              break
+            fi
+
+            echo " - ${filename}"
+            if ! is_safe_file "${filename}"; then
+              run_go_checks=true
+              reason="Found CI-impacting or unknown file: ${filename}; running Go checks."
+              break
+            fi
+
+            if [[ -n "${previous_filename}" ]]; then
+              echo "   previous: ${previous_filename}"
+              if ! is_safe_file "${previous_filename}"; then
                 run_go_checks=true
-                reason="Found SDK/build-impacting or unknown file: ${file}; running Go checks."
+                reason="Found CI-impacting or unknown previous filename: ${previous_filename}; running Go checks."
                 break
-                ;;
-            esac
-          done < "${changed_files}"
+              fi
+            fi
+          done < <(jq -c '.[]' "${files_json}")
 
           finish
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,126 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_go_checks: ${{ steps.classify.outputs.run_go_checks }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        continue-on-error: true
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        env:
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+
+          run_go_checks=true
+          reason="Unable to determine changed files; running Go checks."
+          changed_files="$(mktemp)"
+
+          finish() {
+            echo "run_go_checks=${run_go_checks}" >> "${GITHUB_OUTPUT}"
+            echo "reason=${reason}" >> "${GITHUB_OUTPUT}"
+            echo "run_go_checks=${run_go_checks}"
+            echo "${reason}"
+          }
+
+          if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            reason="Checkout was unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          base=""
+          head="${GITHUB_SHA}"
+
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request)
+              base="${PULL_REQUEST_BASE_SHA}"
+              ;;
+            push)
+              base="${PUSH_BEFORE_SHA}"
+              if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+                reason="Push base SHA is unavailable; running Go checks."
+                finish
+                exit 0
+              fi
+              ;;
+            merge_group)
+              base="${MERGE_GROUP_BASE_SHA}"
+              ;;
+            *)
+              reason="Unsupported event ${GITHUB_EVENT_NAME}; running Go checks."
+              finish
+              exit 0
+              ;;
+          esac
+
+          if [[ -z "${base}" || -z "${head}" ]]; then
+            reason="Diff base or head SHA is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+            reason="Base commit ${base} is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if ! git rev-parse --verify "${head}^{commit}" >/dev/null 2>&1; then
+            reason="Head commit ${head} is unavailable; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if ! git diff --name-only "${base}" "${head}" > "${changed_files}"; then
+            reason="Unable to diff ${base}..${head}; running Go checks."
+            finish
+            exit 0
+          fi
+
+          if [[ ! -s "${changed_files}" ]]; then
+            reason="No changed files detected; running Go checks."
+            finish
+            exit 0
+          fi
+
+          run_go_checks=false
+          reason="Only non-impacting files changed; skipping Go checks."
+
+          echo "Changed files:"
+          while IFS= read -r file; do
+            [[ -z "${file}" ]] && continue
+            echo " - ${file}"
+
+            case "${file}" in
+              *.md|docs/**|.changeset/*.md|.github/ISSUE_TEMPLATE/**|.github/PULL_REQUEST_TEMPLATE/**|.github/pull_request_template.md|.github/workflows/release.yml|.github/workflows/stale.yaml|.github/workflows/lint-pr.yml|.github/workflows/call-flags-project-board.yml)
+                ;;
+              *)
+                run_go_checks=true
+                reason="Found SDK/build-impacting or unknown file: ${file}; running Go checks."
+                break
+                ;;
+            esac
+          done < "${changed_files}"
+
+          finish
+
   build:
     name: Build (Go ${{ matrix.go-version }})
+    needs: changes
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -24,34 +142,56 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Skip non-impacting changes
+        if: needs.changes.outputs.run_go_checks == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "${SKIP_REASON}"
+
       - name: Set up Go ${{ matrix.go-version }}
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out source code
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build
+        if: needs.changes.outputs.run_go_checks != 'false'
         run: go build .
 
   public-api:
     name: Public API
+    needs: changes
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      - name: Skip non-impacting changes
+        if: needs.changes.outputs.run_go_checks == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "${SKIP_REASON}"
+
       - name: Set up Go
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.21'
 
       - name: Check out source code
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check public API snapshot
+        if: needs.changes.outputs.run_go_checks != 'false'
         run: make api-diff
 
   test:
     name: Test (Go ${{ matrix.go-version }})
+    needs: changes
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -59,19 +199,30 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Skip non-impacting changes
+        if: needs.changes.outputs.run_go_checks == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "${SKIP_REASON}"
+
       - name: Set up Go ${{ matrix.go-version }}
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out source code
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test
+        if: needs.changes.outputs.run_go_checks != 'false'
         run: go test -v -count=1 -timeout=5m -coverprofile=coverage.out ./...
 
   race:
     name: Race tests (Go ${{ matrix.go-version }})
+    needs: changes
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -79,19 +230,30 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Skip non-impacting changes
+        if: needs.changes.outputs.run_go_checks == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "${SKIP_REASON}"
+
       - name: Set up Go ${{ matrix.go-version }}
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out source code
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Race tests
+        if: needs.changes.outputs.run_go_checks != 'false'
         run: go test -v -race -count=1 -timeout=5m ./...
 
   vet:
     name: Go vet (Go ${{ matrix.go-version }})
+    needs: changes
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -99,13 +261,22 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Skip non-impacting changes
+        if: needs.changes.outputs.run_go_checks == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "${SKIP_REASON}"
+
       - name: Set up Go ${{ matrix.go-version }}
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out source code
+        if: needs.changes.outputs.run_go_checks != 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Vet
+        if: needs.changes.outputs.run_go_checks != 'false'
         run: go vet ./...


### PR DESCRIPTION
## Summary
- update the existing Unit Tests and Formatting skip logic to use a generic safe-file classifier instead of SDK/repo-specific source/test/build allowlists
- only skip on `pull_request` when every changed `filename` and non-empty `previous_filename` from the GitHub PR files API is globally safe
- keep required check/job names materialized while no-oping checkout/setup-go/Go commands for safe changes; fail open to full checks for pushes, merge groups, API/payload failures, empty file lists, current CI workflow edits, source/test/build/package/lock/config files, and unknown paths

## Validation
- Ruby YAML parse for `.github/workflows/unit-tests.yml` and `.github/workflows/fmt.yml`
- `bash -n` on extracted classifier scripts from both workflows
- mocked classifier sample cases for both workflows: generic safe set => `run_go_checks=false`; source file, unsafe previous filename, current CI workflow, package/lock files, empty API list, push event, and API failure => `run_go_checks=true`
- `git diff --check`
