### PR TITLE
fix: stop duplicating distinct_id in flags person properties

### DIFF
--- a/.changeset/quiet-wolves-fix.md
+++ b/.changeset/quiet-wolves-fix.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Stop duplicating `distinct_id` inside `/flags` person properties.

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,20 +14,20 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests (capture v0)
-    # Pinned to the 0.9.0 release commit of the reusable workflow + harness
+    # Pinned to the 0.10.0 release commit of the reusable workflow + harness
     # image version so v0/v1 runs are reproducible.
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"
       report-name: "sdk-compliance-report-v0"
 
   compliance-v1:
     name: PostHog SDK compliance tests (capture v1)
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile.v1"
       adapter-context: "."
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"
       report-name: "sdk-compliance-report-v1"

--- a/feature_flags_remote_test.go
+++ b/feature_flags_remote_test.go
@@ -338,6 +338,9 @@ func TestGetFeatureFlagFromRemote(t *testing.T) {
 		if requestData.PersonProperties["email"] != "test@example.com" {
 			t.Errorf("Expected request body to contain person properties, got: %v", requestData.PersonProperties)
 		}
+		if _, ok := requestData.PersonProperties["distinct_id"]; ok {
+			t.Errorf("Expected request body person properties to not duplicate distinct_id, got: %v", requestData.PersonProperties)
+		}
 	})
 
 	t.Run("passes groups in request", func(t *testing.T) {

--- a/feature_flags_remote_test.go
+++ b/feature_flags_remote_test.go
@@ -335,11 +335,102 @@ func TestGetFeatureFlagFromRemote(t *testing.T) {
 		personProps := NewProperties().Set("email", "test@example.com")
 		c.getFeatureFlagFromRemote("test-flag", "user-123", nil, nil, personProps, nil)
 
-		if requestData.PersonProperties["email"] != "test@example.com" {
+			if requestData.PersonProperties["email"] != "test@example.com" {
 			t.Errorf("Expected request body to contain person properties, got: %v", requestData.PersonProperties)
 		}
 		if _, ok := requestData.PersonProperties["distinct_id"]; ok {
 			t.Errorf("Expected request body person properties to not duplicate distinct_id, got: %v", requestData.PersonProperties)
+		}
+	})
+
+	t.Run("preserves explicit person properties distinct_id", func(t *testing.T) {
+		var requestData FlagsRequestData
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &requestData); err != nil {
+				t.Errorf("Failed to parse request body: %v", err)
+			}
+			w.Write([]byte(`{"flags": {}, "requestId": "req-props"}`))
+		}))
+		defer server.Close()
+
+		posthog, _ := NewWithConfig("test-api-key", Config{
+			Endpoint: server.URL,
+		})
+		defer posthog.Close()
+
+		c := posthog.(*client)
+		personProps := NewProperties().Set("distinct_id", "custom-distinct-id")
+		c.getFeatureFlagFromRemote("test-flag", "user-123", nil, nil, personProps, nil)
+
+		if requestData.PersonProperties["distinct_id"] != "custom-distinct-id" {
+			t.Errorf("Expected explicit distinct_id person property to be preserved, got: %v", requestData.PersonProperties)
+		}
+	})
+
+	t.Run("GetAllFlags does not duplicate distinct_id in person properties", func(t *testing.T) {
+		var requestData FlagsRequestData
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &requestData); err != nil {
+				t.Errorf("Failed to parse request body: %v", err)
+			}
+			w.Write([]byte(`{"featureFlags": {"test-flag": true}, "requestId": "req-all"}`))
+		}))
+		defer server.Close()
+
+		posthog, _ := NewWithConfig("test-api-key", Config{
+			Endpoint: server.URL,
+		})
+		defer posthog.Close()
+
+		_, err := posthog.GetAllFlags(FeatureFlagPayloadNoKey{
+			DistinctId:        "user-123",
+			PersonProperties: NewProperties().Set("email", "test@example.com"),
+		})
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if _, ok := requestData.PersonProperties["distinct_id"]; ok {
+			t.Errorf("Expected GetAllFlags request person properties to not duplicate distinct_id, got: %v", requestData.PersonProperties)
+		}
+	})
+
+	t.Run("capture enrichment fallback does not duplicate distinct_id in person properties", func(t *testing.T) {
+		var requestData FlagsRequestData
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/flags/definitions" {
+				w.Write([]byte(`{"flags": [], "group_type_mapping": {}}`))
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &requestData); err != nil {
+				t.Errorf("Failed to parse request body: %v", err)
+			}
+			w.Write([]byte(`{"featureFlags": {"test-flag": true}, "requestId": "req-fallback"}`))
+		}))
+		defer server.Close()
+
+		posthog, _ := NewWithConfig("test-api-key", Config{
+			Endpoint:       server.URL,
+			PersonalApiKey: "test-personal-key",
+		})
+		defer posthog.Close()
+
+		c := posthog.(*client)
+		_, err := c.featureFlagsPoller.getFeatureFlagVariantsWithFallback(
+			"user-123",
+			nil,
+			nil,
+			NewProperties().Set("email", "test@example.com"),
+			nil,
+			false,
+		)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if _, ok := requestData.PersonProperties["distinct_id"]; ok {
+			t.Errorf("Expected capture enrichment fallback person properties to not duplicate distinct_id, got: %v", requestData.PersonProperties)
 		}
 	})
 

