### PR TITLE
feat: add SecretKey config, deprecate PersonalApiKey

### DIFF
--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -73,7 +73,7 @@ var (
 
 	ErrMessageTooBig = errors.New("the message exceeds the maximum allowed size")
 
-	ErrNoPersonalAPIKey = errors.New("no PersonalAPIKey provided")
+	ErrNoPersonalAPIKey = errors.New("no SecretKey (or PersonalApiKey) provided")
 
 	ErrNoDistinctID = errors.New("no distinct_id provided")
 
@@ -285,6 +285,8 @@ func (m CompressionMode) String() string
 type Config struct {
 
 	Endpoint string
+
+	SecretKey string
 
 	PersonalApiKey string
 

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -73,7 +73,9 @@ var (
 
 	ErrMessageTooBig = errors.New("the message exceeds the maximum allowed size")
 
-	ErrNoPersonalAPIKey = errors.New("no SecretKey (or PersonalApiKey) provided")
+	ErrNoSecretKey = errors.New("no SecretKey provided")
+
+	ErrNoPersonalAPIKey = ErrNoSecretKey
 
 	ErrNoDistinctID = errors.New("no distinct_id provided")
 

--- a/config.go
+++ b/config.go
@@ -70,10 +70,19 @@ type Config struct {
 	// If empty, it defaults to DefaultEndpoint.
 	Endpoint string
 
-	// PersonalApiKey enables local feature flag evaluation, remote config payloads,
-	// and lower-latency flag APIs. If empty, feature flag methods fall back to the
-	// /flags endpoint unless the method requires local-only behavior.
-	// See https://posthog.com/docs/api/overview for how to create a personal API key.
+	// SecretKey is the credential used for local feature flag evaluation, remote
+	// config payloads, and lower-latency flag APIs. It accepts either a Personal
+	// API Key (phx_...) or a Project Secret API Key (phs_...). If empty, feature
+	// flag methods fall back to the /flags endpoint unless the method requires
+	// local-only behavior. When both SecretKey and PersonalApiKey are set,
+	// SecretKey takes precedence.
+	// See https://posthog.com/docs/api/overview for how to create these keys.
+	SecretKey string
+
+	// PersonalApiKey is a deprecated alias for SecretKey. It is still honored for
+	// backwards compatibility but SecretKey is preferred.
+	//
+	// Deprecated: use SecretKey instead.
 	PersonalApiKey string
 
 	// DisableGeoIP controls whether event and feature flag requests include
@@ -100,7 +109,7 @@ type Config struct {
 	Interval time.Duration
 
 	// DefaultFeatureFlagsPollingInterval is the interval for reloading local feature
-	// flag definitions when PersonalApiKey is configured. If zero, it defaults to
+	// flag definitions when SecretKey is configured. If zero, it defaults to
 	// DefaultFeatureFlagsPollingInterval.
 	DefaultFeatureFlagsPollingInterval time.Duration
 
@@ -245,7 +254,16 @@ const (
 
 func (c *Config) normalize() {
 	c.Endpoint = strings.TrimSpace(c.Endpoint)
+	c.SecretKey = strings.TrimSpace(c.SecretKey)
 	c.PersonalApiKey = strings.TrimSpace(c.PersonalApiKey)
+}
+
+// effectiveSecretKey prefers SecretKey and falls back to the deprecated PersonalApiKey.
+func (c *Config) effectiveSecretKey() string {
+	if c.SecretKey != "" {
+		return c.SecretKey
+	}
+	return c.PersonalApiKey
 }
 
 // Validate verifies that fields that don't have zero-values are set to valid values,

--- a/config_test.go
+++ b/config_test.go
@@ -26,6 +26,19 @@ func TestConfigValidateTrimsWhitespaceSensitiveFields(t *testing.T) {
 	require.Equal(t, "test-personal-key", c.PersonalApiKey)
 }
 
+func TestConfigEffectiveSecretKey(t *testing.T) {
+	require.Equal(t, "", (&Config{}).effectiveSecretKey())
+	require.Equal(t, "phx_personal", (&Config{PersonalApiKey: "phx_personal"}).effectiveSecretKey())
+	require.Equal(t, "phs_secret", (&Config{SecretKey: "phs_secret"}).effectiveSecretKey())
+	require.Equal(t, "phs_secret", (&Config{SecretKey: "phs_secret", PersonalApiKey: "phx_personal"}).effectiveSecretKey())
+}
+
+func TestConfigValidateTrimsSecretKey(t *testing.T) {
+	c := Config{SecretKey: " \tphs_secret\n "}
+	require.NoError(t, c.Validate())
+	require.Equal(t, "phs_secret", c.SecretKey)
+}
+
 func TestMakeConfigDefaultsWhitespaceEndpoint(t *testing.T) {
 	got := makeConfig(Config{Endpoint: " \n\t "})
 	require.Equal(t, DefaultEndpoint, got.Endpoint)

--- a/config_test.go
+++ b/config_test.go
@@ -27,10 +27,20 @@ func TestConfigValidateTrimsWhitespaceSensitiveFields(t *testing.T) {
 }
 
 func TestConfigEffectiveSecretKey(t *testing.T) {
-	require.Equal(t, "", (&Config{}).effectiveSecretKey())
-	require.Equal(t, "phx_personal", (&Config{PersonalApiKey: "phx_personal"}).effectiveSecretKey())
-	require.Equal(t, "phs_secret", (&Config{SecretKey: "phs_secret"}).effectiveSecretKey())
-	require.Equal(t, "phs_secret", (&Config{SecretKey: "phs_secret", PersonalApiKey: "phx_personal"}).effectiveSecretKey())
+	for _, tc := range []struct {
+		name   string
+		config Config
+		want   string
+	}{
+		{"neither", Config{}, ""},
+		{"personal only", Config{PersonalApiKey: "phx_personal"}, "phx_personal"},
+		{"secret only", Config{SecretKey: "phs_secret"}, "phs_secret"},
+		{"secret precedence", Config{SecretKey: "phs_secret", PersonalApiKey: "phx_personal"}, "phs_secret"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.config.effectiveSecretKey())
+		})
+	}
 }
 
 func TestConfigValidateTrimsSecretKey(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -75,9 +75,15 @@ var (
 	// limit.
 	ErrMessageTooBig = errors.New("the message exceeds the maximum allowed size")
 
-	// ErrNoPersonalAPIKey is returned when a SecretKey is required for the
-	// requested operation but was not configured.
-	ErrNoPersonalAPIKey = errors.New("no SecretKey (or PersonalApiKey) provided")
+	// ErrNoSecretKey is returned when a SecretKey is required for the requested
+	// operation but was not configured.
+	ErrNoSecretKey = errors.New("no SecretKey provided")
+
+	// ErrNoPersonalAPIKey is a deprecated alias for ErrNoSecretKey. It refers to
+	// the same error value, so errors.Is checks against either name still match.
+	//
+	// Deprecated: use ErrNoSecretKey.
+	ErrNoPersonalAPIKey = ErrNoSecretKey
 
 	// ErrNoDistinctID is returned when distinct_id is required for the requested
 	// operation but was not provided.

--- a/error.go
+++ b/error.go
@@ -77,7 +77,7 @@ var (
 
 	// ErrNoPersonalAPIKey is returned when a SecretKey is required for the
 	// requested operation but was not configured.
-	ErrNoPersonalAPIKey = errors.New("no PersonalAPIKey provided")
+	ErrNoPersonalAPIKey = errors.New("no SecretKey (or PersonalApiKey) provided")
 
 	// ErrNoDistinctID is returned when distinct_id is required for the requested
 	// operation but was not provided.

--- a/error.go
+++ b/error.go
@@ -75,7 +75,7 @@ var (
 	// limit.
 	ErrMessageTooBig = errors.New("the message exceeds the maximum allowed size")
 
-	// ErrNoPersonalAPIKey is returned when PersonalApiKey is required for the
+	// ErrNoPersonalAPIKey is returned when a SecretKey is required for the
 	// requested operation but was not configured.
 	ErrNoPersonalAPIKey = errors.New("no PersonalAPIKey provided")
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -4,8 +4,8 @@
 # Your project API key (found on the /setup page in PostHog)
 POSTHOG_PROJECT_API_KEY=phc_your_project_api_key_here
 
-# Your personal API key (for local evaluation and other advanced features)
-POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
+# Your secret API key (for local evaluation and other advanced features)
+POSTHOG_SECRET_KEY=phx_your_secret_api_key_here
 
 # PostHog host URL
 # For cloud: https://us.i.posthog.com (US) or https://eu.i.posthog.com (EU)

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ go run *.go
 ```bash
 # Set your PostHog API keys
 export POSTHOG_PROJECT_API_KEY="your-project-api-key"
-export POSTHOG_PERSONAL_API_KEY="your-personal-api-key"
+export POSTHOG_SECRET_KEY="your-secret-api-key"
 
 # Run all examples
 go run *.go
@@ -38,7 +38,7 @@ Before running the examples, you'll need to:
 
 1. **PostHog API Keys**:
    - `POSTHOG_PROJECT_API_KEY`: Your project API key (starts with `phc_...`)
-   - `POSTHOG_PERSONAL_API_KEY`: Your personal API key (starts with `phx_...`)
+   - `POSTHOG_SECRET_KEY`: Your secret API key (starts with `phx_...`)
 
 2. **PostHog Instance** (optional):
    - Default: `http://localhost:8000`
@@ -62,7 +62,7 @@ The examples will automatically load configuration from a `.env` file if it exis
 ```bash
 # PostHog API Configuration
 POSTHOG_PROJECT_API_KEY=phc_your_project_api_key_here
-POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
+POSTHOG_SECRET_KEY=phx_your_secret_api_key_here
 POSTHOG_ENDPOINT=https://us.i.posthog.com
 ```
 

--- a/examples/capture.go
+++ b/examples/capture.go
@@ -66,7 +66,7 @@ func TestCapture(projectAPIKey, endpoint string) {
 	fmt.Println("✅ Basic events sent successfully!")
 }
 
-func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoint string) {
+func TestCaptureWithSendFeatureFlagOption(projectAPIKey, secretKey, endpoint string) {
 	fmt.Println("🏁 Capturing events with feature flags...")
 	fmt.Println("   This demonstrates how to automatically include feature flag states with events")
 
@@ -74,7 +74,7 @@ func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoin
 		Interval:  30 * time.Second,
 		BatchSize: 100,
 		Verbose:   true,
-		SecretKey: personalAPIKey,
+		SecretKey: secretKey,
 		Endpoint:  endpoint,
 	})
 	defer client.Close()
@@ -115,7 +115,7 @@ func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoin
 	fmt.Println("   ℹ️ The second event will not include feature flag information")
 }
 
-func TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpoint string) {
+func TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, secretKey, endpoint string) {
 	fmt.Println("🚀 Advanced feature flags with SendFeatureFlagsOptions...")
 	fmt.Println("   This demonstrates advanced feature flag evaluation with custom properties")
 
@@ -123,7 +123,7 @@ func TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpo
 		Interval:  30 * time.Second,
 		BatchSize: 100,
 		Verbose:   true,
-		SecretKey: personalAPIKey,
+		SecretKey: secretKey,
 		Endpoint:  endpoint,
 	})
 	defer client.Close()

--- a/examples/capture.go
+++ b/examples/capture.go
@@ -71,11 +71,11 @@ func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoin
 	fmt.Println("   This demonstrates how to automatically include feature flag states with events")
 
 	client, _ := posthog.NewWithConfig(projectAPIKey, posthog.Config{
-		Interval:       30 * time.Second,
-		BatchSize:      100,
-		Verbose:        true,
+		Interval:  30 * time.Second,
+		BatchSize: 100,
+		Verbose:   true,
 		SecretKey: personalAPIKey,
-		Endpoint:       endpoint,
+		Endpoint:  endpoint,
 	})
 	defer client.Close()
 
@@ -120,11 +120,11 @@ func TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpo
 	fmt.Println("   This demonstrates advanced feature flag evaluation with custom properties")
 
 	client, _ := posthog.NewWithConfig(projectAPIKey, posthog.Config{
-		Interval:       30 * time.Second,
-		BatchSize:      100,
-		Verbose:        true,
+		Interval:  30 * time.Second,
+		BatchSize: 100,
+		Verbose:   true,
 		SecretKey: personalAPIKey,
-		Endpoint:       endpoint,
+		Endpoint:  endpoint,
 	})
 	defer client.Close()
 

--- a/examples/capture.go
+++ b/examples/capture.go
@@ -74,7 +74,7 @@ func TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoin
 		Interval:       30 * time.Second,
 		BatchSize:      100,
 		Verbose:        true,
-		PersonalApiKey: personalAPIKey,
+		SecretKey: personalAPIKey,
 		Endpoint:       endpoint,
 	})
 	defer client.Close()
@@ -123,7 +123,7 @@ func TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpo
 		Interval:       30 * time.Second,
 		BatchSize:      100,
 		Verbose:        true,
-		PersonalApiKey: personalAPIKey,
+		SecretKey: personalAPIKey,
 		Endpoint:       endpoint,
 	})
 	defer client.Close()

--- a/examples/etag_polling.go
+++ b/examples/etag_polling.go
@@ -70,7 +70,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 // TestETagPolling demonstrates ETag support for local evaluation polling.
 // It polls every 5 seconds and logs the ETag behavior to show when
 // 304 Not Modified responses occur (indicating no data transfer).
-func TestETagPolling(projectAPIKey, personalAPIKey, endpointURL string) {
+func TestETagPolling(projectAPIKey, secretKey, endpointURL string) {
 	fmt.Println(strings.Repeat("=", 60))
 	fmt.Println("ETag Polling Test")
 	fmt.Println(strings.Repeat("=", 60))
@@ -85,7 +85,7 @@ func TestETagPolling(projectAPIKey, personalAPIKey, endpointURL string) {
 	}
 
 	client, err := posthog.NewWithConfig(projectAPIKey, posthog.Config{
-		SecretKey:                          personalAPIKey,
+		SecretKey:                          secretKey,
 		Endpoint:                           endpointURL,
 		DefaultFeatureFlagsPollingInterval: etagPollInterval,
 		Transport:                          transport,

--- a/examples/etag_polling.go
+++ b/examples/etag_polling.go
@@ -85,7 +85,7 @@ func TestETagPolling(projectAPIKey, personalAPIKey, endpointURL string) {
 	}
 
 	client, err := posthog.NewWithConfig(projectAPIKey, posthog.Config{
-		PersonalApiKey:                     personalAPIKey,
+		SecretKey:                          personalAPIKey,
 		Endpoint:                           endpointURL,
 		DefaultFeatureFlagsPollingInterval: etagPollInterval,
 		Transport:                          transport,

--- a/examples/featureflags.go
+++ b/examples/featureflags.go
@@ -8,12 +8,12 @@ import (
 	"github.com/posthog/posthog-go"
 )
 
-func TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint string) {
+func TestIsFeatureEnabled(projectAPIKey, secretKey, endpoint string) {
 	client, err := posthog.NewWithConfig(projectAPIKey, posthog.Config{
 		Interval:                           30 * time.Second,
 		BatchSize:                          100,
 		Verbose:                            true,
-		SecretKey:                          personalAPIKey,
+		SecretKey:                          secretKey,
 		Endpoint:                           endpoint,
 		DefaultFeatureFlagsPollingInterval: 5 * time.Second,
 		FeatureFlagRequestTimeout:          3 * time.Second,
@@ -90,7 +90,7 @@ func TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint string) {
 	fmt.Println("   - GetRemoteConfigPayload(): Returns encrypted payload data")
 }
 
-func TestFlagDependencies(projectAPIKey, personalAPIKey, endpoint string) {
+func TestFlagDependencies(projectAPIKey, secretKey, endpoint string) {
 	fmt.Println("🔗 Testing flag dependencies with local evaluation...")
 	fmt.Println("   This demonstrates pure flag evaluation with no events sent")
 	fmt.Println("   Flag structure: 'test-flag-dependency' depends on 'beta-feature' being enabled")
@@ -108,7 +108,7 @@ func TestFlagDependencies(projectAPIKey, personalAPIKey, endpoint string) {
 		Interval:                           30 * time.Second,
 		BatchSize:                          100,
 		Verbose:                            false, // Disable verbose logging for cleaner output
-		SecretKey:                          personalAPIKey,
+		SecretKey:                          secretKey,
 		Endpoint:                           endpoint,
 		DefaultFeatureFlagsPollingInterval: 5 * time.Second,
 		FeatureFlagRequestTimeout:          3 * time.Second,

--- a/examples/featureflags.go
+++ b/examples/featureflags.go
@@ -13,7 +13,7 @@ func TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint string) {
 		Interval:                           30 * time.Second,
 		BatchSize:                          100,
 		Verbose:                            true,
-		PersonalApiKey:                     personalAPIKey,
+		SecretKey:                          personalAPIKey,
 		Endpoint:                           endpoint,
 		DefaultFeatureFlagsPollingInterval: 5 * time.Second,
 		FeatureFlagRequestTimeout:          3 * time.Second,
@@ -108,7 +108,7 @@ func TestFlagDependencies(projectAPIKey, personalAPIKey, endpoint string) {
 		Interval:                           30 * time.Second,
 		BatchSize:                          100,
 		Verbose:                            false, // Disable verbose logging for cleaner output
-		PersonalApiKey:                     personalAPIKey,
+		SecretKey:                          personalAPIKey,
 		Endpoint:                           endpoint,
 		DefaultFeatureFlagsPollingInterval: 5 * time.Second,
 		FeatureFlagRequestTimeout:          3 * time.Second,

--- a/examples/main.go
+++ b/examples/main.go
@@ -23,9 +23,9 @@ import (
 )
 
 var (
-	projectAPIKey  string
-	personalAPIKey string
-	endpoint       string
+	projectAPIKey string
+	secretKey     string
+	endpoint      string
 )
 
 func init() {
@@ -34,7 +34,7 @@ func init() {
 
 	// Get configuration from environment variables
 	projectAPIKey = os.Getenv("POSTHOG_PROJECT_API_KEY")
-	personalAPIKey = os.Getenv("POSTHOG_SECRET_KEY")
+	secretKey = os.Getenv("POSTHOG_SECRET_KEY")
 	endpoint = os.Getenv("POSTHOG_ENDPOINT")
 
 	if endpoint == "" {
@@ -62,7 +62,7 @@ func promptForInput(prompt string) string {
 
 func checkCredentials() {
 	// Check if credentials are provided
-	if projectAPIKey == "" || personalAPIKey == "" {
+	if projectAPIKey == "" || secretKey == "" {
 		fmt.Println("❌ Missing PostHog credentials!")
 		fmt.Println("   Please set POSTHOG_PROJECT_API_KEY and POSTHOG_SECRET_KEY environment variables")
 		fmt.Println("   or copy .env.example to .env and fill in your values")
@@ -71,8 +71,8 @@ func checkCredentials() {
 		if projectAPIKey == "" {
 			projectAPIKey = promptForInput("Enter your PostHog project API key (starts with phc_): ")
 		}
-		if personalAPIKey == "" {
-			personalAPIKey = promptForInput("Enter your PostHog secret API key (starts with phx_): ")
+		if secretKey == "" {
+			secretKey = promptForInput("Enter your PostHog secret API key (starts with phx_): ")
 		}
 	} else {
 		fmt.Println("✅ PostHog credentials loaded successfully!")
@@ -102,27 +102,27 @@ func runBasicCaptureExamples() {
 
 func runCaptureWithFeatureFlagsExamples() {
 	printExampleSection("CAPTURE WITH FEATURE FLAGS EXAMPLES")
-	TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoint)
+	TestCaptureWithSendFeatureFlagOption(projectAPIKey, secretKey, endpoint)
 }
 
 func runFeatureFlagEvaluationExamples() {
 	printExampleSection("FEATURE FLAG EVALUATION EXAMPLES")
-	TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint)
+	TestIsFeatureEnabled(projectAPIKey, secretKey, endpoint)
 }
 
 func runAdvancedFeatureFlagsExamples() {
 	printExampleSection("ADVANCED FEATURE FLAGS (SendFeatureFlagsOptions) EXAMPLES")
-	TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpoint)
+	TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, secretKey, endpoint)
 }
 
 func runFlagDependenciesExamples() {
 	printExampleSection("FLAG DEPENDENCIES EXAMPLES")
-	TestFlagDependencies(projectAPIKey, personalAPIKey, endpoint)
+	TestFlagDependencies(projectAPIKey, secretKey, endpoint)
 }
 
 func runETagPollingExample() {
 	printExampleSection("ETAG POLLING TEST")
-	TestETagPolling(projectAPIKey, personalAPIKey, endpoint)
+	TestETagPolling(projectAPIKey, secretKey, endpoint)
 }
 
 func printExampleSection(title string) {
@@ -138,18 +138,18 @@ func runAllExamples() {
 	TestCapture(projectAPIKey, endpoint)
 
 	fmt.Printf("\n%s CAPTURE WITH FEATURE FLAGS %s\n", strings.Repeat("🔸", 15), strings.Repeat("🔸", 15))
-	TestCaptureWithSendFeatureFlagOption(projectAPIKey, personalAPIKey, endpoint)
+	TestCaptureWithSendFeatureFlagOption(projectAPIKey, secretKey, endpoint)
 
 	fmt.Printf("\n%s FEATURE FLAG EVALUATION %s\n", strings.Repeat("🔸", 17), strings.Repeat("🔸", 17))
-	TestIsFeatureEnabled(projectAPIKey, personalAPIKey, endpoint)
+	TestIsFeatureEnabled(projectAPIKey, secretKey, endpoint)
 	TestErrorTrackingThroughEnqueueing(projectAPIKey, endpoint)
 	TestErrorTrackingThroughLogHandler(projectAPIKey, endpoint)
 
 	fmt.Printf("\n%s ADVANCED FEATURE FLAGS %s\n", strings.Repeat("🔸", 18), strings.Repeat("🔸", 18))
-	TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, personalAPIKey, endpoint)
+	TestCaptureWithSendFeatureFlagsOptions(projectAPIKey, secretKey, endpoint)
 
 	fmt.Printf("\n%s FLAG DEPENDENCIES %s\n", strings.Repeat("🔸", 20), strings.Repeat("🔸", 20))
-	TestFlagDependencies(projectAPIKey, personalAPIKey, endpoint)
+	TestFlagDependencies(projectAPIKey, secretKey, endpoint)
 }
 
 func isInteractive() bool {

--- a/examples/main.go
+++ b/examples/main.go
@@ -34,7 +34,7 @@ func init() {
 
 	// Get configuration from environment variables
 	projectAPIKey = os.Getenv("POSTHOG_PROJECT_API_KEY")
-	personalAPIKey = os.Getenv("POSTHOG_PERSONAL_API_KEY")
+	personalAPIKey = os.Getenv("POSTHOG_SECRET_KEY")
 	endpoint = os.Getenv("POSTHOG_ENDPOINT")
 
 	if endpoint == "" {
@@ -64,7 +64,7 @@ func checkCredentials() {
 	// Check if credentials are provided
 	if projectAPIKey == "" || personalAPIKey == "" {
 		fmt.Println("❌ Missing PostHog credentials!")
-		fmt.Println("   Please set POSTHOG_PROJECT_API_KEY and POSTHOG_PERSONAL_API_KEY environment variables")
+		fmt.Println("   Please set POSTHOG_PROJECT_API_KEY and POSTHOG_SECRET_KEY environment variables")
 		fmt.Println("   or copy .env.example to .env and fill in your values")
 		fmt.Println()
 
@@ -72,12 +72,12 @@ func checkCredentials() {
 			projectAPIKey = promptForInput("Enter your PostHog project API key (starts with phc_): ")
 		}
 		if personalAPIKey == "" {
-			personalAPIKey = promptForInput("Enter your PostHog personal API key (starts with phx_): ")
+			personalAPIKey = promptForInput("Enter your PostHog secret API key (starts with phx_): ")
 		}
 	} else {
 		fmt.Println("✅ PostHog credentials loaded successfully!")
 		fmt.Println("   Project API Key: [REDACTED]")
-		fmt.Println("   Personal API Key: [REDACTED]")
+		fmt.Println("   Secret API Key: [REDACTED]")
 		fmt.Printf("   Endpoint: %s\n\n", endpoint)
 	}
 }

--- a/feature_flags_local_test.go
+++ b/feature_flags_local_test.go
@@ -27,7 +27,7 @@ func newFeatureFlagsFixtureClient(t *testing.T, fixtureName string) Client {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{PersonalApiKey: "some very secret key", Endpoint: server.URL})
+	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{SecretKey: "some very secret key", Endpoint: server.URL})
 	require.NoError(t, err)
 	t.Cleanup(func() { client.Close() })
 	return client
@@ -45,8 +45,8 @@ func newFeatureFlagsLocalClient(t *testing.T, definitionsFixture string) Client 
 	t.Cleanup(server.Close)
 
 	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { client.Close() })
@@ -65,8 +65,8 @@ func TestFlagPersonProperty(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -142,8 +142,8 @@ func TestFlagGroup(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -170,8 +170,8 @@ func TestFlagGroupProperty(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -224,8 +224,8 @@ func TestComplexDefinition(t *testing.T) {
 	defer server.Close()
 
 	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	require.NoError(t, err)
 	defer client.Close()
@@ -263,8 +263,8 @@ func TestFallbackToFlags(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -291,8 +291,8 @@ func TestFeatureFlagsDontFallbackToFlagsWhenOnlyLocalEvaluationIsTrue(t *testing
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -368,8 +368,8 @@ func TestFeatureFlagDefaultsDontHinderEvaluation(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -427,8 +427,8 @@ func TestFeatureFlagNullComeIntoPlayOnlyWhenFlagsErrorsOut(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -504,8 +504,8 @@ func TestGetAllFlags(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -530,8 +530,8 @@ func TestGetAllFlagsEmptyLocal(t *testing.T) {
 	defer server.Close()
 
 	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	require.NoError(t, err)
 	defer client.Close()
@@ -562,8 +562,8 @@ func TestGetAllFlagsOnlyLocalEvaluationSet(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -592,8 +592,8 @@ func TestFeatureFlagWithDependencies(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("test-api-key", Config{
-		PersonalApiKey: "test-personal-api-key",
-		Endpoint:       server.URL,
+		SecretKey: "test-personal-api-key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -705,8 +705,8 @@ func TestFeatureFlagEarlyExit(t *testing.T) {
 			defer server.Close()
 
 			client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-				PersonalApiKey: "some very secret key",
-				Endpoint:       server.URL,
+				SecretKey: "some very secret key",
+				Endpoint:  server.URL,
 			})
 			defer client.Close()
 
@@ -744,9 +744,9 @@ func TestGetFeatureFlag(t *testing.T) {
 	eventCaptured := make(chan struct{}, 1)
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-		BatchSize:      1,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
+		BatchSize: 1,
 		Callback: testCallback{
 			func(m APIMessage) {
 				if capture, ok := m.(CaptureInApi); ok {
@@ -817,9 +817,9 @@ func TestGetFeatureFlagLocallyEvaluated(t *testing.T) {
 	eventCaptured := make(chan struct{}, 1)
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
-		BatchSize:      1,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
+		BatchSize: 1,
 		Callback: testCallback{
 			func(m APIMessage) {
 				if capture, ok := m.(CaptureInApi); ok {
@@ -879,8 +879,8 @@ func TestGetRemoteConfigPayload(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -977,8 +977,8 @@ func TestConditionsEvaluatedInOrder(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -1047,8 +1047,8 @@ func TestSimpleFlagConsistency(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -2075,8 +2075,8 @@ func TestMultivariateFlagConsistency(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -3104,8 +3104,8 @@ func TestMultivariateFlagConsistencyPayload(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -4140,7 +4140,7 @@ func TestFlagsFetchFail(t *testing.T) {
 	defer server.Close()
 
 	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey:            "some very secret key",
+		SecretKey:                 "some very secret key",
 		Endpoint:                  server.URL,
 		FeatureFlagRequestTimeout: 10 * time.Millisecond,
 	})
@@ -4170,7 +4170,7 @@ func TestFlagWithTimeoutExceeded(t *testing.T) {
 	defer server.Close()
 
 	client, err := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey:            "some very secret key",
+		SecretKey:                 "some very secret key",
 		Endpoint:                  server.URL,
 		FeatureFlagRequestTimeout: 10 * time.Millisecond,
 	})
@@ -4254,7 +4254,7 @@ func TestFlagDefinitionsWithTimeoutExceeded(t *testing.T) {
 	defer server.Close()
 
 	client, clientErr := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey:            "some very secret key",
+		SecretKey:                 "some very secret key",
 		Endpoint:                  server.URL,
 		FeatureFlagRequestTimeout: 100 * time.Millisecond,
 		Logger:                    StdLogger(log.New(&buf, "posthog-test", log.LstdFlags), false),
@@ -4301,8 +4301,8 @@ func TestFetchFlagsFails(t *testing.T) {
 	defer server.Close()
 
 	cli, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer cli.Close()
 
@@ -4346,8 +4346,8 @@ func TestFeatureFlagWithOverrides(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -4427,8 +4427,8 @@ func TestFeatureFlagDistinctIDOverride(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -4490,8 +4490,8 @@ func TestFeatureFlagDeviceIDBucketingLocalEvaluation(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -4524,8 +4524,8 @@ func TestFeatureFlagWithFalseVariant(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("Csyjlnlun3OzyNJAafdlv", Config{
-		PersonalApiKey: "some very secret key",
-		Endpoint:       server.URL,
+		SecretKey: "some very secret key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -4790,8 +4790,8 @@ func TestProductionStyleMultivariateDependencyChain(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("test-api-key", Config{
-		PersonalApiKey: "test-personal-key",
-		Endpoint:       server.URL,
+		SecretKey: "test-personal-key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 
@@ -4958,8 +4958,8 @@ func TestFallbackToAPIWhenFlagHasStaticCohortInMultiCondition(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("test_api_key", Config{
-		Endpoint:       server.URL,
-		PersonalApiKey: "test_personal_api_key",
+		Endpoint:  server.URL,
+		SecretKey: "test_personal_api_key",
 	})
 	defer client.Close()
 
@@ -5036,8 +5036,8 @@ func TestGetFeatureFlagPayloadFallbackToAPIWhenFlagHasStaticCohort(t *testing.T)
 	defer server.Close()
 
 	client, _ := NewWithConfig("test_api_key", Config{
-		Endpoint:       server.URL,
-		PersonalApiKey: "test_personal_api_key",
+		Endpoint:  server.URL,
+		SecretKey: "test_personal_api_key",
 	})
 	defer client.Close()
 
@@ -5100,8 +5100,8 @@ func TestDateBeforeOperatorAbsolute(t *testing.T) {
 	defer server.Close()
 
 	client, _ := NewWithConfig("test-api-key", Config{
-		PersonalApiKey: "test-personal-key",
-		Endpoint:       server.URL,
+		SecretKey: "test-personal-key",
+		Endpoint:  server.URL,
 	})
 	defer client.Close()
 

--- a/posthog.go
+++ b/posthog.go
@@ -80,7 +80,7 @@ type Client interface {
 	// GetFeatureFlagResult evaluates one feature flag and returns its value and payload together.
 	// Use this instead of calling GetFeatureFlag and GetFeatureFlagPayload separately.
 	// It returns ErrFlagNotFound when the flag cannot be found or evaluated and
-	// ErrNoPersonalAPIKey when OnlyEvaluateLocally is true without PersonalApiKey.
+	// ErrNoPersonalAPIKey when OnlyEvaluateLocally is true without SecretKey.
 	GetFeatureFlagResult(FeatureFlagPayload) (*FeatureFlagResult, error)
 
 	// GetFeatureFlagPayload returns the payload for the matching flag value, or an
@@ -90,12 +90,12 @@ type Client interface {
 	GetFeatureFlagPayload(FeatureFlagPayload) (string, error)
 
 	// GetRemoteConfigPayload returns the decrypted payload for a remote config flag key.
-	// It requires Config.PersonalApiKey and returns ErrNoPersonalAPIKey when missing.
+	// It requires Config.SecretKey and returns ErrNoPersonalAPIKey when missing.
 	GetRemoteConfigPayload(string) (string, error)
 
 	// GetAllFlags evaluates all flags for a user. Returned values are booleans for
 	// boolean flags and strings for multivariate variants. It returns ErrNoPersonalAPIKey
-	// when OnlyEvaluateLocally is true without PersonalApiKey.
+	// when OnlyEvaluateLocally is true without SecretKey.
 	GetAllFlags(FeatureFlagPayloadNoKey) (map[string]interface{}, error)
 
 	// EvaluateFlags returns a snapshot of feature-flag evaluations for the
@@ -110,11 +110,11 @@ type Client interface {
 	// locally, EvaluateFlags returns a non-nil snapshot containing the
 	// locally-evaluated flags alongside the error so the caller can still
 	// branch on what was resolved.
-	// If OnlyEvaluateLocally is true and no PersonalApiKey is configured, returns ErrNoPersonalAPIKey.
+	// If OnlyEvaluateLocally is true and no SecretKey is configured, returns ErrNoPersonalAPIKey.
 	EvaluateFlags(EvaluateFlagsPayload) (*FeatureFlagEvaluations, error)
 
 	// ReloadFeatureFlags forces a reload of feature flags.
-	// If no PersonalApiKey is configured, returns ErrNoPersonalAPIKey.
+	// If no SecretKey is configured, returns ErrNoPersonalAPIKey.
 	ReloadFeatureFlags() error
 
 	// CloseWithContext gracefully shuts down the client with the provided context.
@@ -224,7 +224,7 @@ func New(apiKey string) Client {
 
 // NewWithConfig creates a Client with the provided PostHog project API key and Config.
 //
-// The apiKey, Config.Endpoint, and Config.PersonalApiKey values are trimmed before use.
+// The apiKey, Config.Endpoint, Config.SecretKey, and Config.PersonalApiKey values are trimmed before use.
 // It returns a ConfigError when config contains invalid values such as negative
 // intervals or out-of-range retry settings; in that case the returned Client is nil.
 // If apiKey is empty after trimming, NewWithConfig returns a no-op client and nil error.
@@ -275,10 +275,11 @@ func NewWithConfig(apiKey string, config Config) (cli Client, err error) {
 		return nil, fmt.Errorf("error creating flags client: %v", err)
 	}
 
-	if len(c.PersonalApiKey) > 0 {
+	secretKey := c.Config.effectiveSecretKey()
+	if len(secretKey) > 0 {
 		c.featureFlagsPoller, err = newFeatureFlagsPoller(
 			c.key,
-			c.Config.PersonalApiKey,
+			secretKey,
 			c.Logger,
 			c.Endpoint,
 			c.http,
@@ -1762,7 +1763,7 @@ func (c *client) debugf(format string, args ...interface{}) {
 }
 
 func (c *client) warnPersonalAPIKeyMissing(method string) {
-	c.Warnf("PostHog personal_api_key is not configured; %s requires a PersonalApiKey.", method)
+	c.Warnf("PostHog secret key is not configured; %s requires a SecretKey.", method)
 }
 
 func (c *client) Errorf(format string, args ...interface{}) {
@@ -1822,7 +1823,8 @@ func (c *client) makeRemoteConfigRequest(flagKey string) (string, error) {
 		return "", fmt.Errorf("parsing URL: %v", err)
 	}
 
-	if c.PersonalApiKey == "" {
+	secretKey := c.Config.effectiveSecretKey()
+	if secretKey == "" {
 		c.warnPersonalAPIKeyMissing("GetRemoteConfigPayload")
 		return "", ErrNoPersonalAPIKey
 	}
@@ -1836,7 +1838,7 @@ func (c *client) makeRemoteConfigRequest(flagKey string) (string, error) {
 		return "", fmt.Errorf("creating request: %v", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.PersonalApiKey)
+	req.Header.Set("Authorization", "Bearer "+secretKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "posthog-go/"+Version)
 

--- a/posthog.go
+++ b/posthog.go
@@ -80,7 +80,7 @@ type Client interface {
 	// GetFeatureFlagResult evaluates one feature flag and returns its value and payload together.
 	// Use this instead of calling GetFeatureFlag and GetFeatureFlagPayload separately.
 	// It returns ErrFlagNotFound when the flag cannot be found or evaluated and
-	// ErrNoPersonalAPIKey when OnlyEvaluateLocally is true without SecretKey.
+	// ErrNoSecretKey when OnlyEvaluateLocally is true without SecretKey.
 	GetFeatureFlagResult(FeatureFlagPayload) (*FeatureFlagResult, error)
 
 	// GetFeatureFlagPayload returns the payload for the matching flag value, or an
@@ -90,11 +90,11 @@ type Client interface {
 	GetFeatureFlagPayload(FeatureFlagPayload) (string, error)
 
 	// GetRemoteConfigPayload returns the decrypted payload for a remote config flag key.
-	// It requires Config.SecretKey and returns ErrNoPersonalAPIKey when missing.
+	// It requires Config.SecretKey and returns ErrNoSecretKey when missing.
 	GetRemoteConfigPayload(string) (string, error)
 
 	// GetAllFlags evaluates all flags for a user. Returned values are booleans for
-	// boolean flags and strings for multivariate variants. It returns ErrNoPersonalAPIKey
+	// boolean flags and strings for multivariate variants. It returns ErrNoSecretKey
 	// when OnlyEvaluateLocally is true without SecretKey.
 	GetAllFlags(FeatureFlagPayloadNoKey) (map[string]interface{}, error)
 
@@ -110,11 +110,11 @@ type Client interface {
 	// locally, EvaluateFlags returns a non-nil snapshot containing the
 	// locally-evaluated flags alongside the error so the caller can still
 	// branch on what was resolved.
-	// If OnlyEvaluateLocally is true and no SecretKey is configured, returns ErrNoPersonalAPIKey.
+	// If OnlyEvaluateLocally is true and no SecretKey is configured, returns ErrNoSecretKey.
 	EvaluateFlags(EvaluateFlagsPayload) (*FeatureFlagEvaluations, error)
 
 	// ReloadFeatureFlags forces a reload of feature flags.
-	// If no SecretKey is configured, returns ErrNoPersonalAPIKey.
+	// If no SecretKey is configured, returns ErrNoSecretKey.
 	ReloadFeatureFlags() error
 
 	// CloseWithContext gracefully shuts down the client with the provided context.
@@ -785,7 +785,7 @@ func (c *client) IsFeatureEnabled(flagConfig FeatureFlagPayload) (interface{}, e
 func (c *client) ReloadFeatureFlags() error {
 	if c.featureFlagsPoller == nil {
 		c.warnPersonalAPIKeyMissing("ReloadFeatureFlags")
-		return ErrNoPersonalAPIKey
+		return ErrNoSecretKey
 	}
 	c.featureFlagsPoller.ForceReload()
 	return nil
@@ -839,7 +839,7 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 	}
 	if c.featureFlagsPoller == nil && flagConfig.OnlyEvaluateLocally {
 		c.warnPersonalAPIKeyMissing("GetFeatureFlagResult")
-		return nil, ErrNoPersonalAPIKey
+		return nil, ErrNoSecretKey
 	}
 
 	var flagValue interface{}
@@ -1069,7 +1069,7 @@ func (c *client) getAllFlagsWithContext(ctx context.Context, flagConfig FeatureF
 	}
 	if c.featureFlagsPoller == nil && flagConfig.OnlyEvaluateLocally {
 		c.warnPersonalAPIKeyMissing("GetAllFlags")
-		return nil, ErrNoPersonalAPIKey
+		return nil, ErrNoSecretKey
 	}
 
 	var flagsValue map[string]interface{}
@@ -1167,7 +1167,7 @@ func (c *client) evaluateFlagsWithContext(ctx context.Context, payload EvaluateF
 		fallbackToRemote = c.populateLocalEvaluations(records, locallyEvaluated, payload)
 	} else if payload.OnlyEvaluateLocally {
 		c.warnPersonalAPIKeyMissing("EvaluateFlags")
-		return noopFeatureFlagEvaluations, ErrNoPersonalAPIKey
+		return noopFeatureFlagEvaluations, ErrNoSecretKey
 	}
 
 	var requestId string
@@ -1797,7 +1797,7 @@ func (c *client) getFeatureVariants(distinctId string, groups Groups, personProp
 func (c *client) getFeatureVariantsWithOptions(distinctId string, groups Groups, personProperties Properties, groupProperties map[string]Properties, options *SendFeatureFlagsOptions) (map[string]interface{}, error) {
 	if c.featureFlagsPoller == nil {
 		c.warnPersonalAPIKeyMissing("Capture.SendFeatureFlags")
-		return nil, ErrNoPersonalAPIKey
+		return nil, ErrNoSecretKey
 	}
 
 	var deviceId *string
@@ -1826,7 +1826,7 @@ func (c *client) makeRemoteConfigRequest(flagKey string) (string, error) {
 	secretKey := c.Config.effectiveSecretKey()
 	if secretKey == "" {
 		c.warnPersonalAPIKeyMissing("GetRemoteConfigPayload")
-		return "", ErrNoPersonalAPIKey
+		return "", ErrNoSecretKey
 	}
 
 	q := parsedURL.Query()

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -275,6 +275,40 @@ func TestNewWithConfig_TrimsWhitespaceSensitiveInputsInRequests(t *testing.T) {
 	require.Equal(t, "Bearer test-personal-key", remoteConfigAuth)
 }
 
+func TestRemoteConfigAuthUsesResolvedSecretKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   Config
+		wantAuth string
+	}{
+		{"secret key", Config{SecretKey: "phs_secret"}, "Bearer phs_secret"},
+		{"personal api key fallback", Config{PersonalApiKey: "phx_personal"}, "Bearer phx_personal"},
+		{"secret key wins", Config{SecretKey: "phs_secret", PersonalApiKey: "phx_personal"}, "Bearer phs_secret"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotAuth string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`"ok"`))
+			}))
+			defer server.Close()
+
+			tc.config.Endpoint = server.URL
+			client, err := NewWithConfig("test-api-key", tc.config)
+			require.NoError(t, err)
+			defer client.Close()
+
+			payload, err := client.GetRemoteConfigPayload("test-flag")
+			require.NoError(t, err)
+			require.Equal(t, "ok", payload)
+			require.Equal(t, tc.wantAuth, gotAuth)
+		})
+	}
+}
+
 var _ Message = (*testErrorMessage)(nil)
 
 // Instances of this type are used to force message validation errors in unit
@@ -1345,11 +1379,11 @@ func TestFeatureFlagsWithNoPersonalApiKey(t *testing.T) {
 	require.Empty(t, localEvaluations.Keys())
 
 	joinedLogs := strings.Join(logged, "\n")
-	require.Contains(t, joinedLogs, "PostHog personal_api_key is not configured; ReloadFeatureFlags requires a PersonalApiKey.")
-	require.Contains(t, joinedLogs, "PostHog personal_api_key is not configured; GetRemoteConfigPayload requires a PersonalApiKey.")
-	require.Contains(t, joinedLogs, "PostHog personal_api_key is not configured; GetFeatureFlagResult requires a PersonalApiKey.")
-	require.Contains(t, joinedLogs, "PostHog personal_api_key is not configured; GetAllFlags requires a PersonalApiKey.")
-	require.Contains(t, joinedLogs, "PostHog personal_api_key is not configured; EvaluateFlags requires a PersonalApiKey.")
+	require.Contains(t, joinedLogs, "PostHog secret key is not configured; ReloadFeatureFlags requires a SecretKey.")
+	require.Contains(t, joinedLogs, "PostHog secret key is not configured; GetRemoteConfigPayload requires a SecretKey.")
+	require.Contains(t, joinedLogs, "PostHog secret key is not configured; GetFeatureFlagResult requires a SecretKey.")
+	require.Contains(t, joinedLogs, "PostHog secret key is not configured; GetAllFlags requires a SecretKey.")
+	require.Contains(t, joinedLogs, "PostHog secret key is not configured; EvaluateFlags requires a SecretKey.")
 }
 
 func TestFeatureFlagPublicMethodsKeepDistinctIDConfigError(t *testing.T) {

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -288,30 +288,21 @@ func TestRemoteConfigAuthUsesResolvedSecretKey(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var mu sync.Mutex
 			var gotAuth string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if auth := r.Header.Get("Authorization"); auth != "" {
-					mu.Lock()
-					gotAuth = auth
-					mu.Unlock()
-				}
+				gotAuth = r.Header.Get("Authorization")
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`"ok"`))
 			}))
 			defer server.Close()
 
 			tc.config.Endpoint = server.URL
-			client, err := NewWithConfig("test-api-key", tc.config)
-			require.NoError(t, err)
-			defer client.Close()
+			c := &client{Config: tc.config, key: "test-api-key", http: http.Client{}}
 
-			payload, err := client.GetRemoteConfigPayload("test-flag")
+			payload, err := c.makeRemoteConfigRequest("test-flag")
 			require.NoError(t, err)
 			require.Equal(t, "ok", payload)
-			mu.Lock()
 			require.Equal(t, tc.wantAuth, gotAuth)
-			mu.Unlock()
 		})
 	}
 }

--- a/posthog_test.go
+++ b/posthog_test.go
@@ -288,9 +288,14 @@ func TestRemoteConfigAuthUsesResolvedSecretKey(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
 			var gotAuth string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				gotAuth = r.Header.Get("Authorization")
+				if auth := r.Header.Get("Authorization"); auth != "" {
+					mu.Lock()
+					gotAuth = auth
+					mu.Unlock()
+				}
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`"ok"`))
 			}))
@@ -304,7 +309,9 @@ func TestRemoteConfigAuthUsesResolvedSecretKey(t *testing.T) {
 			payload, err := client.GetRemoteConfigPayload("test-flag")
 			require.NoError(t, err)
 			require.Equal(t, "ok", payload)
+			mu.Lock()
 			require.Equal(t, tc.wantAuth, gotAuth)
+			mu.Unlock()
 		})
 	}
 }


### PR DESCRIPTION
## Problem

The config field used for local feature flag evaluation and remote config is named `PersonalApiKey`, but it actually accepts **either** a Personal API Key (`phx_...`) **or** a Project Secret API Key (`phs_...`). The name is misleading — users with a Project Secret API Key reasonably assume the field won't accept their key.

## Change

- Add a new canonical config field **`SecretKey`** that accepts either credential type.
- Keep **`PersonalApiKey`** as a **deprecated alias** (marked `// Deprecated: use SecretKey instead.`). Fully backwards compatible / non-breaking.
- Resolve the effective credential at the point of use: prefer `SecretKey`, fall back to `PersonalApiKey`. `SecretKey` wins when both are set.
- Update user-facing godoc and the "not configured" log message to reference `SecretKey`.
- Tests cover: `SecretKey` is used, `PersonalApiKey` still works, and `SecretKey` wins when both are set (unit resolution + end-to-end remote-config `Authorization` header).

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Context

Coordinated rename across the backend SDKs. See internal Slack discussion and PostHog/posthog-js#4046 (the field-rename item only). Mirrors the draft opened in posthog-python (#727).
