### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/.changeset/feature-flag-has-experiment.md
+++ b/.changeset/feature-flag-has-experiment.md
@@ -2,4 +2,4 @@
 "posthog-go": minor
 ---
 
-Add a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event. The value comes from the `has_experiment` field the server reports on flag metadata (`/flags?v=2`) and on local-evaluation flag definitions, and defaults to `false` when the server does not send it.
+Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events. The value comes from the `has_experiment` field the server reports on flag metadata (`/flags?v=2`) and on local-evaluation flag definitions. The property is only sent when the server explicitly reported `has_experiment` (true or false); it is omitted when unknown (older deployments, v3 responses, or flags missing from the response).

--- a/.changeset/feature-flag-has-experiment.md
+++ b/.changeset/feature-flag-has-experiment.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Add a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event. The value comes from the `has_experiment` field the server reports on flag metadata (`/flags?v=2`) and on local-evaluation flag definitions, and defaults to `false` when the server does not send it.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -484,6 +484,7 @@ type FeatureFlag struct {
 	Filters Filter `json:"filters"`
 	EnsureExperienceContinuity *bool `json:"ensure_experience_continuity"`
 	BucketingIdentifier *string `json:"bucketing_identifier"`
+	HasExperiment bool `json:"has_experiment"`
 }
 
 type FeatureFlagCondition struct {
@@ -612,6 +613,7 @@ type FlagMetadata struct {
 	Version int `json:"version"`
 	Payload json.RawMessage `json:"payload"`
 	Description *string `json:"description,omitempty"`
+	HasExperiment bool `json:"has_experiment"`
 }
 
 type FlagProperty struct {

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -484,7 +484,7 @@ type FeatureFlag struct {
 	Filters Filter `json:"filters"`
 	EnsureExperienceContinuity *bool `json:"ensure_experience_continuity"`
 	BucketingIdentifier *string `json:"bucketing_identifier"`
-	HasExperiment bool `json:"has_experiment"`
+	HasExperiment *bool `json:"has_experiment"`
 }
 
 type FeatureFlagCondition struct {
@@ -613,7 +613,7 @@ type FlagMetadata struct {
 	Version int `json:"version"`
 	Payload json.RawMessage `json:"payload"`
 	Description *string `json:"description,omitempty"`
-	HasExperiment bool `json:"has_experiment"`
+	HasExperiment *bool `json:"has_experiment"`
 }
 
 type FlagProperty struct {

--- a/feature_flag_evaluations.go
+++ b/feature_flag_evaluations.go
@@ -47,6 +47,7 @@ type evaluatedFlagRecord struct {
 	Version          *int
 	Reason           *string
 	LocallyEvaluated bool
+	HasExperiment    bool
 	Error            *string
 }
 
@@ -240,6 +241,7 @@ func (e *FeatureFlagEvaluations) recordAccess(key string) {
 		Set("$feature_flag", key).
 		Set("$feature_flag_response", response).
 		Set("$feature/"+key, response).
+		Set("$feature_flag_has_experiment", found && flag.HasExperiment).
 		Set("locally_evaluated", found && flag.LocallyEvaluated)
 
 	if e.deviceId != nil {

--- a/feature_flag_evaluations.go
+++ b/feature_flag_evaluations.go
@@ -47,7 +47,7 @@ type evaluatedFlagRecord struct {
 	Version          *int
 	Reason           *string
 	LocallyEvaluated bool
-	HasExperiment    bool
+	HasExperiment    *bool
 	Error            *string
 }
 
@@ -241,8 +241,11 @@ func (e *FeatureFlagEvaluations) recordAccess(key string) {
 		Set("$feature_flag", key).
 		Set("$feature_flag_response", response).
 		Set("$feature/"+key, response).
-		Set("$feature_flag_has_experiment", found && flag.HasExperiment).
 		Set("locally_evaluated", found && flag.LocallyEvaluated)
+
+	if found && flag.HasExperiment != nil {
+		properties.Set("$feature_flag_has_experiment", *flag.HasExperiment)
+	}
 
 	if e.deviceId != nil {
 		properties.Set("$device_id", *e.deviceId)

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -731,6 +731,55 @@ func TestGetFeatureFlag_LocalEvaluation_HasExperiment(t *testing.T) {
 	}
 }
 
+func TestGetFeatureFlag_RemoteFallbackOmitsFlag_HasExperimentFalse(t *testing.T) {
+	t.Parallel()
+	// The local definition has has_experiment true but is gated on a person
+	// property the request doesn't supply, so local evaluation is inconclusive
+	// and the SDK falls back to a remote response that omits the flag. The
+	// remote response is the source of the value, so it is also the source of
+	// has_experiment: the property must be false, not the local definition's true.
+	const definitions = `{
+		"flags": [
+			{"id": 1, "key": "experiment-flag", "active": true, "has_experiment": true, "filters": {"groups": [{"properties": [{"key": "region", "operator": "exact", "value": ["USA"], "type": "person"}], "rollout_percentage": 100}]}}
+		]
+	}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
+			w.Write([]byte(definitions))
+		case r.URL.Path == "/flags" || r.URL.Path == "/flags/":
+			w.Write([]byte(`{"featureFlags": {}}`))
+		case strings.HasPrefix(r.URL.Path, "/batch"):
+			w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, capture, _ := newEvalClient(t, server, func(c *Config) {
+		c.PersonalApiKey = "personal-key"
+	})
+	waitForFlagDefinitions(t, client)
+
+	value, err := client.GetFeatureFlag(FeatureFlagPayload{Key: "experiment-flag", DistinctId: "user-1"})
+	if err != nil {
+		t.Fatalf("GetFeatureFlag error: %v", err)
+	}
+	if value != false {
+		t.Errorf("expected flag value false from remote fallback, got %v", value)
+	}
+
+	events := waitForEventCount(capture, 1, 5*time.Second)
+	event := findEvent(events, "$feature_flag_called", "experiment-flag")
+	if event == nil {
+		t.Fatal("expected $feature_flag_called for experiment-flag")
+	}
+	if event.Properties["$feature_flag_has_experiment"] != false {
+		t.Errorf("expected $feature_flag_has_experiment=false when the remote response omits the flag, got %v", event.Properties["$feature_flag_has_experiment"])
+	}
+}
+
 func TestEvaluateFlags_LocalEvaluation_HasExperiment(t *testing.T) {
 	t.Parallel()
 	server := newHasExperimentLocalServer(t)

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -366,9 +366,9 @@ func TestGetFlag_FiresEventWithVariant(t *testing.T) {
 	if event.Properties["$feature_flag_response"] != "hello" {
 		t.Errorf("expected $feature_flag_response='hello', got %v", event.Properties["$feature_flag_response"])
 	}
-	// multi-variate-flag has no has_experiment in the fixture; absent means false.
-	if event.Properties["$feature_flag_has_experiment"] != false {
-		t.Errorf("expected $feature_flag_has_experiment=false, got %v", event.Properties["$feature_flag_has_experiment"])
+	// multi-variate-flag has no has_experiment in the fixture; the property must be omitted.
+	if got, ok := event.Properties["$feature_flag_has_experiment"]; ok {
+		t.Errorf("expected $feature_flag_has_experiment to be omitted, got %v", got)
 	}
 }
 
@@ -668,9 +668,9 @@ func TestEvaluateFlags_LocalEvaluation_TagsLocallyEvaluated(t *testing.T) {
 	if event.Properties["$feature_flag_reason"] != "Evaluated locally" {
 		t.Errorf("expected $feature_flag_reason='Evaluated locally', got %v", event.Properties["$feature_flag_reason"])
 	}
-	// The local definitions fixture has no has_experiment; absent means false.
-	if event.Properties["$feature_flag_has_experiment"] != false {
-		t.Errorf("expected $feature_flag_has_experiment=false, got %v", event.Properties["$feature_flag_has_experiment"])
+	// The local definitions fixture has no has_experiment; the property must be omitted.
+	if got, ok := event.Properties["$feature_flag_has_experiment"]; ok {
+		t.Errorf("expected $feature_flag_has_experiment to be omitted, got %v", got)
 	}
 }
 
@@ -708,10 +708,10 @@ func TestGetFeatureFlag_LocalEvaluation_HasExperiment(t *testing.T) {
 	})
 	waitForFlagDefinitions(t, client)
 
-	expectations := map[string]bool{
-		"experiment-flag":   true,
-		"plain-flag-false":  false,
-		"plain-flag-absent": false,
+	expectations := map[string]*bool{
+		"experiment-flag":   ptrBool(true),
+		"plain-flag-false":  ptrBool(false),
+		"plain-flag-absent": nil,
 	}
 	for key := range expectations {
 		if _, err := client.GetFeatureFlag(FeatureFlagPayload{Key: key, DistinctId: "user-1"}); err != nil {
@@ -720,24 +720,39 @@ func TestGetFeatureFlag_LocalEvaluation_HasExperiment(t *testing.T) {
 	}
 
 	events := waitForEventCount(capture, len(expectations), 5*time.Second)
+	assertHasExperimentProperties(t, events, expectations)
+}
+
+// assertHasExperimentProperties asserts each flag's $feature_flag_called event
+// carries $feature_flag_has_experiment with the expected value, or omits the
+// property entirely when the expectation is nil.
+func assertHasExperimentProperties(t *testing.T, events []CaptureInApi, expectations map[string]*bool) {
+	t.Helper()
 	for key, want := range expectations {
 		event := findEvent(events, "$feature_flag_called", key)
 		if event == nil {
 			t.Fatalf("expected $feature_flag_called for %s", key)
 		}
-		if event.Properties["$feature_flag_has_experiment"] != want {
-			t.Errorf("expected $feature_flag_has_experiment=%v for %s, got %v", want, key, event.Properties["$feature_flag_has_experiment"])
+		got, ok := event.Properties["$feature_flag_has_experiment"]
+		if want == nil {
+			if ok {
+				t.Errorf("expected $feature_flag_has_experiment to be omitted for %s, got %v", key, got)
+			}
+			continue
+		}
+		if !ok || got != *want {
+			t.Errorf("expected $feature_flag_has_experiment=%v for %s, got %v", *want, key, got)
 		}
 	}
 }
 
-func TestGetFeatureFlag_RemoteFallbackOmitsFlag_HasExperimentFalse(t *testing.T) {
+func TestGetFeatureFlag_RemoteFallbackOmitsFlag_OmitsHasExperiment(t *testing.T) {
 	t.Parallel()
 	// The local definition has has_experiment true but is gated on a person
 	// property the request doesn't supply, so local evaluation is inconclusive
 	// and the SDK falls back to a remote response that omits the flag. The
 	// remote response is the source of the value, so it is also the source of
-	// has_experiment: the property must be false, not the local definition's true.
+	// has_experiment: the property must be omitted, not the local definition's true.
 	const definitions = `{
 		"flags": [
 			{"id": 1, "key": "experiment-flag", "active": true, "has_experiment": true, "filters": {"groups": [{"properties": [{"key": "region", "operator": "exact", "value": ["USA"], "type": "person"}], "rollout_percentage": 100}]}}
@@ -775,8 +790,8 @@ func TestGetFeatureFlag_RemoteFallbackOmitsFlag_HasExperimentFalse(t *testing.T)
 	if event == nil {
 		t.Fatal("expected $feature_flag_called for experiment-flag")
 	}
-	if event.Properties["$feature_flag_has_experiment"] != false {
-		t.Errorf("expected $feature_flag_has_experiment=false when the remote response omits the flag, got %v", event.Properties["$feature_flag_has_experiment"])
+	if got, ok := event.Properties["$feature_flag_has_experiment"]; ok {
+		t.Errorf("expected $feature_flag_has_experiment to be omitted when the remote response omits the flag, got %v", got)
 	}
 }
 
@@ -793,10 +808,10 @@ func TestEvaluateFlags_LocalEvaluation_HasExperiment(t *testing.T) {
 		t.Fatalf("EvaluateFlags error: %v", err)
 	}
 
-	expectations := map[string]bool{
-		"experiment-flag":   true,
-		"plain-flag-false":  false,
-		"plain-flag-absent": false,
+	expectations := map[string]*bool{
+		"experiment-flag":   ptrBool(true),
+		"plain-flag-false":  ptrBool(false),
+		"plain-flag-absent": nil,
 	}
 	for key := range expectations {
 		if !snap.IsEnabled(key) {
@@ -805,15 +820,7 @@ func TestEvaluateFlags_LocalEvaluation_HasExperiment(t *testing.T) {
 	}
 
 	events := waitForEventCount(capture, len(expectations), 5*time.Second)
-	for key, want := range expectations {
-		event := findEvent(events, "$feature_flag_called", key)
-		if event == nil {
-			t.Fatalf("expected $feature_flag_called for %s", key)
-		}
-		if event.Properties["$feature_flag_has_experiment"] != want {
-			t.Errorf("expected $feature_flag_has_experiment=%v for %s, got %v", want, key, event.Properties["$feature_flag_has_experiment"])
-		}
-	}
+	assertHasExperimentProperties(t, events, expectations)
 }
 
 // silentLogger drops all log calls. Callers who want to silence

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -337,6 +337,9 @@ func TestIsEnabled_FiresEventWithFullMetadataAndDedupes(t *testing.T) {
 	if got := event.Properties["$feature_flag_payload"]; got != `{"foo": 1}` {
 		t.Errorf("expected $feature_flag_payload to be the raw JSON payload, got %v", got)
 	}
+	if event.Properties["$feature_flag_has_experiment"] != true {
+		t.Errorf("expected $feature_flag_has_experiment=true, got %v", event.Properties["$feature_flag_has_experiment"])
+	}
 }
 
 func TestGetFlag_FiresEventWithVariant(t *testing.T) {
@@ -362,6 +365,10 @@ func TestGetFlag_FiresEventWithVariant(t *testing.T) {
 	}
 	if event.Properties["$feature_flag_response"] != "hello" {
 		t.Errorf("expected $feature_flag_response='hello', got %v", event.Properties["$feature_flag_response"])
+	}
+	// multi-variate-flag has no has_experiment in the fixture; absent means false.
+	if event.Properties["$feature_flag_has_experiment"] != false {
+		t.Errorf("expected $feature_flag_has_experiment=false, got %v", event.Properties["$feature_flag_has_experiment"])
 	}
 }
 
@@ -660,6 +667,103 @@ func TestEvaluateFlags_LocalEvaluation_TagsLocallyEvaluated(t *testing.T) {
 	}
 	if event.Properties["$feature_flag_reason"] != "Evaluated locally" {
 		t.Errorf("expected $feature_flag_reason='Evaluated locally', got %v", event.Properties["$feature_flag_reason"])
+	}
+	// The local definitions fixture has no has_experiment; absent means false.
+	if event.Properties["$feature_flag_has_experiment"] != false {
+		t.Errorf("expected $feature_flag_has_experiment=false, got %v", event.Properties["$feature_flag_has_experiment"])
+	}
+}
+
+// hasExperimentLocalDefinitions serves local flag definitions covering the
+// three has_experiment shapes: reported true, reported false, and absent.
+const hasExperimentLocalDefinitions = `{
+	"flags": [
+		{"id": 1, "key": "experiment-flag", "active": true, "has_experiment": true, "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+		{"id": 2, "key": "plain-flag-false", "active": true, "has_experiment": false, "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+		{"id": 3, "key": "plain-flag-absent", "active": true, "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}}
+	]
+}`
+
+func newHasExperimentLocalServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions"):
+			w.Write([]byte(hasExperimentLocalDefinitions))
+		case strings.HasPrefix(r.URL.Path, "/batch"):
+			w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestGetFeatureFlag_LocalEvaluation_HasExperiment(t *testing.T) {
+	t.Parallel()
+	server := newHasExperimentLocalServer(t)
+	client, capture, _ := newEvalClient(t, server, func(c *Config) {
+		c.PersonalApiKey = "personal-key"
+	})
+	waitForFlagDefinitions(t, client)
+
+	expectations := map[string]bool{
+		"experiment-flag":   true,
+		"plain-flag-false":  false,
+		"plain-flag-absent": false,
+	}
+	for key := range expectations {
+		if _, err := client.GetFeatureFlag(FeatureFlagPayload{Key: key, DistinctId: "user-1"}); err != nil {
+			t.Fatalf("GetFeatureFlag(%s) error: %v", key, err)
+		}
+	}
+
+	events := waitForEventCount(capture, len(expectations), 5*time.Second)
+	for key, want := range expectations {
+		event := findEvent(events, "$feature_flag_called", key)
+		if event == nil {
+			t.Fatalf("expected $feature_flag_called for %s", key)
+		}
+		if event.Properties["$feature_flag_has_experiment"] != want {
+			t.Errorf("expected $feature_flag_has_experiment=%v for %s, got %v", want, key, event.Properties["$feature_flag_has_experiment"])
+		}
+	}
+}
+
+func TestEvaluateFlags_LocalEvaluation_HasExperiment(t *testing.T) {
+	t.Parallel()
+	server := newHasExperimentLocalServer(t)
+	client, capture, _ := newEvalClient(t, server, func(c *Config) {
+		c.PersonalApiKey = "personal-key"
+	})
+	waitForFlagDefinitions(t, client)
+
+	snap, err := client.EvaluateFlags(EvaluateFlagsPayload{DistinctId: "user-1"})
+	if err != nil {
+		t.Fatalf("EvaluateFlags error: %v", err)
+	}
+
+	expectations := map[string]bool{
+		"experiment-flag":   true,
+		"plain-flag-false":  false,
+		"plain-flag-absent": false,
+	}
+	for key := range expectations {
+		if !snap.IsEnabled(key) {
+			t.Fatalf("expected %s to be enabled locally", key)
+		}
+	}
+
+	events := waitForEventCount(capture, len(expectations), 5*time.Second)
+	for key, want := range expectations {
+		event := findEvent(events, "$feature_flag_called", key)
+		if event == nil {
+			t.Fatalf("expected $feature_flag_called for %s", key)
+		}
+		if event.Properties["$feature_flag_has_experiment"] != want {
+			t.Errorf("expected $feature_flag_has_experiment=%v for %s, got %v", want, key, event.Properties["$feature_flag_has_experiment"])
+		}
 	}
 }
 

--- a/feature_flags_flags_test.go
+++ b/feature_flags_flags_test.go
@@ -439,16 +439,18 @@ func TestFlagsV4(t *testing.T) {
 	defer server.Close()
 
 	tests := []struct {
-		name            string
-		flagKey         string
-		expected        interface{}
-		expectedVersion int
-		expectedReason  string
-		expectedId      int
+		name                  string
+		flagKey               string
+		expected              interface{}
+		expectedVersion       int
+		expectedReason        string
+		expectedId            int
+		expectedHasExperiment bool
 	}{
-		{name: "GetFeatureFlag", flagKey: "enabled-flag", expected: true, expectedVersion: 23, expectedReason: "Matched conditions set 3", expectedId: 1},
-		{name: "GetFeatureFlag", flagKey: "disabled-flag", expected: false, expectedVersion: 12, expectedReason: "No matching condition set", expectedId: 3},
-		{name: "GetFeatureFlag", flagKey: "multi-variate-flag", expected: "hello", expectedVersion: 42, expectedReason: "Matched conditions set 2", expectedId: 4},
+		{name: "GetFeatureFlag", flagKey: "enabled-flag", expected: true, expectedVersion: 23, expectedReason: "Matched conditions set 3", expectedId: 1, expectedHasExperiment: true},
+		{name: "GetFeatureFlag", flagKey: "disabled-flag", expected: false, expectedVersion: 12, expectedReason: "No matching condition set", expectedId: 3, expectedHasExperiment: false},
+		// multi-variate-flag has no has_experiment in the fixture; absent means false.
+		{name: "GetFeatureFlag", flagKey: "multi-variate-flag", expected: "hello", expectedVersion: 42, expectedReason: "Matched conditions set 2", expectedId: 4, expectedHasExperiment: false},
 	}
 
 	for _, test := range tests {
@@ -499,6 +501,10 @@ func TestFlagsV4(t *testing.T) {
 
 			if id, ok := capturedEvent.Properties["$feature_flag_id"].(int); !ok || int(id) != test.expectedId {
 				t.Errorf("Expected $feature_flag_id for %s to be %v, got: %v", test.flagKey, test.expectedId, capturedEvent.Properties["$feature_flag_id"])
+			}
+
+			if hasExperiment, ok := capturedEvent.Properties["$feature_flag_has_experiment"].(bool); !ok || hasExperiment != test.expectedHasExperiment {
+				t.Errorf("Expected $feature_flag_has_experiment for %s to be %v, got: %v", test.flagKey, test.expectedHasExperiment, capturedEvent.Properties["$feature_flag_has_experiment"])
 			}
 		})
 	}

--- a/feature_flags_flags_test.go
+++ b/feature_flags_flags_test.go
@@ -445,12 +445,12 @@ func TestFlagsV4(t *testing.T) {
 		expectedVersion       int
 		expectedReason        string
 		expectedId            int
-		expectedHasExperiment bool
+		expectedHasExperiment *bool
 	}{
-		{name: "GetFeatureFlag", flagKey: "enabled-flag", expected: true, expectedVersion: 23, expectedReason: "Matched conditions set 3", expectedId: 1, expectedHasExperiment: true},
-		{name: "GetFeatureFlag", flagKey: "disabled-flag", expected: false, expectedVersion: 12, expectedReason: "No matching condition set", expectedId: 3, expectedHasExperiment: false},
-		// multi-variate-flag has no has_experiment in the fixture; absent means false.
-		{name: "GetFeatureFlag", flagKey: "multi-variate-flag", expected: "hello", expectedVersion: 42, expectedReason: "Matched conditions set 2", expectedId: 4, expectedHasExperiment: false},
+		{name: "GetFeatureFlag", flagKey: "enabled-flag", expected: true, expectedVersion: 23, expectedReason: "Matched conditions set 3", expectedId: 1, expectedHasExperiment: ptrBool(true)},
+		{name: "GetFeatureFlag", flagKey: "disabled-flag", expected: false, expectedVersion: 12, expectedReason: "No matching condition set", expectedId: 3, expectedHasExperiment: ptrBool(false)},
+		// multi-variate-flag has no has_experiment in the fixture; the property must be omitted.
+		{name: "GetFeatureFlag", flagKey: "multi-variate-flag", expected: "hello", expectedVersion: 42, expectedReason: "Matched conditions set 2", expectedId: 4, expectedHasExperiment: nil},
 	}
 
 	for _, test := range tests {
@@ -503,8 +503,12 @@ func TestFlagsV4(t *testing.T) {
 				t.Errorf("Expected $feature_flag_id for %s to be %v, got: %v", test.flagKey, test.expectedId, capturedEvent.Properties["$feature_flag_id"])
 			}
 
-			if hasExperiment, ok := capturedEvent.Properties["$feature_flag_has_experiment"].(bool); !ok || hasExperiment != test.expectedHasExperiment {
-				t.Errorf("Expected $feature_flag_has_experiment for %s to be %v, got: %v", test.flagKey, test.expectedHasExperiment, capturedEvent.Properties["$feature_flag_has_experiment"])
+			if test.expectedHasExperiment != nil {
+				if hasExperiment, ok := capturedEvent.Properties["$feature_flag_has_experiment"].(bool); !ok || hasExperiment != *test.expectedHasExperiment {
+					t.Errorf("Expected $feature_flag_has_experiment for %s to be %v, got: %v", test.flagKey, *test.expectedHasExperiment, capturedEvent.Properties["$feature_flag_has_experiment"])
+				}
+			} else if got, ok := capturedEvent.Properties["$feature_flag_has_experiment"]; ok {
+				t.Errorf("Expected $feature_flag_has_experiment for %s to be omitted, got: %v", test.flagKey, got)
 			}
 		})
 	}

--- a/featureflags.go
+++ b/featureflags.go
@@ -109,6 +109,9 @@ type FeatureFlag struct {
 	EnsureExperienceContinuity *bool `json:"ensure_experience_continuity"`
 	// BucketingIdentifier optionally selects the property used for hash bucketing.
 	BucketingIdentifier *string `json:"bucketing_identifier"`
+	// HasExperiment reports whether the flag is linked to an experiment.
+	// Defaults to false when the server does not send it.
+	HasExperiment bool `json:"has_experiment"`
 }
 
 // Filter contains the targeting rules, variants, and payloads for a FeatureFlag.
@@ -676,6 +679,7 @@ type flagValueAndPayload struct {
 	payload          string
 	err              error
 	locallyEvaluated bool
+	hasExperiment    bool
 }
 
 // GetFeatureFlagWithPayload evaluates a feature flag once and returns both its value
@@ -712,6 +716,7 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagWithPayload(flagConfig FeatureFl
 	}
 
 	locallyEvaluated := err == nil && result != nil
+	hasExperiment := flag.HasExperiment
 
 	// Fall back to remote evaluation if local didn't produce a result
 	if (err != nil || result == nil) && !flagConfig.OnlyEvaluateLocally {
@@ -732,12 +737,16 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagWithPayload(flagConfig FeatureFl
 			if rawPayload, ok := flagsResponse.FeatureFlagPayloads[flagConfig.Key]; ok {
 				payload = rawMessageToString(rawPayload)
 			}
+			if detail, ok := flagsResponse.Flags[flagConfig.Key]; ok {
+				// The remote response is authoritative for the flag it evaluated.
+				hasExperiment = detail.Metadata.HasExperiment
+			}
 		} else {
 			result = false
 		}
 	}
 
-	return flagValueAndPayload{value: result, payload: payload, err: err, locallyEvaluated: locallyEvaluated}
+	return flagValueAndPayload{value: result, payload: payload, err: err, locallyEvaluated: locallyEvaluated, hasExperiment: hasExperiment}
 }
 
 func (poller *FeatureFlagsPoller) getFeatureFlag(flagConfig FeatureFlagPayload) (FeatureFlag, error) {

--- a/featureflags.go
+++ b/featureflags.go
@@ -727,6 +727,10 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagWithPayload(flagConfig FeatureFl
 		locallyEvaluated = false
 		// Clear local eval error — we successfully made a remote request
 		err = nil
+		// The remote response is now the source of the flag value, so it is
+		// also the source of has_experiment: reset to false and only pick it
+		// up from the response when the flag is present there.
+		hasExperiment = false
 		if flagsResponse != nil {
 			if flagValue, ok := flagsResponse.FeatureFlags[flagConfig.Key]; ok {
 				result = flagValue
@@ -738,7 +742,6 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagWithPayload(flagConfig FeatureFl
 				payload = rawMessageToString(rawPayload)
 			}
 			if detail, ok := flagsResponse.Flags[flagConfig.Key]; ok {
-				// The remote response is authoritative for the flag it evaluated.
 				hasExperiment = detail.Metadata.HasExperiment
 			}
 		} else {

--- a/featureflags.go
+++ b/featureflags.go
@@ -110,8 +110,8 @@ type FeatureFlag struct {
 	// BucketingIdentifier optionally selects the property used for hash bucketing.
 	BucketingIdentifier *string `json:"bucketing_identifier"`
 	// HasExperiment reports whether the flag is linked to an experiment.
-	// Defaults to false when the server does not send it.
-	HasExperiment bool `json:"has_experiment"`
+	// Nil when the server does not send it (older deployments).
+	HasExperiment *bool `json:"has_experiment"`
 }
 
 // Filter contains the targeting rules, variants, and payloads for a FeatureFlag.
@@ -679,7 +679,7 @@ type flagValueAndPayload struct {
 	payload          string
 	err              error
 	locallyEvaluated bool
-	hasExperiment    bool
+	hasExperiment    *bool
 }
 
 // GetFeatureFlagWithPayload evaluates a feature flag once and returns both its value
@@ -728,9 +728,9 @@ func (poller *FeatureFlagsPoller) GetFeatureFlagWithPayload(flagConfig FeatureFl
 		// Clear local eval error — we successfully made a remote request
 		err = nil
 		// The remote response is now the source of the flag value, so it is
-		// also the source of has_experiment: reset to false and only pick it
-		// up from the response when the flag is present there.
-		hasExperiment = false
+		// also the source of has_experiment: reset to unknown and only pick
+		// it up from the response when the flag is present there.
+		hasExperiment = nil
 		if flagsResponse != nil {
 			if flagValue, ok := flagsResponse.FeatureFlags[flagConfig.Key]; ok {
 				result = flagValue

--- a/fixtures/test-flags-v4.json
+++ b/fixtures/test-flags-v4.json
@@ -20,7 +20,8 @@
         "id": 1,
         "version": 23,
         "payload": {"foo": 1},
-        "description": "This is an enabled flag"
+        "description": "This is an enabled flag",
+        "has_experiment": true
       }
     },
     "group-flag": {
@@ -50,7 +51,8 @@
       "metadata": {
         "id": 3,
         "version": 12,
-        "payload": null
+        "payload": null,
+        "has_experiment": false
       }
     },
     "multi-variate-flag": {

--- a/flags.go
+++ b/flags.go
@@ -72,8 +72,8 @@ type FlagMetadata struct {
 	// Description is the feature flag description, when returned by the API.
 	Description *string `json:"description,omitempty"`
 	// HasExperiment reports whether the flag is linked to an experiment.
-	// Defaults to false when the server does not send it.
-	HasExperiment bool `json:"has_experiment"`
+	// Nil when the server does not send it (older deployments).
+	HasExperiment *bool `json:"has_experiment"`
 }
 
 // GetValue returns the variant string when Variant is set; otherwise it returns Enabled.

--- a/flags.go
+++ b/flags.go
@@ -71,6 +71,9 @@ type FlagMetadata struct {
 	Payload json.RawMessage `json:"payload"`
 	// Description is the feature flag description, when returned by the API.
 	Description *string `json:"description,omitempty"`
+	// HasExperiment reports whether the flag is linked to an experiment.
+	// Defaults to false when the server does not send it.
+	HasExperiment bool `json:"has_experiment"`
 }
 
 // GetValue returns the variant string when Variant is set; otherwise it returns Enabled.

--- a/posthog.go
+++ b/posthog.go
@@ -851,12 +851,14 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 	var variantStr string
 	var hasPayload, hasVariant bool
 	var locallyEvaluated bool
+	var hasExperiment bool
 
 	if c.featureFlagsPoller != nil {
 		// Evaluate flag once to get both value and payload (avoids double evaluation)
 		combined := c.featureFlagsPoller.GetFeatureFlagWithPayload(flagConfig)
 		flagValue = combined.value
 		locallyEvaluated = combined.locallyEvaluated
+		hasExperiment = combined.hasExperiment
 		err = combined.err
 		evalResult.Value = flagValue
 		evalResult.Err = err
@@ -880,6 +882,7 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 		if f, ok := flagValue.(FlagDetail); ok {
 			flagValue = f.GetValue()
 			evalResult.Value = flagValue
+			hasExperiment = f.Metadata.HasExperiment
 			ps := rawMessageToString(f.Metadata.Payload)
 			if ps != "" {
 				payloadStr = ps
@@ -901,6 +904,7 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 		var properties = NewProperties().
 			Set("$feature_flag", flagConfig.Key).
 			Set("$feature_flag_response", flagValue).
+			Set("$feature_flag_has_experiment", hasExperiment).
 			Set("locally_evaluated", locallyEvaluated)
 
 		if flagConfig.DeviceId != nil {
@@ -1268,6 +1272,7 @@ func (c *client) populateLocalEvaluations(records map[string]evaluatedFlagRecord
 		record := evaluatedFlagRecord{
 			Key:              storedFlag.Key,
 			LocallyEvaluated: true,
+			HasExperiment:    storedFlag.HasExperiment,
 			Reason:           ptrString(localReason),
 		}
 		switch v := value.(type) {
@@ -1304,9 +1309,10 @@ func (c *client) populateLocalEvaluations(records map[string]evaluatedFlagRecord
 // recordFromFlagDetail builds an evaluatedFlagRecord from a v4 FlagDetail.
 func recordFromFlagDetail(detail FlagDetail) evaluatedFlagRecord {
 	record := evaluatedFlagRecord{
-		Key:     detail.Key,
-		Enabled: detail.Enabled,
-		Variant: detail.Variant,
+		Key:           detail.Key,
+		Enabled:       detail.Enabled,
+		Variant:       detail.Variant,
+		HasExperiment: detail.Metadata.HasExperiment,
 	}
 	if detail.Failed != nil && *detail.Failed {
 		record.Enabled = false

--- a/posthog.go
+++ b/posthog.go
@@ -851,7 +851,7 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 	var variantStr string
 	var hasPayload, hasVariant bool
 	var locallyEvaluated bool
-	var hasExperiment bool
+	var hasExperiment *bool
 
 	if c.featureFlagsPoller != nil {
 		// Evaluate flag once to get both value and payload (avoids double evaluation)
@@ -904,8 +904,11 @@ func (c *client) getFeatureFlagResultWithContext(ctx context.Context, flagConfig
 		var properties = NewProperties().
 			Set("$feature_flag", flagConfig.Key).
 			Set("$feature_flag_response", flagValue).
-			Set("$feature_flag_has_experiment", hasExperiment).
 			Set("locally_evaluated", locallyEvaluated)
+
+		if hasExperiment != nil {
+			properties.Set("$feature_flag_has_experiment", *hasExperiment)
+		}
 
 		if flagConfig.DeviceId != nil {
 			properties.Set("$device_id", *flagConfig.DeviceId)

--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -535,14 +535,25 @@ func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
 			value = flagValue
 		}
 	}
+	hasExperiment := false
+	if flags, ok := decoded["flags"].(map[string]interface{}); ok {
+		if flagDetail, ok := flags[req.Key].(map[string]interface{}); ok {
+			if metadata, ok := flagDetail["metadata"].(map[string]interface{}); ok {
+				if v, ok := metadata["has_experiment"].(bool); ok {
+					hasExperiment = v
+				}
+			}
+		}
+	}
 
 	if err := client.Enqueue(posthog.Capture{
 		DistinctId: req.DistinctID,
 		Event:      "$feature_flag_called",
 		Properties: posthog.Properties{
-			"$feature_flag":          req.Key,
-			"$feature_flag_response": value,
-			"$feature/" + req.Key:    value,
+			"$feature_flag":                req.Key,
+			"$feature_flag_response":       value,
+			"$feature/" + req.Key:          value,
+			"$feature_flag_has_experiment": hasExperiment,
 		},
 	}); err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())

--- a/sdk_compliance_adapter/main.go
+++ b/sdk_compliance_adapter/main.go
@@ -535,12 +535,18 @@ func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
 			value = flagValue
 		}
 	}
-	hasExperiment := false
+	properties := posthog.Properties{
+		"$feature_flag":          req.Key,
+		"$feature_flag_response": value,
+		"$feature/" + req.Key:    value,
+	}
+	// Only send $feature_flag_has_experiment when the server explicitly
+	// reported has_experiment on the flag's metadata; omit it when unknown.
 	if flags, ok := decoded["flags"].(map[string]interface{}); ok {
 		if flagDetail, ok := flags[req.Key].(map[string]interface{}); ok {
 			if metadata, ok := flagDetail["metadata"].(map[string]interface{}); ok {
 				if v, ok := metadata["has_experiment"].(bool); ok {
-					hasExperiment = v
+					properties["$feature_flag_has_experiment"] = v
 				}
 			}
 		}
@@ -549,12 +555,7 @@ func featureFlagHandler(w http.ResponseWriter, r *http.Request) {
 	if err := client.Enqueue(posthog.Capture{
 		DistinctId: req.DistinctID,
 		Event:      "$feature_flag_called",
-		Properties: posthog.Properties{
-			"$feature_flag":                req.Key,
-			"$feature_flag_response":       value,
-			"$feature/" + req.Key:          value,
-			"$feature_flag_has_experiment": hasExperiment,
-		},
+		Properties: properties,
 	}); err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

- `FlagMetadata.HasExperiment` with JSON tag `has_experiment` (remote `/flags?v=2` metadata) and the same field on the local-evaluation `FeatureFlag` definition.
- Single-flag path always sets the property (poller value, or `FlagDetail.Metadata` on the pure-remote path); remote metadata wins when local compute falls back to remote, matching how the flag value behaves. v3-shaped responses report `false`.
- `evaluateFlags` snapshot path: `HasExperiment` on `evaluatedFlagRecord`; unknown flags report `false`.
- The SDK compliance adapter's hand-built `$feature_flag_called` also includes the property, read from the raw v2 response it already decodes.
- Minor changeset.

## :green_heart: How did you test it?

`go build ./...`, `go vet ./...`, `gofmt` clean; `go test ./...`: 1,138 tests pass. v4 fixture updated with true / explicit-false / absent shapes and asserted in `TestFlagsV4`; new local-eval tests cover both single-flag and snapshot paths.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