--- a/feature_flags_remote_test.go
+++ b/feature_flags_remote_test.go
@@ -335,7 +335,7 @@ func TestGetFeatureFlagFromRemote(t *testing.T) {
 		personProps := NewProperties().Set("email", "test@example.com")
 		c.getFeatureFlagFromRemote("test-flag", "user-123", nil, nil, personProps, nil)
 
-			if requestData.PersonProperties["email"] != "test@example.com" {
+		if requestData.PersonProperties["email"] != "test@example.com" {
 			t.Errorf("Expected request body to contain person properties, got: %v", requestData.PersonProperties)
 		}
 		if _, ok := requestData.PersonProperties["distinct_id"]; ok {

--- a/feature_flags_remote_test.go
+++ b/feature_flags_remote_test.go
@@ -385,7 +385,7 @@ func TestGetFeatureFlagFromRemote(t *testing.T) {
 		defer posthog.Close()
 
 		_, err := posthog.GetAllFlags(FeatureFlagPayloadNoKey{
-			DistinctId:        "user-123",
+			DistinctId:       "user-123",
 			PersonProperties: NewProperties().Set("email", "test@example.com"),
 		})
 		if err != nil {

--- a/featureflags.go
+++ b/featureflags.go
@@ -1928,7 +1928,7 @@ func flagHasDependencies(flag FeatureFlag) bool {
 }
 
 // flagHasPersonProperties returns true if any condition in the flag checks person properties.
-// When false, the distinct_id merge into personProperties can be skipped entirely.
+// When false, local evaluation can skip constructing person-property context for the flag.
 func flagHasPersonProperties(flag FeatureFlag) bool {
 	for _, group := range flag.Filters.Groups {
 		if len(group.Properties) > 0 {

--- a/featureflags.go
+++ b/featureflags.go
@@ -601,10 +601,6 @@ func (poller *FeatureFlagsPoller) fetchNewFeatureFlags() {
 func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) (interface{}, bool, error) {
 	flag, err := poller.getFeatureFlag(flagConfig)
 
-	// Make sure person_properties contains distinct_id so /flags request payloads
-	// have it under person_properties (matches the batch path and what server expects).
-	personProps := mergeDistinctIDIntoProperties(flagConfig.PersonProperties, flagConfig.DistinctId)
-
 	var result interface{}
 	locallyEvaluated := false
 
@@ -614,7 +610,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 			flagConfig.DistinctId,
 			flagConfig.DeviceId,
 			flagConfig.Groups,
-			personProps,
+			flagConfig.PersonProperties,
 			flagConfig.GroupProperties,
 			poller.getCohorts(),
 		)
@@ -626,28 +622,13 @@ func (poller *FeatureFlagsPoller) GetFeatureFlag(flagConfig FeatureFlagPayload) 
 	}
 
 	if (err != nil || result == nil) && !flagConfig.OnlyEvaluateLocally {
-		result, err = poller.getFeatureFlagVariant(flagConfig.Key, flagConfig.DistinctId, flagConfig.DeviceId, flagConfig.Groups, personProps, flagConfig.GroupProperties)
+		result, err = poller.getFeatureFlagVariant(flagConfig.Key, flagConfig.DistinctId, flagConfig.DeviceId, flagConfig.Groups, flagConfig.PersonProperties, flagConfig.GroupProperties)
 		if err != nil {
 			return nil, locallyEvaluated, err
 		}
 	}
 
 	return result, locallyEvaluated, err
-}
-
-// mergeDistinctIDIntoProperties returns a copy of properties with distinct_id added
-// (if not already present). Used so /flags request payloads always carry distinct_id
-// inside person_properties as well as at the top level.
-func mergeDistinctIDIntoProperties(properties Properties, distinctID string) Properties {
-	if _, ok := properties["distinct_id"]; ok {
-		return properties
-	}
-	merged := make(Properties, len(properties)+1)
-	merged["distinct_id"] = distinctID
-	for k, v := range properties {
-		merged[k] = v
-	}
-	return merged
 }
 
 // GetFeatureFlagPayload returns the payload for the evaluated flag value.
@@ -788,10 +769,6 @@ func (poller *FeatureFlagsPoller) GetAllFlags(flagConfig FeatureFlagPayloadNoKey
 	// Pre-size response map to avoid rehashing as flags are added
 	response := make(map[string]interface{}, len(featureFlags))
 
-	// Pre-merge distinct_id into person properties once for the entire batch,
-	// instead of copying the map per-flag inside computeFlagLocally.
-	personProps := mergeDistinctIDIntoProperties(flagConfig.PersonProperties, flagConfig.DistinctId)
-
 	if len(featureFlags) == 0 {
 		fallbackToDecide = true
 	} else {
@@ -801,7 +778,7 @@ func (poller *FeatureFlagsPoller) GetAllFlags(flagConfig FeatureFlagPayloadNoKey
 				flagConfig.DistinctId,
 				flagConfig.DeviceId,
 				flagConfig.Groups,
-				personProps,
+				flagConfig.PersonProperties,
 				flagConfig.GroupProperties,
 				cohorts,
 			)
@@ -2249,11 +2226,6 @@ func (poller *FeatureFlagsPoller) getFeatureFlagVariantsWithFallback(distinctId 
 
 	cohorts := poller.getCohorts()
 	result := make(map[string]interface{}, len(flags))
-
-	// Merge distinct_id into person_properties so both local evaluation and the
-	// remote /flags fallback match on distinct_id as a person property, matching
-	// GetFeatureFlag and the GetAllFlags batch path.
-	personProperties = mergeDistinctIDIntoProperties(personProperties, distinctId)
 
 	// Fall back to the remote request when no definitions are loaded or any flag
 	// can't be computed locally.

--- a/sdk_compliance_adapter/CONTRIBUTING.md
+++ b/sdk_compliance_adapter/CONTRIBUTING.md
@@ -10,7 +10,7 @@ CI runs two jobs: `compliance` (capture v0, `Dockerfile`) and `compliance-v1`
 (capture v1, `Dockerfile.v1`). The only difference between the images is the
 `CAPTURE_MODE=v1` env var, which flips the adapter's `/health` capabilities and
 selects `posthog.CaptureModeAnalyticsV1` at init. Both jobs pin the reusable
-workflow to the 0.9.0 release commit and run the `0.9.0` harness image.
+workflow to the 0.10.0 release commit and run the `0.10.0` harness image.
 
 ### Locally with Docker Compose
 
@@ -45,7 +45,7 @@ docker run -d --name sdk-adapter --network test-network -p 8080:8080 posthog-go-
 docker run --rm \
   --name test-harness \
   --network test-network \
-  ghcr.io/posthog/sdk-test-harness:0.9.0 \
+  ghcr.io/posthog/sdk-test-harness:0.10.0 \
   run --adapter-url http://sdk-adapter:8080 --mock-url http://test-harness:8081
 
 # Cleanup

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   # Test harness
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network


### PR DESCRIPTION
## :bulb: Motivation and Context
`/flags` requests already send `distinct_id` at the top level. Automatically copying the same value into `person_properties.distinct_id` sends duplicated identity data and differs from the desired payload shape.

This PR keeps the top-level `distinct_id` and stops automatically injecting it into `person_properties`. Caller-provided person properties are still forwarded.

## :green_heart: How did you test it?

- `Not run locally because the `go` binary is not installed in this environment (`go: command not found`).`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was implemented with pi in dedicated git worktrees. I changed the /flags request construction so SDKs keep the top-level distinct_id while no longer auto-copying it into person_properties; explicit caller-provided person_properties['distinct_id'] values are still preserved where covered.
