### PR TITLE
feat: send error tracking stack frames in canonical bottom-up order

### DIFF
--- a/.changeset/canonical-frame-order.md
+++ b/.changeset/canonical-frame-order.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Error tracking stack frames are now sent in the canonical cross-SDK wire order: the entry point is first and the crash/capture site is last. Previously frames were sent innermost-first. Coordinated rollout: the ingestion pipeline gates on `$lib_version`, so this ships as a minor release.

--- a/error_tracking_stack_trace.go
+++ b/error_tracking_stack_trace.go
@@ -49,8 +49,9 @@ type DefaultStackTraceExtractor struct {
 	InAppDecider InAppDecider
 }
 
-// GetStackTrace captures the current goroutine stack and converts it to an ExceptionStacktrace.
-// The skip parameter omits leading runtime.Callers frames before conversion.
+// GetStackTrace captures the current goroutine stack in wire order (outermost
+// frame first, capture site last). The skip parameter omits leading
+// runtime.Callers frames before conversion.
 func (d DefaultStackTraceExtractor) GetStackTrace(skip int) *ExceptionStacktrace {
 	pcs := make([]uintptr, 64)
 	stackCallCount := runtime.Callers(skip, pcs)
@@ -74,6 +75,13 @@ func (d DefaultStackTraceExtractor) GetStackTrace(skip int) *ExceptionStacktrace
 		if !hasMore {
 			break
 		}
+	}
+
+	// runtime.CallersFrames yields innermost first; reverse to the canonical
+	// wire order shared across PostHog SDKs (matching NativeStackTraceExtractor):
+	// outermost (entry point) first, capture site last.
+	for i, j := 0, len(traces)-1; i < j; i, j = i+1, j-1 {
+		traces[i], traces[j] = traces[j], traces[i]
 	}
 
 	return &ExceptionStacktrace{

--- a/error_tracking_stack_trace_test.go
+++ b/error_tracking_stack_trace_test.go
@@ -61,25 +61,27 @@ func TestDefaultStackTraceExtractor_GetStackTrace(t *testing.T) {
 		skip              int
 		expectedNames     []string
 	}{
+		// Frames are emitted in canonical wire order: outermost (entry point,
+		// runtime.goexit) first, capture site (runtime.Callers) last.
 		"the basic happy path with no skip or function depth": {
 			functionCallDepth: 0,
 			skip:              0,
 			expectedNames: []string{
-				"runtime.Callers",
-				"github.com/posthog/posthog-go.DefaultStackTraceExtractor.GetStackTrace",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.TestDefaultStackTraceExtractor_GetStackTrace.func1",
-				"testing.tRunner",
 				"runtime.goexit",
+				"testing.tRunner",
+				"github.com/posthog/posthog-go.TestDefaultStackTraceExtractor_GetStackTrace.func1",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.DefaultStackTraceExtractor.GetStackTrace",
+				"runtime.Callers",
 			},
 		},
-		"skipping will remove entries from the head of the list, useful to omit internal function calls that add no value": {
+		"skipping removes the innermost frames, now at the tail, useful to omit internal function calls that add no value": {
 			functionCallDepth: 0,
 			skip:              3,
 			expectedNames: []string{
-				"github.com/posthog/posthog-go.TestDefaultStackTraceExtractor_GetStackTrace.func1",
-				"testing.tRunner",
 				"runtime.goexit",
+				"testing.tRunner",
+				"github.com/posthog/posthog-go.TestDefaultStackTraceExtractor_GetStackTrace.func1",
 			},
 		},
 		"calls with a very high skip level should return an empty stack trace": {
@@ -91,8 +93,9 @@ func TestDefaultStackTraceExtractor_GetStackTrace(t *testing.T) {
 			functionCallDepth: 5,
 			skip:              0,
 			expectedNames: []string{
-				"runtime.Callers",
-				"github.com/posthog/posthog-go.DefaultStackTraceExtractor.GetStackTrace",
+				"runtime.goexit",
+				"testing.tRunner",
+				"github.com/posthog/posthog-go.TestDefaultStackTraceExtractor_GetStackTrace.func1",
 				// +1 total for the 'actual' function call
 				"github.com/posthog/posthog-go.recursiveChain",
 				"github.com/posthog/posthog-go.recursiveChain",
@@ -100,79 +103,81 @@ func TestDefaultStackTraceExtractor_GetStackTrace(t *testing.T) {
 				"github.com/posthog/posthog-go.recursiveChain",
 				"github.com/posthog/posthog-go.recursiveChain",
 				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.TestDefaultStackTraceExtractor_GetStackTrace.func1",
-				"testing.tRunner",
-				"runtime.goexit",
+				"github.com/posthog/posthog-go.DefaultStackTraceExtractor.GetStackTrace",
+				"runtime.Callers",
 			},
 		},
-		"once we exceed the pre-configured limit of 64, we will start to drop traces at the tail end": {
+		// The 64-frame capture limit drops the outermost frames (the runtime
+		// stops yielding after 64 innermost entries), so after reversal the
+		// entry-point frames are gone and the slice starts mid-chain.
+		"once we exceed the pre-configured limit of 64, we will start to drop traces at the outermost end": {
 			functionCallDepth: 77,
 			skip:              0,
 			expectedNames: []string{
-				"runtime.Callers",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
+				"github.com/posthog/posthog-go.recursiveChain",
 				"github.com/posthog/posthog-go.DefaultStackTraceExtractor.GetStackTrace",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
-				"github.com/posthog/posthog-go.recursiveChain",
+				"runtime.Callers",
 			},
 		},
 	}
@@ -193,5 +198,27 @@ func TestDefaultStackTraceExtractor_GetStackTrace(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDefaultStackTraceExtractor_CanonicalWireOrder is an explicit regression
+// guard for the canonical wire order shared across PostHog SDKs: frames run
+// bottom-up, so the first frame is the outermost entry point and the last frame
+// is the innermost capture site. Reversing this order would silently break
+// server-side grouping and display.
+func TestDefaultStackTraceExtractor_CanonicalWireOrder(t *testing.T) {
+	extractor := DefaultStackTraceExtractor{InAppDecider: SimpleInAppDecider}
+
+	traces := extractor.GetStackTrace(0)
+	if traces == nil || len(traces.Frames) < 2 {
+		t.Fatalf("expected at least two frames, got %v", traces)
+	}
+
+	if got := traces.Frames[0].Function; got != "runtime.goexit" {
+		t.Errorf("first frame should be the outermost entry point: got=%q want=%q", got, "runtime.goexit")
+	}
+
+	if got := traces.Frames[len(traces.Frames)-1].Function; got != "runtime.Callers" {
+		t.Errorf("last frame should be the innermost capture site: got=%q want=%q", got, "runtime.Callers")
 	}
 }

--- a/request_context.go
+++ b/request_context.go
@@ -515,6 +515,13 @@ func parseDebugStackFrames(stack []byte) []StackFrame {
 		})
 	}
 
+	// debug.Stack prints innermost first; reverse to the canonical wire order
+	// shared across PostHog SDKs (matching GetStackTrace): outermost (entry
+	// point) first, panic site last.
+	for i, j := 0, len(frames)-1; i < j; i, j = i+1, j-1 {
+		frames[i], frames[j] = frames[j], frames[i]
+	}
+
 	return frames
 }
 

--- a/request_context_test.go
+++ b/request_context_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -347,6 +348,34 @@ func TestEnqueueWithContext_PersonlessCaptureDefaultPropertiesCannotEnablePerson
 	properties := requireProperties(t, event)
 	require.Equal(t, false, properties[propertyProcessPersonProfile])
 	require.Equal(t, "api", properties["service"])
+}
+
+func TestParseDebugStackFramesUsesCanonicalBottomUpOrder(t *testing.T) {
+	// Regression guard for the canonical wire order on the panic-recovery
+	// path: debug.Stack prints innermost first, so without the reversal the
+	// panic site would sit at frames[0] while GetStackTrace puts it last.
+	var stack []byte
+	func() {
+		defer func() {
+			recover()
+			stack = debug.Stack()
+		}()
+		panic("boom")
+	}()
+
+	frames := parseDebugStackFrames(stack)
+	if len(frames) < 2 {
+		t.Fatalf("expected multiple frames, got %d", len(frames))
+	}
+
+	first := frames[0].Function
+	last := frames[len(frames)-1].Function
+	if !strings.Contains(last, "TestParseDebugStackFramesUsesCanonicalBottomUpOrder") {
+		t.Fatalf("expected panic-adjacent frame last, got first=%q last=%q", first, last)
+	}
+	if strings.Contains(first, "TestParseDebugStackFramesUsesCanonicalBottomUpOrder.func") {
+		t.Fatalf("panic site must not be first: first=%q", first)
+	}
 }
 
 func TestRequestContextMiddleware_CapturesPanicsWithRequestContextAndRethrows(t *testing.T) {


### PR DESCRIPTION
## Problem

PostHog SDKs disagree on the order of stack frames inside `$exception_list[].stacktrace.frames`. posthog-go currently emits frames in Go's native `runtime.CallersFrames` order (innermost first, crash/capture site at index 0), while the canonical cross-SDK convention being standardized in [PostHog/sdk-specs#11](https://github.com/PostHog/sdk-specs/pull/11) is bottom-up: entry point first, crash site last. Mixed conventions make the same logical error group, fingerprint, and display differently per platform.

## Changes

- `DefaultStackTraceExtractor.GetStackTrace` reverses the collected frames after the `runtime.CallersFrames` loop, emitting canonical wire order (frames[0] = outermost/entry point, last = capture site). This matches the already-canonical `NativeStackTraceExtractor`.
- The single-element `$exception_list` behavior is unchanged.
- Changeset with a **minor** bump.

## Tests

- Reversed the ordered expectations in the four existing table cases and updated the skip/cap case names and comments (skip drops the tail now; the 64-frame cap drops the head).
- New regression test `TestDefaultStackTraceExtractor_CanonicalWireOrder`: first frame = entry point (`runtime.goexit`), last frame = capture site (`runtime.Callers`).
- `go build ./...`, `go vet ./...`, focused error-tracking suite: 31 passed.

## Coordination

This is a breaking wire-order change. Do not merge/release until the ingestion pipeline's normalization gate (cymbal) is live; it gates legacy payloads per `$lib`/`$lib_version`, so this must ship as a **minor** release. Part of the cross-SDK ordering standardization tracked in [PostHog/sdk-specs#11](https://github.com/PostHog/sdk-specs/pull/11).
