### PR TITLE
fix(capture): unify retry backoff ceiling at 30s

### DIFF
--- a/.changeset/capture-v1-retry-after-cap.md
+++ b/.changeset/capture-v1-retry-after-cap.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Unify the capture retry backoff ceiling at 30s. `DefaultBackoff`'s cap changes from 10s to 30s (default only — override via `Config.RetryAfter`), and the Capture V1 send now clamps a server `Retry-After` to the same 30s so a hostile or buggy header cannot park a batch goroutine. `Retry-After` still acts as a minimum; the configured backoff is never truncated. This aligns the default retry behavior with posthog-rs and posthog-python.

--- a/.changeset/capture-v1-retry-after-cap.md
+++ b/.changeset/capture-v1-retry-after-cap.md
@@ -1,5 +1,5 @@
 ---
-"posthog-go": minor
+"posthog-go": patch
 ---
 
 Unify the capture retry backoff ceiling at 30s. `DefaultBackoff`'s cap changes from 10s to 30s (default only — override via `Config.RetryAfter`), and the Capture V1 send now clamps a server `Retry-After` to the same 30s so a hostile or buggy header cannot park a batch goroutine. `Retry-After` still acts as a minimum; the configured backoff is never truncated. This aligns the default retry behavior with posthog-rs and posthog-python.

--- a/backoff.go
+++ b/backoff.go
@@ -20,14 +20,20 @@ func NewBackoff(base time.Duration, factor uint8, jitter float64, cap time.Durat
 	return &Backoff{base, factor, jitter, cap}
 }
 
+// defaultMaxBackoff is the single ceiling for capture retry waits: it caps the
+// default exponential backoff and clamps a server Retry-After to the same value.
+// Keeps the max retry wait bounded and unifies the default with posthog-rs /
+// posthog-python (all 30s).
+const defaultMaxBackoff = 30 * time.Second
+
 // DefaultBackoff creates a Backoff with the SDK's default retry policy:
 //
 //	base: 100 milliseconds
 //	factor: 2
 //	jitter: 0
-//	cap: 10 seconds
+//	cap: 30 seconds
 func DefaultBackoff() *Backoff {
-	return NewBackoff(time.Millisecond*100, 2, 0, time.Second*10)
+	return NewBackoff(time.Millisecond*100, 2, 0, defaultMaxBackoff)
 }
 
 // Duration returns the backoff interval for the given attempt.

--- a/capture_v1_send.go
+++ b/capture_v1_send.go
@@ -180,14 +180,29 @@ func (c *client) partitionV1Results(res *v1Result, data []json.RawMessage, msgs 
 	return nextData, nextMsgs, nextUuids
 }
 
-// backoffV1 waits before the next attempt, honoring Retry-After when it exceeds
-// the configured backoff. Returns false if shutdown was requested during the wait.
-func (c *client) backoffV1(attemptIndex int, res *v1Result) bool {
+// retryDelayV1 is the pure delay decision for the next attempt: the configured
+// backoff, raised to the server Retry-After when it is larger (Retry-After is a
+// minimum, not a replacement). The Retry-After is clamped to defaultMaxBackoff
+// so a hostile or buggy header can't park a batch goroutine; the configured
+// backoff itself (Config.RetryAfter) is never truncated.
+func (c *client) retryDelayV1(attemptIndex int, res *v1Result) time.Duration {
 	retryDelay := c.RetryAfter(attemptIndex)
-	if res != nil && res.hasRetryAfter && res.retryAfter > retryDelay {
-		retryDelay = res.retryAfter
+	if res != nil && res.hasRetryAfter {
+		clamped := res.retryAfter
+		if clamped > defaultMaxBackoff {
+			clamped = defaultMaxBackoff
+		}
+		if clamped > retryDelay {
+			retryDelay = clamped
+		}
 	}
-	retryTimer := time.NewTimer(retryDelay)
+	return retryDelay
+}
+
+// backoffV1 waits before the next attempt using retryDelayV1. Returns false if
+// shutdown was requested during the wait.
+func (c *client) backoffV1(attemptIndex int, res *v1Result) bool {
+	retryTimer := time.NewTimer(c.retryDelayV1(attemptIndex, res))
 	select {
 	case <-retryTimer.C:
 		return true

--- a/capture_v1_send_test.go
+++ b/capture_v1_send_test.go
@@ -756,6 +756,37 @@ func TestV1SendRetryAfterHonored(t *testing.T) {
 	}
 }
 
+func TestRetryDelayV1(t *testing.T) {
+	const base = 100 * time.Millisecond
+	res := func(d time.Duration, has bool) *v1Result {
+		return &v1Result{retryAfter: d, hasRetryAfter: has}
+	}
+	// Configured backoff is a constant `base`; Retry-After is a minimum, not a
+	// replacement, and is clamped to defaultMaxBackoff (the configured backoff
+	// itself is never truncated).
+	cases := []struct {
+		name string
+		res  *v1Result
+		want time.Duration
+	}{
+		{"no_response_uses_configured", nil, base},
+		{"no_retry_after_uses_configured", res(0, false), base},
+		{"larger_retry_after_wins", res(5*time.Second, true), 5 * time.Second},
+		{"smaller_retry_after_ignored", res(10*time.Millisecond, true), base},
+		{"retry_after_at_ceiling", res(defaultMaxBackoff, true), defaultMaxBackoff},
+		{"retry_after_above_ceiling_clamped", res(90*time.Second, true), defaultMaxBackoff},
+		{"absurd_retry_after_clamped", res(1000*time.Hour, true), defaultMaxBackoff},
+	}
+	c := &client{Config: Config{RetryAfter: func(int) time.Duration { return base }}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.retryDelayV1(0, tc.res); got != tc.want {
+				t.Errorf("retryDelayV1 = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestV1SendMultiEventExhaustion(t *testing.T) {
 	cb := &recordingCallback{}
 	srv := &v1TestServer{respond: func(_ int, uuids []string) (int, string, string) {


### PR DESCRIPTION
## :bulb: Motivation and Context

Cross-SDK capture retry parity. This unifies the retry backoff ceiling at a 30s default across posthog-go, posthog-rs, and posthog-python, and bounds a server `Retry-After` (previously unbounded in Go) so a hostile/buggy header can't stall a batch goroutine.

## :green_heart: How did you test it?

- `retryDelayV1` now waits the larger of the configured backoff and the `Retry-After`, with the header clamped to `defaultMaxBackoff` (30s); the configured backoff is never truncated.
- `DefaultBackoff` cap changed 10s -> 30s (default only; override via `Config.RetryAfter`), unifying Go's exp-backoff ceiling with the other SDKs.
- `go build`, `gofmt`, and `go test ./...` all green; `TestRetryDelayV1` updated for the clamp (absurd/above-ceiling -> 30s).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] Default behavior change (`DefaultBackoff` 10s -> 30s; `Retry-After` clamped) — changeset added (`minor`).

### If releasing new changes

- [x] Added a changeset

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Cursor (Claude Opus 4.8) as part of a cross-SDK capture retry unification (paired with posthog-rs #177 and the posthog-python capture-v1 stack). Prod telemetry showed the backend sends `Retry-After: 1s` and retryable responses are ~1 in 18M, so 30s (the existing default ceiling elsewhere) is the agreed unified value.
