### PR TITLE
fix: Retry flags requests on 502 and 504

### DIFF
--- a/.changeset/gentle-flags-retry.md
+++ b/.changeset/gentle-flags-retry.md
@@ -1,0 +1,5 @@
+---
+'posthog-go': patch
+---
+
+Retry remote feature flag requests after transient 502 and 504 responses.

--- a/flags.go
+++ b/flags.go
@@ -296,9 +296,14 @@ func (d *flagsClient) makeFlagsRequest(distinctId string, deviceId *string, grou
 		}
 
 		if res.StatusCode != http.StatusOK {
+			statusCode := res.StatusCode
 			res.Body.Close()
 			cancel()
-			return nil, NewAPIError(res.StatusCode, fmt.Sprintf("unexpected status code from /flags/: %d", res.StatusCode))
+			if attempt != attempts-1 && isRetryableFlagsStatusCode(statusCode) {
+				d.sleepBeforeFlagsRetry(attempt)
+				continue
+			}
+			return nil, NewAPIError(statusCode, fmt.Sprintf("unexpected status code from /flags/: %d", statusCode))
 		}
 
 		resBody, err = io.ReadAll(res.Body)
@@ -346,6 +351,10 @@ func isRetryableFlagsRequestError(err error) bool {
 		return true
 	}
 	return false
+}
+
+func isRetryableFlagsStatusCode(statusCode int) bool {
+	return statusCode == http.StatusBadGateway || statusCode == http.StatusGatewayTimeout
 }
 
 // rawMessageToString converts a json.RawMessage to a string.

--- a/flags_test.go
+++ b/flags_test.go
@@ -122,6 +122,40 @@ func TestMakeFlagsRequestRetriesHTTP502And504ThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestMakeFlagsRequestRetriesHTTP502And504UntilExhausted(t *testing.T) {
+	for _, status := range []int{http.StatusBadGateway, http.StatusGatewayTimeout} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+
+			client, err := newFlagsClient("test-api-key", server.URL, http.Client{}, time.Second, testLogger{t.Logf, t.Logf}, nil)
+			if err != nil {
+				t.Fatalf("newFlagsClient returned error: %v", err)
+			}
+			client.retryAfter = func(int) time.Duration { return 0 }
+
+			_, err = client.makeFlagsRequest("user-1", nil, nil, nil, nil, false, nil)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			apiErr, ok := err.(*APIError)
+			if !ok {
+				t.Fatalf("expected APIError, got %T: %v", err, err)
+			}
+			if apiErr.StatusCode != status {
+				t.Fatalf("expected status %d, got %d", status, apiErr.StatusCode)
+			}
+			if got := calls.Load(); got != int32(defaultFlagsRequestMaxAttempts) {
+				t.Fatalf("expected %d attempts, got %d", defaultFlagsRequestMaxAttempts, got)
+			}
+		})
+	}
+}
+
 func TestDefaultFlagsBackoffStartsAt300msAndDoubles(t *testing.T) {
 	backoff := defaultFlagsBackoff()
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -86,6 +86,42 @@ func TestMakeFlagsRequestRetriesTransientErrorsThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestMakeFlagsRequestRetriesHTTP502And504ThenSucceeds(t *testing.T) {
+	for _, status := range []int{http.StatusBadGateway, http.StatusGatewayTimeout} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				call := calls.Add(1)
+				if call == 1 {
+					w.WriteHeader(status)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"featureFlags":{"beta-feature":true},"featureFlagPayloads":{}}`))
+			}))
+			defer server.Close()
+
+			client, err := newFlagsClient("test-api-key", server.URL, http.Client{}, time.Second, testLogger{t.Logf, t.Logf}, nil)
+			if err != nil {
+				t.Fatalf("newFlagsClient returned error: %v", err)
+			}
+			client.retryAfter = func(int) time.Duration { return 0 }
+
+			res, err := client.makeFlagsRequest("user-1", nil, nil, nil, nil, false, nil)
+			if err != nil {
+				t.Fatalf("makeFlagsRequest returned error: %v", err)
+			}
+			if got := calls.Load(); got != 2 {
+				t.Fatalf("expected 2 attempts, got %d", got)
+			}
+			if got := res.FeatureFlags["beta-feature"]; got != true {
+				t.Fatalf("expected beta-feature=true, got %#v", got)
+			}
+		})
+	}
+}
+
 func TestDefaultFlagsBackoffStartsAt300msAndDoubles(t *testing.T) {
 	backoff := defaultFlagsBackoff()
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Remote `/flags` requests currently retry transient request/read failures, but HTTP 502/504 responses return immediately. The SDK test harness adds contract coverage for `502 -> 200` and `504 -> 200`, expecting `/flags` to retry once by default and return the successful flag value.

This change retries only `/flags` HTTP 502 and 504 responses, using the existing `FeatureFlagRequestMaxRetries`/max-attempts behavior. Capture is unchanged.

## :green_heart: How did you test it?

```sh
go test ./... -run 'TestMakeFlagsRequestRetriesHTTP502And504ThenSucceeds|TestMakeFlagsRequestDoesNotRetryHTTPStatusErrors|TestMakeFlagsRequestRetriesTransientErrorsThenSucceeds'
go test .
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by an AI coding agent following a human request to align `/flags` retry behavior with the SDK test harness. The change is intentionally scoped to retrying HTTP 502/504 responses from `/flags` while preserving existing transient request/read retry behavior and max retry configuration.
