### PR TITLE
feat(error-tracking): grouped inline frames + debug images for server-side symbolication

### DIFF
--- a/.changeset/grouped-inline-frames.md
+++ b/.changeset/grouped-inline-frames.md
@@ -3,3 +3,5 @@
 ---
 
 Error tracking stack traces now support server-side symbolication. When the running executable's identity can be determined (GNU build id on Linux, LC_UUID on macOS), the default extractor emits frames with raw instruction addresses and client-expanded inline groups, and exceptions carry a `$debug_images` property, so PostHog can re-symbolicate against debug symbols uploaded with `posthog-cli symbol-sets upload` — including exact inline expansion and source context. Without uploaded symbols the runtime-resolved frames are kept as-is, and when the executable can't be identified the frames keep their previous plain shape.
+
+Requires a PostHog backend with grouped inline frame support (PostHog Cloud, or self-hosted ≥ July 2026). Older backends resolve each group member independently, which duplicates inline expansions when debug symbols are uploaded. To keep the previous plain frames, use a custom `StackTraceExtractor`.

--- a/.changeset/grouped-inline-frames.md
+++ b/.changeset/grouped-inline-frames.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Error tracking stack traces now support server-side symbolication. When the running executable's identity can be determined (GNU build id on Linux, LC_UUID on macOS), the default extractor emits frames with raw instruction addresses and client-expanded inline groups, and exceptions carry a `$debug_images` property, so PostHog can re-symbolicate against debug symbols uploaded with `posthog-cli symbol-sets upload` — including exact inline expansion and source context. Without uploaded symbols the runtime-resolved frames are kept as-is, and when the executable can't be identified the frames keep their previous plain shape.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -366,6 +366,21 @@ type ConfigError struct {
 
 func (e ConfigError) Error() string
 
+type DebugImage struct {
+	Type string `json:"type"`
+	DebugID string `json:"debug_id"`
+	CodeID string `json:"code_id,omitempty"`
+	ImageAddr string `json:"image_addr"`
+	ImageSize uint64 `json:"image_size,omitempty"`
+	ImageVmaddr string `json:"image_vmaddr,omitempty"`
+	CodeFile string `json:"code_file,omitempty"`
+	Arch string `json:"arch"`
+}
+
+type DebugImageProvider interface {
+	GetDebugImages() []DebugImage
+}
+
 type DecideRequestData struct {
 	ApiKey string `json:"api_key"`
 	DistinctId string `json:"distinct_id"`
@@ -383,7 +398,10 @@ type DefaultStackTraceExtractor struct {
 	InAppDecider InAppDecider
 }
 
+func (d DefaultStackTraceExtractor) GetDebugImages() []DebugImage
+
 func (d DefaultStackTraceExtractor) GetStackTrace(skip int) *ExceptionStacktrace
+
 
 type DescriptionExtractor interface {
 	ExtractDescription(r slog.Record) string
@@ -418,6 +436,7 @@ type Exception struct {
 	Uuid string
 
 	DistinctId string
+	DebugImages []DebugImage
 	Timestamp time.Time
 	Properties Properties
 	DisableGeoIP bool
@@ -454,6 +473,7 @@ type ExceptionInApiProperties struct {
 	IsServer *bool `json:"$is_server,omitempty"`
 	DistinctId string `json:"distinct_id"`
 	DisableGeoIP bool `json:"$geoip_disable,omitempty"`
+	DebugImages []DebugImage `json:"$debug_images,omitempty"`
 	ExceptionList []ExceptionItem `json:"$exception_list"`
 	ExceptionFingerprint *string `json:"$exception_fingerprint,omitempty"`
 
@@ -873,6 +893,12 @@ type StackFrame struct {
 	InApp bool `json:"in_app"`
 	Synthetic bool `json:"synthetic"`
 	Platform string `json:"platform"`
+	Lang string `json:"lang,omitempty"`
+	InstructionAddr string `json:"instruction_addr,omitempty"`
+	SymbolAddr string `json:"symbol_addr,omitempty"`
+	ImageAddr string `json:"image_addr,omitempty"`
+	ClientResolved bool `json:"client_resolved,omitempty"`
+	Inline bool `json:"inline,omitempty"`
 }
 
 type StackTraceExtractor interface {

--- a/before_send_test.go
+++ b/before_send_test.go
@@ -396,6 +396,7 @@ func TestBeforeSendDoesNotMutateOriginalExceptionData(t *testing.T) {
 			}},
 		},
 	}}
+	originalImages := []DebugImage{{Type: "macho", DebugID: "original-debug-id"}}
 
 	client, err := NewWithConfig("test-api-key", Config{
 		Endpoint:  server.URL,
@@ -413,6 +414,7 @@ func TestBeforeSendDoesNotMutateOriginalExceptionData(t *testing.T) {
 			exception.ExceptionList[0].Stacktrace.Type = "hook"
 			exception.ExceptionList[0].Stacktrace.Frames[0].Filename = "hook.go"
 			exception.ExceptionList[0].Stacktrace.Frames[0].LineNo = 2
+			exception.DebugImages[0].DebugID = "hook-debug-id"
 			exception.Properties["hook_ran"] = true
 			return exception
 		},
@@ -425,6 +427,7 @@ func TestBeforeSendDoesNotMutateOriginalExceptionData(t *testing.T) {
 		Properties:           NewProperties(),
 		ExceptionList:        originalList,
 		ExceptionFingerprint: &fingerprint,
+		DebugImages:          originalImages,
 	}))
 
 	message := firstMessage(t, readBatch(t, body))
@@ -439,6 +442,7 @@ func TestBeforeSendDoesNotMutateOriginalExceptionData(t *testing.T) {
 	require.Equal(t, "raw", originalList[0].Stacktrace.Type)
 	require.Equal(t, "original.go", originalList[0].Stacktrace.Frames[0].Filename)
 	require.Equal(t, 1, originalList[0].Stacktrace.Frames[0].LineNo)
+	require.Equal(t, "original-debug-id", originalImages[0].DebugID)
 }
 
 func TestBeforeSendReceivesTypedMessagesBeforeAPIfy(t *testing.T) {

--- a/capture_v1.go
+++ b/capture_v1.go
@@ -356,6 +356,9 @@ func (msg Exception) apifyEvent() apiEvent {
 	if msg.ExceptionFingerprint != nil {
 		myProperties.Set("$exception_fingerprint", msg.ExceptionFingerprint)
 	}
+	if len(msg.DebugImages) > 0 {
+		myProperties.Set("$debug_images", msg.DebugImages)
+	}
 
 	return apiEvent{
 		event:      "$exception",

--- a/error_tracking.go
+++ b/error_tracking.go
@@ -21,6 +21,9 @@ type Exception struct {
 	// DistinctId identifies the user or entity associated with the exception.
 	// When using EnqueueWithContext, this can be inherited from RequestContext.
 	DistinctId string
+	// DebugImages lists the binary images referenced by "native" stack
+	// frames, sent as $debug_images for server-side symbolication.
+	DebugImages []DebugImage
 	// Timestamp is the event timestamp. If zero, Enqueue uses the current time.
 	Timestamp time.Time
 	// Properties are custom event properties flattened into the exception event.
@@ -80,8 +83,27 @@ type StackFrame struct {
 	InApp bool `json:"in_app"`
 	// Synthetic reports whether the frame was synthesized by instrumentation.
 	Synthetic bool `json:"synthetic"`
-	// Platform identifies the runtime platform; Go frames use "go".
+	// Platform identifies the runtime platform; plain Go frames use "go",
+	// frames with raw addresses for server-side symbolication use "native".
 	Platform string `json:"platform"`
+	// Lang is a display-language hint for "native" frames; Go frames use "go".
+	Lang string `json:"lang,omitempty"`
+	// InstructionAddr is the raw return address for the frame's physical
+	// group, as hex. The server symbolicates it against uploaded debug
+	// symbols.
+	InstructionAddr string `json:"instruction_addr,omitempty"`
+	// SymbolAddr is the start address of the enclosing function, as hex.
+	SymbolAddr string `json:"symbol_addr,omitempty"`
+	// ImageAddr is the load address of the image containing the instruction.
+	ImageAddr string `json:"image_addr,omitempty"`
+	// ClientResolved reports that Function, Filename, and LineNo were
+	// resolved in-process from the Go runtime's symbol table.
+	ClientResolved bool `json:"client_resolved,omitempty"`
+	// Inline marks a frame the runtime synthesized for a call inlined into
+	// the preceding physical frame, which carries the same InstructionAddr.
+	// The server resolves the group's address once and either replaces the
+	// whole group with its own expansion or keeps the client frames verbatim.
+	Inline bool `json:"inline,omitempty"`
 }
 
 // ExceptionInApi is the wire-format payload produced from an Exception message.
@@ -117,6 +139,8 @@ type ExceptionInApiProperties struct {
 	DistinctId string `json:"distinct_id"`
 	// DisableGeoIP is sent as $geoip_disable when GeoIP lookup is disabled.
 	DisableGeoIP bool `json:"$geoip_disable,omitempty"`
+	// DebugImages is sent as $debug_images when "native" frames are present.
+	DebugImages []DebugImage `json:"$debug_images,omitempty"`
 	// ExceptionList is sent as $exception_list.
 	ExceptionList []ExceptionItem `json:"$exception_list"`
 	// ExceptionFingerprint is sent as $exception_fingerprint when provided.
@@ -230,6 +254,7 @@ func (msg Exception) APIfy() APIMessage {
 			IsServer:             isServer,
 			DistinctId:           msg.DistinctId,
 			DisableGeoIP:         msg.DisableGeoIP,
+			DebugImages:          msg.DebugImages,
 			ExceptionList:        msg.ExceptionList,
 			ExceptionFingerprint: msg.ExceptionFingerprint,
 			Custom:               msg.Properties,
@@ -260,5 +285,6 @@ func NewDefaultException(
 				Stacktrace: defaultStackTrace.GetStackTrace(3),
 			},
 		},
+		DebugImages: defaultStackTrace.GetDebugImages(),
 	}
 }

--- a/error_tracking_debug_images.go
+++ b/error_tracking_debug_images.go
@@ -64,23 +64,25 @@ func mainImage() mainImageInfo {
 var mainImageFn = mainImage
 
 // debugIDFromGNUBuildID derives a debug id from a GNU build id the same way
-// the PostHog server and CLI derive it from the binary: the first 16 bytes
-// interpreted as a little-endian GUID (first three fields byte-swapped),
-// zero-padded when the build id is shorter.
-func debugIDFromGNUBuildID(buildID []byte) string {
+// the PostHog server and CLI derive it from the binary (symbolic's
+// compute_debug_id): the first 16 bytes as a GUID, zero-padded when shorter,
+// with the first three fields byte-swapped only for little-endian ELF files.
+func debugIDFromGNUBuildID(buildID []byte, littleEndian bool) string {
 	if len(buildID) == 0 {
 		return ""
 	}
 	var data [16]byte
 	copy(data[:], buildID)
-	reverse := func(b []byte) {
-		for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
-			b[i], b[j] = b[j], b[i]
+	if littleEndian {
+		reverse := func(b []byte) {
+			for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+				b[i], b[j] = b[j], b[i]
+			}
 		}
+		reverse(data[0:4])
+		reverse(data[4:6])
+		reverse(data[6:8])
 	}
-	reverse(data[0:4])
-	reverse(data[4:6])
-	reverse(data[6:8])
 	return formatUUID(data)
 }
 

--- a/error_tracking_debug_images.go
+++ b/error_tracking_debug_images.go
@@ -92,13 +92,12 @@ func formatUUID(data [16]byte) string {
 }
 
 // nativeImageArch maps GOARCH to the architecture vocabulary shared by the
-// other PostHog SDKs and debug formats.
+// other PostHog SDKs ("arm64" is already the shared spelling — posthog-rs
+// normalizes aarch64 to it).
 func nativeImageArch() string {
 	switch runtime.GOARCH {
 	case "amd64":
 		return "x86_64"
-	case "arm64":
-		return "aarch64"
 	case "386":
 		return "x86"
 	default:

--- a/error_tracking_debug_images.go
+++ b/error_tracking_debug_images.go
@@ -1,0 +1,105 @@
+package posthog
+
+import (
+	"encoding/hex"
+	"runtime"
+	"sync"
+)
+
+// DebugImage describes a binary image loaded into the process, sent as the
+// event-level $debug_images property so PostHog can symbolicate raw frame
+// addresses against debug symbols uploaded with
+// `posthog-cli symbol-sets upload`.
+type DebugImage struct {
+	// Type is the image format: "elf" on Linux, "macho" on macOS.
+	Type string `json:"type"`
+	// DebugID identifies the uploaded symbol set for this image.
+	DebugID string `json:"debug_id"`
+	// CodeID is the full code identifier (the complete GNU build ID on ELF).
+	CodeID string `json:"code_id,omitempty"`
+	// ImageAddr is the runtime load address of the image, as hex.
+	ImageAddr string `json:"image_addr"`
+	// ImageSize is the loaded extent of the image in bytes.
+	ImageSize uint64 `json:"image_size,omitempty"`
+	// ImageVmaddr is the link-time base address of the image, as hex.
+	ImageVmaddr string `json:"image_vmaddr,omitempty"`
+	// CodeFile is the path of the binary on disk.
+	CodeFile string `json:"code_file,omitempty"`
+	// Arch is the processor architecture the image was built for.
+	Arch string `json:"arch"`
+}
+
+// DebugImageProvider is implemented by stack trace extractors that can also
+// report the binary images their frames reference. Integrations that accept a
+// StackTraceExtractor (e.g. the slog capture handler) use it to attach
+// $debug_images to the exceptions they build.
+type DebugImageProvider interface {
+	GetDebugImages() []DebugImage
+}
+
+// mainImageInfo is the cached result of inspecting the running executable.
+type mainImageInfo struct {
+	image DebugImage
+	base  uint64
+	end   uint64
+	ok    bool
+}
+
+var (
+	mainImageOnce   sync.Once
+	mainImageCached mainImageInfo
+)
+
+// mainImage inspects the running executable once and caches the result; the
+// binary cannot change while the process runs.
+func mainImage() mainImageInfo {
+	mainImageOnce.Do(func() {
+		mainImageCached = loadMainImage()
+	})
+	return mainImageCached
+}
+
+// mainImageFn is the seam tests use to force a known image (or none), keeping
+// grouped-frame emission deterministic across build environments.
+var mainImageFn = mainImage
+
+// debugIDFromGNUBuildID derives a debug id from a GNU build id the same way
+// the PostHog server and CLI derive it from the binary: the first 16 bytes
+// interpreted as a little-endian GUID (first three fields byte-swapped),
+// zero-padded when the build id is shorter.
+func debugIDFromGNUBuildID(buildID []byte) string {
+	if len(buildID) == 0 {
+		return ""
+	}
+	var data [16]byte
+	copy(data[:], buildID)
+	reverse := func(b []byte) {
+		for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+			b[i], b[j] = b[j], b[i]
+		}
+	}
+	reverse(data[0:4])
+	reverse(data[4:6])
+	reverse(data[6:8])
+	return formatUUID(data)
+}
+
+func formatUUID(data [16]byte) string {
+	hexStr := hex.EncodeToString(data[:])
+	return hexStr[0:8] + "-" + hexStr[8:12] + "-" + hexStr[12:16] + "-" + hexStr[16:20] + "-" + hexStr[20:32]
+}
+
+// nativeImageArch maps GOARCH to the architecture vocabulary shared by the
+// other PostHog SDKs and debug formats.
+func nativeImageArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		return "aarch64"
+	case "386":
+		return "x86"
+	default:
+		return runtime.GOARCH
+	}
+}

--- a/error_tracking_debug_images_darwin.go
+++ b/error_tracking_debug_images_darwin.go
@@ -128,9 +128,13 @@ func machoUUID(file *macho.File) ([16]byte, bool) {
 //
 // The path from os.Executable can point at a different build than the mapped
 // image (atomic deploy, symlink switch, self-update), which would yield a
-// plausible but wrong base and UUID. Cross-checking the slide against a
-// second, unrelated function catches that: per-function slides only agree for
-// the binary actually loaded.
+// plausible but wrong base and UUID. To catch that, the slide is cross-checked
+// against every physical function on the current call stack plus runtime.GC:
+// per-function slides only agree when the file matches the loaded binary's
+// layout across all of them (app, runtime, and SDK link units). A replacement
+// build that keeps every one of those entries identical is not detected —
+// full certainty would need the mapped image's own header via dyld, which
+// pure Go can't read safely.
 func machoSlide(file *macho.File) (uint64, bool) {
 	pclntab := file.Section("__gopclntab")
 	text := file.Section("__text")
@@ -153,6 +157,18 @@ func machoSlide(file *macho.File) (uint64, bool) {
 	check, ok := slideForPC(table, reflect.ValueOf(runtime.GC).Pointer())
 	if !ok || check != slide {
 		return 0, false
+	}
+
+	pcs := make([]uintptr, 32)
+	for _, pc := range pcs[:runtime.Callers(1, pcs)] {
+		frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
+		if frame.Func == nil {
+			continue
+		}
+		check, ok := slideForPC(table, pc)
+		if !ok || check != slide {
+			return 0, false
+		}
 	}
 	return slide, true
 }

--- a/error_tracking_debug_images_darwin.go
+++ b/error_tracking_debug_images_darwin.go
@@ -7,34 +7,48 @@ import (
 	"debug/macho"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
-	"reflect"
 	"runtime"
 	"strings"
 )
 
-// Snapshot the executable's identity at process start: macOS has no
-// /proc/self/exe equivalent, so reading the launch path later races with
-// deploys or self-updates replacing the file (see machoSlide). At init time
-// the file at the launch path is still the mapped binary.
+// pinnedExecutable is a handle to the binary this process was launched from,
+// opened at init before anything can replace the launch path. macOS has no
+// /proc/self/exe equivalent: reading the path later races with deploys or
+// self-updates swapping the file, which would pair this process's addresses
+// with a different build's UUID. The pinned inode always reads the mapped
+// binary; the handle is kept for the process lifetime.
+var pinnedExecutable struct {
+	file *os.File
+	path string
+}
+
 func init() {
-	go func() { _ = mainImage() }()
+	path, err := os.Executable()
+	if err != nil {
+		return
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	pinnedExecutable.file = file
+	pinnedExecutable.path = path
 }
 
 // loadMainImage inspects the running executable: its Mach-O UUID (which
 // `posthog-cli dsym upload` uses, uppercase, as the symbol set id) and its
 // runtime load address, computed from the ASLR slide of a known function.
 func loadMainImage() mainImageInfo {
-	exe, err := os.Executable()
-	if err != nil {
+	if pinnedExecutable.file == nil {
 		return mainImageInfo{}
 	}
 
-	file, closeFile, err := openMachO(exe)
+	file, err := openMachO(pinnedExecutable.file)
 	if err != nil {
 		return mainImageInfo{}
 	}
-	defer closeFile()
 
 	uuid, ok := machoUUID(file)
 	if !ok {
@@ -73,7 +87,7 @@ func loadMainImage() mainImageInfo {
 			ImageAddr:   fmt.Sprintf("0x%x", base),
 			ImageSize:   end - base,
 			ImageVmaddr: fmt.Sprintf("0x%x", textSeg.Addr),
-			CodeFile:    exe,
+			CodeFile:    pinnedExecutable.path,
 			Arch:        nativeImageArch(),
 		},
 		base: base,
@@ -82,17 +96,18 @@ func loadMainImage() mainImageInfo {
 	}
 }
 
-// openMachO opens a thin Mach-O executable, or the slice matching the running
-// architecture from a universal (fat) binary such as a lipo'd release build.
-func openMachO(exe string) (*macho.File, func() error, error) {
-	file, err := macho.Open(exe)
+// openMachO parses a thin Mach-O executable, or the slice matching the
+// running architecture from a universal (fat) binary such as a lipo'd release
+// build. The reader must stay valid for the returned file's lifetime.
+func openMachO(r io.ReaderAt) (*macho.File, error) {
+	file, err := macho.NewFile(r)
 	if err == nil {
-		return file, file.Close, nil
+		return file, nil
 	}
 
-	fat, fatErr := macho.OpenFat(exe)
+	fat, fatErr := macho.NewFatFile(r)
 	if fatErr != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	var want macho.Cpu
 	switch runtime.GOARCH {
@@ -103,16 +118,14 @@ func openMachO(exe string) (*macho.File, func() error, error) {
 	case "386":
 		want = macho.Cpu386
 	default:
-		fat.Close()
-		return nil, nil, err
+		return nil, err
 	}
 	for _, arch := range fat.Arches {
 		if arch.Cpu == want {
-			return arch.File, fat.Close, nil
+			return arch.File, nil
 		}
 	}
-	fat.Close()
-	return nil, nil, err
+	return nil, err
 }
 
 // machoUUID extracts the LC_UUID load command payload.
@@ -132,17 +145,9 @@ func machoUUID(file *macho.File) ([16]byte, bool) {
 
 // machoSlide computes the ASLR slide by comparing the runtime address of a
 // function in this package with its link-time address from the Go pclntab
-// (the Mach-O symbol table no longer carries Go function symbols).
-//
-// The path from os.Executable can point at a different build than the mapped
-// image (atomic deploy, symlink switch, self-update), which would yield a
-// plausible but wrong base and UUID. To catch that, the slide is cross-checked
-// against every physical function on the current call stack plus runtime.GC:
-// per-function slides only agree when the file matches the loaded binary's
-// layout across all of them (app, runtime, and SDK link units). A replacement
-// build that keeps every one of those entries identical is not detected —
-// full certainty would need the mapped image's own header via dyld, which
-// pure Go can't read safely.
+// (the Mach-O symbol table no longer carries Go function symbols). The pinned
+// handle guarantees the file is the mapped binary, so one reference point is
+// sound.
 func machoSlide(file *macho.File) (uint64, bool) {
 	pclntab := file.Section("__gopclntab")
 	text := file.Section("__text")
@@ -158,33 +163,7 @@ func machoSlide(file *macho.File) (uint64, bool) {
 		return 0, false
 	}
 
-	slide, ok := slideForPC(table, funcPC())
-	if !ok {
-		return 0, false
-	}
-	check, ok := slideForPC(table, reflect.ValueOf(runtime.GC).Pointer())
-	if !ok || check != slide {
-		return 0, false
-	}
-
-	pcs := make([]uintptr, 32)
-	for _, pc := range pcs[:runtime.Callers(1, pcs)] {
-		frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
-		if frame.Func == nil {
-			continue
-		}
-		check, ok := slideForPC(table, pc)
-		if !ok || check != slide {
-			return 0, false
-		}
-	}
-	return slide, true
-}
-
-// slideForPC returns the difference between a function's runtime address and
-// its link-time address in the file's pclntab.
-func slideForPC(table *gosym.Table, pc uintptr) (uint64, bool) {
-	entry := runtime.FuncForPC(pc).Entry()
+	entry := runtime.FuncForPC(funcPC()).Entry()
 	fn := table.LookupFunc(runtime.FuncForPC(entry).Name())
 	if fn == nil || uint64(entry) < fn.Entry {
 		return 0, false

--- a/error_tracking_debug_images_darwin.go
+++ b/error_tracking_debug_images_darwin.go
@@ -13,6 +13,14 @@ import (
 	"strings"
 )
 
+// Snapshot the executable's identity at process start: macOS has no
+// /proc/self/exe equivalent, so reading the launch path later races with
+// deploys or self-updates replacing the file (see machoSlide). At init time
+// the file at the launch path is still the mapped binary.
+func init() {
+	go func() { _ = mainImage() }()
+}
+
 // loadMainImage inspects the running executable: its Mach-O UUID (which
 // `posthog-cli dsym upload` uses, uppercase, as the symbol set id) and its
 // runtime load address, computed from the ASLR slide of a known function.

--- a/error_tracking_debug_images_darwin.go
+++ b/error_tracking_debug_images_darwin.go
@@ -1,0 +1,125 @@
+//go:build darwin
+
+package posthog
+
+import (
+	"debug/gosym"
+	"debug/macho"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// loadMainImage inspects the running executable: its Mach-O UUID (which
+// `posthog-cli dsym upload` uses, uppercase, as the symbol set id) and its
+// runtime load address, computed from the ASLR slide of a known function.
+func loadMainImage() mainImageInfo {
+	exe, err := os.Executable()
+	if err != nil {
+		return mainImageInfo{}
+	}
+
+	file, err := macho.Open(exe)
+	if err != nil {
+		return mainImageInfo{}
+	}
+	defer file.Close()
+
+	uuid, ok := machoUUID(file)
+	if !ok {
+		return mainImageInfo{}
+	}
+
+	textSeg := file.Segment("__TEXT")
+	if textSeg == nil {
+		return mainImageInfo{}
+	}
+
+	slide, ok := machoSlide(file)
+	if !ok {
+		return mainImageInfo{}
+	}
+
+	base := textSeg.Addr + slide
+	end := base
+	for _, load := range file.Loads {
+		if seg, isSeg := load.(*macho.Segment); isSeg {
+			if segEnd := seg.Addr + seg.Memsz + slide; segEnd > end {
+				end = segEnd
+			}
+		}
+	}
+
+	var data [16]byte
+	copy(data[:], uuid[:])
+
+	return mainImageInfo{
+		image: DebugImage{
+			Type: "macho",
+			// Uppercase to match the symbol set ids stored by
+			// `posthog-cli dsym upload`.
+			DebugID:     strings.ToUpper(formatUUID(data)),
+			ImageAddr:   fmt.Sprintf("0x%x", base),
+			ImageSize:   end - base,
+			ImageVmaddr: fmt.Sprintf("0x%x", textSeg.Addr),
+			CodeFile:    exe,
+			Arch:        nativeImageArch(),
+		},
+		base: base,
+		end:  end,
+		ok:   true,
+	}
+}
+
+// machoUUID extracts the LC_UUID load command payload.
+func machoUUID(file *macho.File) ([16]byte, bool) {
+	const lcUUID = 0x1b
+	var uuid [16]byte
+	for _, load := range file.Loads {
+		raw := load.Raw()
+		// Load command layout: cmd uint32, cmdsize uint32, payload
+		if len(raw) >= 24 && binary.LittleEndian.Uint32(raw[0:4]) == lcUUID {
+			copy(uuid[:], raw[8:24])
+			return uuid, true
+		}
+	}
+	return uuid, false
+}
+
+// machoSlide computes the ASLR slide by comparing the runtime address of a
+// function in this package with its link-time address from the Go pclntab
+// (the Mach-O symbol table no longer carries Go function symbols).
+func machoSlide(file *macho.File) (uint64, bool) {
+	pclntab := file.Section("__gopclntab")
+	text := file.Section("__text")
+	if pclntab == nil || text == nil {
+		return 0, false
+	}
+	data, err := pclntab.Data()
+	if err != nil {
+		return 0, false
+	}
+	table, err := gosym.NewTable(nil, gosym.NewLineTable(data, text.Addr))
+	if err != nil {
+		return 0, false
+	}
+
+	pc := runtime.FuncForPC(funcPC()).Entry()
+	fn := table.LookupFunc(runtime.FuncForPC(pc).Name())
+	if fn == nil || uint64(pc) < fn.Entry {
+		return 0, false
+	}
+	return uint64(pc) - fn.Entry, true
+}
+
+// funcPC returns a program counter inside this package, used as the slide
+// reference point.
+//
+//go:noinline
+func funcPC() uintptr {
+	pcs := make([]uintptr, 1)
+	runtime.Callers(1, pcs)
+	return pcs[0]
+}

--- a/error_tracking_debug_images_darwin.go
+++ b/error_tracking_debug_images_darwin.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 )
@@ -124,6 +125,12 @@ func machoUUID(file *macho.File) ([16]byte, bool) {
 // machoSlide computes the ASLR slide by comparing the runtime address of a
 // function in this package with its link-time address from the Go pclntab
 // (the Mach-O symbol table no longer carries Go function symbols).
+//
+// The path from os.Executable can point at a different build than the mapped
+// image (atomic deploy, symlink switch, self-update), which would yield a
+// plausible but wrong base and UUID. Cross-checking the slide against a
+// second, unrelated function catches that: per-function slides only agree for
+// the binary actually loaded.
 func machoSlide(file *macho.File) (uint64, bool) {
 	pclntab := file.Section("__gopclntab")
 	text := file.Section("__text")
@@ -139,12 +146,26 @@ func machoSlide(file *macho.File) (uint64, bool) {
 		return 0, false
 	}
 
-	pc := runtime.FuncForPC(funcPC()).Entry()
-	fn := table.LookupFunc(runtime.FuncForPC(pc).Name())
-	if fn == nil || uint64(pc) < fn.Entry {
+	slide, ok := slideForPC(table, funcPC())
+	if !ok {
 		return 0, false
 	}
-	return uint64(pc) - fn.Entry, true
+	check, ok := slideForPC(table, reflect.ValueOf(runtime.GC).Pointer())
+	if !ok || check != slide {
+		return 0, false
+	}
+	return slide, true
+}
+
+// slideForPC returns the difference between a function's runtime address and
+// its link-time address in the file's pclntab.
+func slideForPC(table *gosym.Table, pc uintptr) (uint64, bool) {
+	entry := runtime.FuncForPC(pc).Entry()
+	fn := table.LookupFunc(runtime.FuncForPC(entry).Name())
+	if fn == nil || uint64(entry) < fn.Entry {
+		return 0, false
+	}
+	return uint64(entry) - fn.Entry, true
 }
 
 // funcPC returns a program counter inside this package, used as the slide

--- a/error_tracking_debug_images_darwin.go
+++ b/error_tracking_debug_images_darwin.go
@@ -21,11 +21,11 @@ func loadMainImage() mainImageInfo {
 		return mainImageInfo{}
 	}
 
-	file, err := macho.Open(exe)
+	file, closeFile, err := openMachO(exe)
 	if err != nil {
 		return mainImageInfo{}
 	}
-	defer file.Close()
+	defer closeFile()
 
 	uuid, ok := machoUUID(file)
 	if !ok {
@@ -71,6 +71,39 @@ func loadMainImage() mainImageInfo {
 		end:  end,
 		ok:   true,
 	}
+}
+
+// openMachO opens a thin Mach-O executable, or the slice matching the running
+// architecture from a universal (fat) binary such as a lipo'd release build.
+func openMachO(exe string) (*macho.File, func() error, error) {
+	file, err := macho.Open(exe)
+	if err == nil {
+		return file, file.Close, nil
+	}
+
+	fat, fatErr := macho.OpenFat(exe)
+	if fatErr != nil {
+		return nil, nil, err
+	}
+	var want macho.Cpu
+	switch runtime.GOARCH {
+	case "amd64":
+		want = macho.CpuAmd64
+	case "arm64":
+		want = macho.CpuArm64
+	case "386":
+		want = macho.Cpu386
+	default:
+		fat.Close()
+		return nil, nil, err
+	}
+	for _, arch := range fat.Arches {
+		if arch.Cpu == want {
+			return arch.File, fat.Close, nil
+		}
+	}
+	fat.Close()
+	return nil, nil, err
 }
 
 // machoUUID extracts the LC_UUID load command payload.

--- a/error_tracking_debug_images_darwin.go
+++ b/error_tracking_debug_images_darwin.go
@@ -18,7 +18,10 @@ import (
 // /proc/self/exe equivalent: reading the path later races with deploys or
 // self-updates swapping the file, which would pair this process's addresses
 // with a different build's UUID. The pinned inode always reads the mapped
-// binary; the handle is kept for the process lifetime.
+// binary; the handle is kept for the process lifetime. A swap within the
+// exec-to-init window is not detectable without dyld (cgo) and is accepted as
+// residual risk; the slide check in machoSlide rejects layout-incompatible
+// replacements.
 var pinnedExecutable struct {
 	file *os.File
 	path string

--- a/error_tracking_debug_images_darwin_test.go
+++ b/error_tracking_debug_images_darwin_test.go
@@ -1,0 +1,58 @@
+//go:build darwin
+
+package posthog
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenMachOUniversal wraps the running test binary in a universal (fat)
+// container and checks that openMachO picks the slice for the running
+// architecture, since macho.Open alone rejects fat files.
+func TestOpenMachOUniversal(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	thin, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(thin) < 12 {
+		t.Fatal("test binary too small")
+	}
+
+	// fat_header + one fat_arch entry (both big-endian), then the thin slice
+	// at an aligned offset; cputype/cpusubtype copied from the thin header.
+	const sliceOffset = 0x4000
+	fat := make([]byte, sliceOffset+len(thin))
+	binary.BigEndian.PutUint32(fat[0:4], 0xcafebabe) // FAT_MAGIC
+	binary.BigEndian.PutUint32(fat[4:8], 1)          // nfat_arch
+	binary.BigEndian.PutUint32(fat[8:12], binary.LittleEndian.Uint32(thin[4:8]))
+	binary.BigEndian.PutUint32(fat[12:16], binary.LittleEndian.Uint32(thin[8:12]))
+	binary.BigEndian.PutUint32(fat[16:20], sliceOffset)
+	binary.BigEndian.PutUint32(fat[20:24], uint32(len(thin)))
+	binary.BigEndian.PutUint32(fat[24:28], 14) // 2^14 page alignment
+	copy(fat[sliceOffset:], thin)
+
+	path := filepath.Join(t.TempDir(), "universal")
+	if err := os.WriteFile(path, fat, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	file, closeFile, err := openMachO(path)
+	if err != nil {
+		t.Fatalf("openMachO(universal) = %v", err)
+	}
+	defer closeFile()
+
+	if _, ok := machoUUID(file); !ok {
+		t.Error("expected LC_UUID in the selected slice")
+	}
+	if file.Segment("__TEXT") == nil {
+		t.Error("expected __TEXT segment in the selected slice")
+	}
+}

--- a/error_tracking_debug_images_darwin_test.go
+++ b/error_tracking_debug_images_darwin_test.go
@@ -42,12 +42,16 @@ func TestOpenMachOUniversal(t *testing.T) {
 	if err := os.WriteFile(path, fat, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	universal, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer universal.Close()
 
-	file, closeFile, err := openMachO(path)
+	file, err := openMachO(universal)
 	if err != nil {
 		t.Fatalf("openMachO(universal) = %v", err)
 	}
-	defer closeFile()
 
 	if _, ok := machoUUID(file); !ok {
 		t.Error("expected LC_UUID in the selected slice")

--- a/error_tracking_debug_images_linux.go
+++ b/error_tracking_debug_images_linux.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -125,8 +126,23 @@ func mapsLineRange(line, exe string) (start, stop uint64, ok bool) {
 }
 
 // gnuBuildID extracts the NT_GNU_BUILD_ID note from an ELF file. Returns nil
-// when the binary carries no GNU build id.
+// when the binary carries no GNU build id. Program headers are checked first:
+// fully stripped binaries can drop the section table entirely while PT_NOTE
+// segments survive, and that's also where the loader (and symbolic, which the
+// PostHog uploader uses) looks.
 func gnuBuildID(file *elf.File) []byte {
+	for _, prog := range file.Progs {
+		if prog.Type != elf.PT_NOTE || prog.Filesz == 0 || prog.Filesz > 1<<20 {
+			continue
+		}
+		data := make([]byte, prog.Filesz)
+		if _, err := io.ReadFull(prog.Open(), data); err != nil {
+			continue
+		}
+		if id := parseGNUBuildIDNote(data, file.ByteOrder); id != nil {
+			return id
+		}
+	}
 	for _, section := range file.Sections {
 		if section.Type != elf.SHT_NOTE {
 			continue

--- a/error_tracking_debug_images_linux.go
+++ b/error_tracking_debug_images_linux.go
@@ -1,0 +1,169 @@
+//go:build linux
+
+package posthog
+
+import (
+	"bufio"
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// loadMainImage inspects the running executable: its mapped address range
+// from /proc/self/maps and its GNU build id from the ELF notes. Returns a
+// zero-value info (ok=false) when either is unavailable — e.g. the binary
+// was linked without `-ldflags=-B=gobuildid`.
+func loadMainImage() mainImageInfo {
+	exe, err := os.Executable()
+	if err != nil {
+		return mainImageInfo{}
+	}
+
+	base, end, ok := executableMappedRange(exe)
+	if !ok {
+		return mainImageInfo{}
+	}
+
+	// Open the magic link rather than the resolved path: it always reads the
+	// mapped image, even after the binary on disk is replaced or deleted
+	// (e.g. mid-deploy).
+	file, err := elf.Open("/proc/self/exe")
+	if err != nil {
+		return mainImageInfo{}
+	}
+	defer file.Close()
+
+	buildID := gnuBuildID(file)
+	if len(buildID) == 0 {
+		return mainImageInfo{}
+	}
+
+	vmaddr := uint64(0)
+	for _, prog := range file.Progs {
+		if prog.Type == elf.PT_LOAD {
+			vmaddr = prog.Vaddr
+			break
+		}
+	}
+
+	return mainImageInfo{
+		image: DebugImage{
+			Type:        "elf",
+			DebugID:     debugIDFromGNUBuildID(buildID),
+			CodeID:      hex.EncodeToString(buildID),
+			ImageAddr:   fmt.Sprintf("0x%x", base),
+			ImageSize:   end - base,
+			ImageVmaddr: fmt.Sprintf("0x%x", vmaddr),
+			CodeFile:    exe,
+			Arch:        nativeImageArch(),
+		},
+		base: base,
+		end:  end,
+		ok:   true,
+	}
+}
+
+// executableMappedRange parses /proc/self/maps and returns the address range
+// covered by the executable's own mappings.
+func executableMappedRange(exe string) (base, end uint64, ok bool) {
+	file, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return 0, 0, false
+	}
+	defer file.Close()
+
+	// A replaced-on-disk executable keeps its mapping but both readlink
+	// /proc/self/exe and the maps pathname grow a " (deleted)" suffix.
+	exe = strings.TrimSuffix(exe, " (deleted)")
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		start, stop, lineOK := mapsLineRange(scanner.Text(), exe)
+		if !lineOK {
+			continue
+		}
+		if !ok || start < base {
+			base = start
+		}
+		if stop > end {
+			end = stop
+		}
+		ok = true
+	}
+
+	return base, end, ok
+}
+
+// mapsLineRange parses one /proc/self/maps line and returns its address range
+// when the mapping belongs to exe. Format: start-end perms offset dev inode
+// pathname — the pathname is the remainder of the line (it may contain
+// spaces), so it can't be pulled out with Fields.
+func mapsLineRange(line, exe string) (start, stop uint64, ok bool) {
+	pathIdx := strings.IndexByte(line, '/')
+	if pathIdx < 0 || strings.TrimSuffix(line[pathIdx:], " (deleted)") != exe {
+		return 0, 0, false
+	}
+	fields := strings.Fields(line[:pathIdx])
+	if len(fields) < 5 {
+		return 0, 0, false
+	}
+	addrs := strings.SplitN(fields[0], "-", 2)
+	if len(addrs) != 2 {
+		return 0, 0, false
+	}
+	start, err1 := strconv.ParseUint(addrs[0], 16, 64)
+	stop, err2 := strconv.ParseUint(addrs[1], 16, 64)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return start, stop, true
+}
+
+// gnuBuildID extracts the NT_GNU_BUILD_ID note from an ELF file. Returns nil
+// when the binary carries no GNU build id.
+func gnuBuildID(file *elf.File) []byte {
+	for _, section := range file.Sections {
+		if section.Type != elf.SHT_NOTE {
+			continue
+		}
+		data, err := section.Data()
+		if err != nil {
+			continue
+		}
+		if id := parseGNUBuildIDNote(data, file.ByteOrder); id != nil {
+			return id
+		}
+	}
+	return nil
+}
+
+// parseGNUBuildIDNote walks ELF note records; their header fields use the
+// file's own byte order.
+func parseGNUBuildIDNote(data []byte, byteOrder binary.ByteOrder) []byte {
+	const gnuBuildIDType = 3
+	for len(data) >= 12 {
+		nameSize := byteOrder.Uint32(data[0:4])
+		descSize := byteOrder.Uint32(data[4:8])
+		noteType := byteOrder.Uint32(data[8:12])
+		data = data[12:]
+
+		alignedName := (nameSize + 3) &^ 3
+		alignedDesc := (descSize + 3) &^ 3
+		if uint64(len(data)) < uint64(alignedName)+uint64(alignedDesc) {
+			return nil
+		}
+		name := data[:nameSize]
+		desc := data[alignedName : alignedName+descSize]
+		data = data[alignedName+alignedDesc:]
+
+		if noteType == gnuBuildIDType && bytes.Equal(name, []byte("GNU\x00")) {
+			return desc
+		}
+	}
+	return nil
+}

--- a/error_tracking_debug_images_linux.go
+++ b/error_tracking_debug_images_linux.go
@@ -54,7 +54,7 @@ func loadMainImage() mainImageInfo {
 	return mainImageInfo{
 		image: DebugImage{
 			Type:        "elf",
-			DebugID:     debugIDFromGNUBuildID(buildID),
+			DebugID:     debugIDFromGNUBuildID(buildID, file.ByteOrder == binary.LittleEndian),
 			CodeID:      hex.EncodeToString(buildID),
 			ImageAddr:   fmt.Sprintf("0x%x", base),
 			ImageSize:   end - base,

--- a/error_tracking_debug_images_linux.go
+++ b/error_tracking_debug_images_linux.go
@@ -159,18 +159,21 @@ func gnuBuildID(file *elf.File) []byte {
 }
 
 // parseGNUBuildIDNote walks ELF note records; their header fields use the
-// file's own byte order.
+// file's own byte order. All size arithmetic happens in uint64: aligning a
+// near-max uint32 size would wrap, slip past the bounds check, and panic on
+// the slice below — and this parser must never crash the host process, even
+// on a malformed note.
 func parseGNUBuildIDNote(data []byte, byteOrder binary.ByteOrder) []byte {
 	const gnuBuildIDType = 3
 	for len(data) >= 12 {
-		nameSize := byteOrder.Uint32(data[0:4])
-		descSize := byteOrder.Uint32(data[4:8])
+		nameSize := uint64(byteOrder.Uint32(data[0:4]))
+		descSize := uint64(byteOrder.Uint32(data[4:8]))
 		noteType := byteOrder.Uint32(data[8:12])
 		data = data[12:]
 
 		alignedName := (nameSize + 3) &^ 3
 		alignedDesc := (descSize + 3) &^ 3
-		if uint64(len(data)) < uint64(alignedName)+uint64(alignedDesc) {
+		if uint64(len(data)) < alignedName+alignedDesc {
 			return nil
 		}
 		name := data[:nameSize]

--- a/error_tracking_debug_images_linux_test.go
+++ b/error_tracking_debug_images_linux_test.go
@@ -2,7 +2,67 @@
 
 package posthog
 
-import "testing"
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"testing"
+)
+
+// TestGNUBuildIDFromProgramHeader covers fully stripped binaries: no section
+// table at all, with the NT_GNU_BUILD_ID note reachable only through a
+// PT_NOTE program header. The ELF is hand-assembled: file header, one program
+// header, then the note.
+func TestGNUBuildIDFromProgramHeader(t *testing.T) {
+	le := binary.LittleEndian
+	buildID := []byte{
+		0x55, 0x53, 0x98, 0xeb, 0xd0, 0x1c, 0x90, 0x28, 0x5a, 0x3d,
+		0x85, 0x13, 0x8a, 0x19, 0xcb, 0xf9, 0xbb, 0xce, 0xc3, 0x52,
+	}
+
+	note := make([]byte, 12, 12+4+len(buildID))
+	le.PutUint32(note[0:4], 4)                    // namesz ("GNU\x00")
+	le.PutUint32(note[4:8], uint32(len(buildID))) // descsz
+	le.PutUint32(note[8:12], 3)                   // NT_GNU_BUILD_ID
+	note = append(note, "GNU\x00"...)
+	note = append(note, buildID...)
+
+	const ehSize, phSize = 64, 56
+	image := make([]byte, ehSize+phSize+len(note))
+	copy(image, "\x7fELF")
+	image[4] = 2                     // ELFCLASS64
+	image[5] = 1                     // little-endian
+	image[6] = 1                     // EV_CURRENT
+	le.PutUint16(image[16:18], 2)    // ET_EXEC
+	le.PutUint16(image[18:20], 0x3e) // EM_X86_64
+	le.PutUint32(image[20:24], 1)    // e_version
+	le.PutUint64(image[32:40], ehSize)
+	le.PutUint16(image[52:54], ehSize)
+	le.PutUint16(image[54:56], phSize)
+	le.PutUint16(image[56:58], 1) // e_phnum
+
+	ph := image[ehSize:]
+	le.PutUint32(ph[0:4], uint32(elf.PT_NOTE))
+	le.PutUint32(ph[4:8], 4) // PF_R
+	le.PutUint64(ph[8:16], ehSize+phSize)
+	le.PutUint64(ph[32:40], uint64(len(note))) // p_filesz
+	le.PutUint64(ph[40:48], uint64(len(note))) // p_memsz
+	le.PutUint64(ph[48:56], 4)                 // p_align
+	copy(image[ehSize+phSize:], note)
+
+	file, err := elf.NewFile(bytes.NewReader(image))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if len(file.Sections) != 0 {
+		t.Fatal("fixture must have no section table")
+	}
+
+	if got := gnuBuildID(file); !bytes.Equal(got, buildID) {
+		t.Errorf("gnuBuildID() = %x, want %x", got, buildID)
+	}
+}
 
 func TestMapsLineRange(t *testing.T) {
 	tests := []struct {

--- a/error_tracking_debug_images_linux_test.go
+++ b/error_tracking_debug_images_linux_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package posthog
+
+import "testing"
+
+func TestMapsLineRange(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		exe   string
+		start uint64
+		stop  uint64
+		ok    bool
+	}{
+		{
+			name:  "plain mapping",
+			line:  "00400000-0047f000 r-xp 00000000 fd:01 123456                             /usr/bin/app",
+			exe:   "/usr/bin/app",
+			start: 0x400000,
+			stop:  0x47f000,
+			ok:    true,
+		},
+		{
+			name:  "path with spaces",
+			line:  "00400000-0047f000 r-xp 00000000 fd:01 123456                             /opt/my app/bin server",
+			exe:   "/opt/my app/bin server",
+			start: 0x400000,
+			stop:  0x47f000,
+			ok:    true,
+		},
+		{
+			name:  "deleted executable",
+			line:  "00400000-0047f000 r-xp 00000000 fd:01 123456                             /usr/bin/app (deleted)",
+			exe:   "/usr/bin/app",
+			start: 0x400000,
+			stop:  0x47f000,
+			ok:    true,
+		},
+		{
+			name: "different file",
+			line: "7f0000000000-7f0000001000 r-xp 00000000 fd:01 654321                     /usr/lib/libc.so.6",
+			exe:  "/usr/bin/app",
+			ok:   false,
+		},
+		{
+			name: "anonymous mapping",
+			line: "7ffd1c000000-7ffd1c021000 rw-p 00000000 00:00 0                          [stack]",
+			exe:  "/usr/bin/app",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, stop, ok := mapsLineRange(tt.line, tt.exe)
+			if ok != tt.ok || start != tt.start || stop != tt.stop {
+				t.Errorf("mapsLineRange() = (%#x, %#x, %v), want (%#x, %#x, %v)",
+					start, stop, ok, tt.start, tt.stop, tt.ok)
+			}
+		})
+	}
+}

--- a/error_tracking_debug_images_linux_test.go
+++ b/error_tracking_debug_images_linux_test.go
@@ -64,6 +64,29 @@ func TestGNUBuildIDFromProgramHeader(t *testing.T) {
 	}
 }
 
+// TestParseGNUBuildIDNoteMalformed feeds note headers whose sizes are crafted
+// to wrap 32-bit alignment arithmetic; the parser must return nil rather than
+// panic, since it runs inside the host application's capture path.
+func TestParseGNUBuildIDNoteMalformed(t *testing.T) {
+	le := binary.LittleEndian
+	malformed := [][2]uint32{
+		{0xfffffffe, 0},          // namesz aligns to 0 in uint32
+		{0, 0xfffffffe},          // descsz aligns to 0 in uint32
+		{0xffffffff, 0xffffffff}, // both wrap
+		{16, 0},                  // sizes larger than the payload
+	}
+	for _, sizes := range malformed {
+		note := make([]byte, 16)
+		le.PutUint32(note[0:4], sizes[0])
+		le.PutUint32(note[4:8], sizes[1])
+		le.PutUint32(note[8:12], 3)
+		if got := parseGNUBuildIDNote(note, le); got != nil {
+			t.Errorf("parseGNUBuildIDNote(namesz=%#x, descsz=%#x) = %x, want nil",
+				sizes[0], sizes[1], got)
+		}
+	}
+}
+
 func TestMapsLineRange(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/error_tracking_debug_images_other.go
+++ b/error_tracking_debug_images_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin
+
+package posthog
+
+// loadMainImage is unsupported on this platform: frames still carry raw
+// addresses, but no debug image is reported, so they fall back to the
+// runtime-resolved function, file, and line.
+func loadMainImage() mainImageInfo {
+	return mainImageInfo{}
+}

--- a/error_tracking_debug_images_test.go
+++ b/error_tracking_debug_images_test.go
@@ -1,0 +1,170 @@
+package posthog
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubMainImage forces a known image (or none) so grouped-frame emission is
+// deterministic regardless of the build environment. Tests using it must not
+// run in parallel.
+func stubMainImage(t *testing.T, info mainImageInfo) {
+	t.Helper()
+	prev := mainImageFn
+	mainImageFn = func() mainImageInfo { return info }
+	t.Cleanup(func() { mainImageFn = prev })
+}
+
+func coveringImage() mainImageInfo {
+	return mainImageInfo{
+		image: DebugImage{
+			Type:      "elf",
+			DebugID:   "eb985355-1cd0-2890-5a3d-85138a19cbf9",
+			ImageAddr: "0x400000",
+			ImageSize: 1 << 40,
+			Arch:      "x86_64",
+		},
+		base: 0,
+		end:  ^uint64(0),
+		ok:   true,
+	}
+}
+
+func TestDebugIDFromGNUBuildID(t *testing.T) {
+	// Vector verified against symbolic's ElfObject::debug_id, which the
+	// PostHog server and CLI use: the first 16 bytes as a little-endian GUID.
+	buildID, err := hex.DecodeString("555398ebd01c90285a3d85138a19cbf9bbcec352")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := debugIDFromGNUBuildID(buildID), "eb985355-1cd0-2890-5a3d-85138a19cbf9"; got != want {
+		t.Errorf("debugIDFromGNUBuildID() = %q, want %q", got, want)
+	}
+
+	// Short build ids are zero-padded to 16 bytes
+	if got, want := debugIDFromGNUBuildID([]byte{0xab, 0xcd}), "0000cdab-0000-0000-0000-000000000000"; got != want {
+		t.Errorf("debugIDFromGNUBuildID(short) = %q, want %q", got, want)
+	}
+
+	if got := debugIDFromGNUBuildID(nil); got != "" {
+		t.Errorf("debugIDFromGNUBuildID(nil) = %q, want empty", got)
+	}
+}
+
+func TestNativeImageArch(t *testing.T) {
+	arch := nativeImageArch()
+	if arch == "amd64" || arch == "arm64" {
+		t.Errorf("nativeImageArch() = %q, want shared vocabulary", arch)
+	}
+}
+
+//go:noinline
+func defaultCaptureSite() Exception {
+	return NewDefaultException(time.Now(), "user-1", "GroupTest", "grouped capture test")
+}
+
+// The real running executable, no stub: an integration check that discovered
+// images are well formed and referenced by frames. Skips where the test
+// binary carries no identity (Linux Go test binaries have no GNU build id).
+func TestRealDebugImages(t *testing.T) {
+	exception := defaultCaptureSite()
+
+	if len(exception.DebugImages) == 0 {
+		t.Skip("no debug image for the test binary on this platform/build")
+	}
+
+	image := exception.DebugImages[0]
+	if image.Type != "elf" && image.Type != "macho" {
+		t.Errorf("image.Type = %q", image.Type)
+	}
+	if len(image.DebugID) < 36 {
+		t.Errorf("image.DebugID = %q, want uuid-shaped", image.DebugID)
+	}
+	if image.Arch == "amd64" || image.Arch == "arm64" {
+		t.Errorf("image.Arch = %q, want shared vocabulary (x86_64/aarch64)", image.Arch)
+	}
+
+	base, err := strconv.ParseUint(strings.TrimPrefix(image.ImageAddr, "0x"), 16, 64)
+	if err != nil || base == 0 {
+		t.Fatalf("image.ImageAddr = %q, want non-zero hex", image.ImageAddr)
+	}
+
+	// Frames in the main executable reference the image's address, and their
+	// instruction addresses fall inside its extent.
+	frames := exception.ExceptionList[0].Stacktrace.Frames
+	referenced := false
+	for _, frame := range frames {
+		if frame.ImageAddr != image.ImageAddr {
+			continue
+		}
+		referenced = true
+		addr, err := strconv.ParseUint(strings.TrimPrefix(frame.InstructionAddr, "0x"), 16, 64)
+		if err != nil {
+			t.Fatalf("frame.InstructionAddr = %q", frame.InstructionAddr)
+		}
+		if addr < base || addr >= base+image.ImageSize {
+			t.Errorf("frame addr %#x outside image [%#x, %#x)", addr, base, base+image.ImageSize)
+		}
+	}
+	if !referenced {
+		t.Error("no frame references the main image")
+	}
+}
+
+func TestExceptionAPIfyIncludesDebugImages(t *testing.T) {
+	stubMainImage(t, coveringImage())
+	exception := defaultCaptureSite()
+	exception.Type = "exception"
+
+	payload, err := json.Marshal(exception.APIfy())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded struct {
+		Properties struct {
+			DebugImages []DebugImage `json:"$debug_images"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Properties.DebugImages) != 1 {
+		t.Fatalf("expected $debug_images in payload, got %s", payload)
+	}
+}
+
+func TestSlogHandlerAttachesDebugImages(t *testing.T) {
+	stubMainImage(t, coveringImage())
+
+	client := &fakeEnqueueClient{}
+	next := &fakeNextSlogHandler{isEnabled: false}
+	handler := NewSlogCaptureHandler(next, client,
+		WithDistinctIDFn(func(_ context.Context, _ slog.Record) string { return "user-1" }),
+	)
+
+	if err := handler.Handle(context.Background(), createLogRecord(slog.LevelError, "boom")); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.enqueuedMsgs) != 1 {
+		t.Fatalf("expected 1 enqueue, got %d", len(client.enqueuedMsgs))
+	}
+
+	exception, ok := client.enqueuedMsgs[0].(Exception)
+	if !ok {
+		t.Fatalf("expected Exception, got %T", client.enqueuedMsgs[0])
+	}
+	if len(exception.DebugImages) != 1 {
+		t.Fatalf("expected the default extractor to provide debug images")
+	}
+	frames := exception.ExceptionList[0].Stacktrace.Frames
+	if len(frames) == 0 || frames[len(frames)-1].Platform != "native" {
+		t.Errorf("expected native frames from the covered image")
+	}
+}

--- a/error_tracking_debug_images_test.go
+++ b/error_tracking_debug_images_test.go
@@ -63,8 +63,8 @@ func TestDebugIDFromGNUBuildID(t *testing.T) {
 }
 
 func TestNativeImageArch(t *testing.T) {
-	arch := nativeImageArch()
-	if arch == "amd64" || arch == "arm64" {
+	// amd64 is Go-only vocabulary; arm64 is already the shared spelling.
+	if arch := nativeImageArch(); arch == "amd64" || arch == "aarch64" {
 		t.Errorf("nativeImageArch() = %q, want shared vocabulary", arch)
 	}
 }
@@ -91,8 +91,8 @@ func TestRealDebugImages(t *testing.T) {
 	if len(image.DebugID) < 36 {
 		t.Errorf("image.DebugID = %q, want uuid-shaped", image.DebugID)
 	}
-	if image.Arch == "amd64" || image.Arch == "arm64" {
-		t.Errorf("image.Arch = %q, want shared vocabulary (x86_64/aarch64)", image.Arch)
+	if image.Arch == "amd64" || image.Arch == "aarch64" {
+		t.Errorf("image.Arch = %q, want shared vocabulary (x86_64/arm64)", image.Arch)
 	}
 
 	base, err := strconv.ParseUint(strings.TrimPrefix(image.ImageAddr, "0x"), 16, 64)

--- a/error_tracking_debug_images_test.go
+++ b/error_tracking_debug_images_test.go
@@ -43,16 +43,21 @@ func TestDebugIDFromGNUBuildID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := debugIDFromGNUBuildID(buildID), "eb985355-1cd0-2890-5a3d-85138a19cbf9"; got != want {
+	if got, want := debugIDFromGNUBuildID(buildID, true), "eb985355-1cd0-2890-5a3d-85138a19cbf9"; got != want {
 		t.Errorf("debugIDFromGNUBuildID() = %q, want %q", got, want)
 	}
 
+	// Big-endian ELF files keep the GUID fields unswapped, matching symbolic.
+	if got, want := debugIDFromGNUBuildID(buildID, false), "555398eb-d01c-9028-5a3d-85138a19cbf9"; got != want {
+		t.Errorf("debugIDFromGNUBuildID(BE) = %q, want %q", got, want)
+	}
+
 	// Short build ids are zero-padded to 16 bytes
-	if got, want := debugIDFromGNUBuildID([]byte{0xab, 0xcd}), "0000cdab-0000-0000-0000-000000000000"; got != want {
+	if got, want := debugIDFromGNUBuildID([]byte{0xab, 0xcd}, true), "0000cdab-0000-0000-0000-000000000000"; got != want {
 		t.Errorf("debugIDFromGNUBuildID(short) = %q, want %q", got, want)
 	}
 
-	if got := debugIDFromGNUBuildID(nil); got != "" {
+	if got := debugIDFromGNUBuildID(nil, true); got != "" {
 		t.Errorf("debugIDFromGNUBuildID(nil) = %q, want empty", got)
 	}
 }

--- a/error_tracking_debug_images_test.go
+++ b/error_tracking_debug_images_test.go
@@ -140,6 +140,48 @@ func TestExceptionAPIfyIncludesDebugImages(t *testing.T) {
 	}
 }
 
+func TestExceptionApifyEventIncludesDebugImages(t *testing.T) {
+	stubMainImage(t, coveringImage())
+	exception := defaultCaptureSite()
+
+	ev := exception.apifyEvent()
+	images, ok := ev.properties["$debug_images"].([]DebugImage)
+	if !ok || len(images) != 1 {
+		t.Fatalf("expected $debug_images in v1 properties, got %v", ev.properties["$debug_images"])
+	}
+
+	// And absent (not an empty array) when there are none.
+	exception.DebugImages = nil
+	if _, present := exception.apifyEvent().properties["$debug_images"]; present {
+		t.Error("expected no $debug_images key without images")
+	}
+}
+
+func TestPanicFallbackStackTraceCarriesDebugImages(t *testing.T) {
+	stubMainImage(t, coveringImage())
+
+	// Unparseable panic stack: falls back to the default extractor, which
+	// emits native frames, so the images must come along.
+	stacktrace, images := stackTraceFromDebugStack([]byte("not a panic stack"))
+	if stacktrace == nil || len(stacktrace.Frames) == 0 {
+		t.Fatal("expected fallback frames")
+	}
+	if len(images) != 1 {
+		t.Errorf("expected debug images with the extractor fallback, got %v", images)
+	}
+
+	// Parseable stack: frames come from the panic text with no addresses, so
+	// no images are attached.
+	goroutineStack := []byte("goroutine 1 [running]:\npanic({0x0, 0x0})\n\t/goroot/src/runtime/panic.go:770 +0x1\nmain.crash(...)\n\t/app/main.go:10 +0x1\nmain.main()\n\t/app/main.go:5 +0x2\n")
+	stacktrace, images = stackTraceFromDebugStack(goroutineStack)
+	if stacktrace == nil || len(stacktrace.Frames) == 0 {
+		t.Fatal("expected parsed frames")
+	}
+	if images != nil {
+		t.Errorf("expected no debug images for parsed panic frames, got %v", images)
+	}
+}
+
 func TestSlogHandlerAttachesDebugImages(t *testing.T) {
 	stubMainImage(t, coveringImage())
 

--- a/error_tracking_slog.go
+++ b/error_tracking_slog.go
@@ -80,6 +80,9 @@ func (h *SlogCaptureHandler) Handle(ctx context.Context, r slog.Record) error {
 		ExceptionFingerprint: h.cfg.fingerprint(ctx, r),
 		Properties:           h.cfg.properties(ctx, r),
 	}
+	if provider, ok := h.cfg.stackTraceExtractor.(DebugImageProvider); ok {
+		ex.DebugImages = provider.GetDebugImages()
+	}
 	_ = enqueueWithContext(ctx, h.client, ex) // ignore enqueue error to keep logging safe
 
 	return err

--- a/error_tracking_stack_trace.go
+++ b/error_tracking_stack_trace.go
@@ -52,34 +52,105 @@ type DefaultStackTraceExtractor struct {
 // GetStackTrace captures the current goroutine stack in wire order (outermost
 // frame first, capture site last). The skip parameter omits leading
 // runtime.Callers frames before conversion.
+//
+// When the running executable's identity is known (see DebugImage), frames
+// are emitted as client-expanded inline groups for server-side symbolication:
+// each physical stack frame and the entries the runtime synthesizes for calls
+// inlined into it share one raw return address, with the synthesized layers
+// tagged inline. PostHog resolves that address once against uploaded debug
+// symbols and atomically replaces the whole group with its own expansion
+// (exact inline chain, source context), or keeps these runtime-resolved
+// frames verbatim when no symbols are uploaded. When the executable can't be
+// identified, frames keep the plain pre-existing shape.
 func (d DefaultStackTraceExtractor) GetStackTrace(skip int) *ExceptionStacktrace {
 	pcs := make([]uintptr, 64)
 	stackCallCount := runtime.Callers(skip, pcs)
-	frames := runtime.CallersFrames(pcs[:stackCallCount])
+
+	image := mainImageFn()
 
 	traces := make([]StackFrame, 0, stackCallCount)
-	for {
-		frame, hasMore := frames.Next()
-		if frame == *new(runtime.Frame) {
-			break
+	i := 0
+	for i < stackCallCount {
+		// One physical stack frame per iteration: resolve the leaf entry,
+		// then collect the entries runtime.Callers synthesizes for its inline
+		// ancestors, anchored by the physical frame (Func != nil) sharing the
+		// same entry pc. Matching on the entry pc keeps non-Go frames (also
+		// Func == nil, but with zero or distinct entries) and recursive calls
+		// of the physical function separate.
+		leafPC := pcs[i]
+		i++
+		leaf, _ := runtime.CallersFrames([]uintptr{leafPC}).Next()
+		if leaf == (runtime.Frame{}) {
+			continue
 		}
 
-		traces = append(traces, StackFrame{
-			Filename:  frame.File,
-			LineNo:    frame.Line,
-			Function:  frame.Function,
-			InApp:     d.InAppDecider(frame),
-			Synthetic: false,
-			Platform:  "go",
-		})
-		if !hasMore {
-			break
+		group := []runtime.Frame{leaf}
+		anchored := leaf.Func != nil
+		if leaf.Func == nil && leaf.Entry != 0 {
+			for i < stackCallCount {
+				parent, _ := runtime.CallersFrames([]uintptr{pcs[i]}).Next()
+				if parent == (runtime.Frame{}) || parent.Entry != leaf.Entry {
+					break
+				}
+				i++
+				group = append(group, parent)
+				if parent.Func != nil {
+					anchored = true
+					break
+				}
+			}
+		}
+
+		covered := image.ok && uint64(leafPC) >= image.base && uint64(leafPC) < image.end
+		if !covered || !anchored {
+			// No resolvable image for this address (or the pcs buffer cut the
+			// group off from its physical frame): plain Go frames, the
+			// pre-native wire shape.
+			for _, frame := range group {
+				traces = append(traces, StackFrame{
+					Filename:  frame.File,
+					LineNo:    frame.Line,
+					Function:  frame.Function,
+					InApp:     d.InAppDecider(frame),
+					Synthetic: false,
+					Platform:  "go",
+				})
+			}
+			continue
+		}
+
+		// Client-expanded inline group. Every layer carries the group's raw
+		// leaf address: the entry whose address the server expands to the
+		// whole chain, with the server subtracting one to target the call
+		// instruction (frame.PC is already adjusted, so sending it would
+		// shift that lookup one instruction too far). The physical anchor is
+		// the group's lead; the synthesized layers are marked inline.
+		for idx, frame := range group {
+			isAnchor := idx == len(group)-1
+			stackFrame := StackFrame{
+				Filename:        frame.File,
+				LineNo:          frame.Line,
+				Function:        frame.Function,
+				InApp:           d.InAppDecider(frame),
+				Synthetic:       false,
+				Platform:        "native",
+				Lang:            "go",
+				ClientResolved:  true,
+				Inline:          !isAnchor,
+				InstructionAddr: fmt.Sprintf("0x%x", uint64(leafPC)),
+				ImageAddr:       image.image.ImageAddr,
+			}
+			if frame.Entry != 0 {
+				stackFrame.SymbolAddr = fmt.Sprintf("0x%x", uint64(frame.Entry))
+			}
+			traces = append(traces, stackFrame)
 		}
 	}
 
-	// runtime.CallersFrames yields innermost first; reverse to the canonical
-	// wire order shared across PostHog SDKs (matching NativeStackTraceExtractor):
-	// outermost (entry point) first, capture site last.
+	// The runtime yields innermost first; reverse to the canonical wire order
+	// shared across PostHog SDKs: outermost (entry point) first, capture site
+	// last. The reversal also puts each group's physical frame ahead of its
+	// inline members, the order the server-side group contract expects.
 	for i, j := 0, len(traces)-1; i < j; i, j = i+1, j-1 {
 		traces[i], traces[j] = traces[j], traces[i]
 	}
@@ -88,4 +159,14 @@ func (d DefaultStackTraceExtractor) GetStackTrace(skip int) *ExceptionStacktrace
 		Type:   "raw",
 		Frames: traces,
 	}
+}
+
+// GetDebugImages returns the debug images referenced by captured frames —
+// currently the main executable, when its identity could be determined.
+func (d DefaultStackTraceExtractor) GetDebugImages() []DebugImage {
+	image := mainImageFn()
+	if !image.ok {
+		return nil
+	}
+	return []DebugImage{image.image}
 }

--- a/error_tracking_stack_trace.go
+++ b/error_tracking_stack_trace.go
@@ -79,14 +79,27 @@ func (d DefaultStackTraceExtractor) GetStackTrace(skip int) *ExceptionStacktrace
 		// of the physical function separate.
 		leafPC := pcs[i]
 		i++
-		leaf, _ := runtime.CallersFrames([]uintptr{leafPC}).Next()
+		expanded := runtime.CallersFrames([]uintptr{leafPC})
+		leaf, more := expanded.Next()
 		if leaf == (runtime.Frame{}) {
 			continue
 		}
 
 		group := []runtime.Frame{leaf}
+		// A single pc can expand to several frames: a cgo traceback
+		// symbolizer (runtime.SetCgoTraceback) reports inlined C frames this
+		// way. Drain them all; they stay unanchored (Entry 0) and fall through
+		// to the plain emission below.
+		for more {
+			var frame runtime.Frame
+			frame, more = expanded.Next()
+			if frame == (runtime.Frame{}) {
+				break
+			}
+			group = append(group, frame)
+		}
 		anchored := leaf.Func != nil
-		if leaf.Func == nil && leaf.Entry != 0 {
+		if len(group) == 1 && leaf.Func == nil && leaf.Entry != 0 {
 			for i < stackCallCount {
 				parent, _ := runtime.CallersFrames([]uintptr{pcs[i]}).Next()
 				if parent == (runtime.Frame{}) || parent.Entry != leaf.Entry {

--- a/error_tracking_stack_trace_test.go
+++ b/error_tracking_stack_trace_test.go
@@ -2,7 +2,9 @@ package posthog
 
 import (
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -220,5 +222,101 @@ func TestDefaultStackTraceExtractor_CanonicalWireOrder(t *testing.T) {
 
 	if got := traces.Frames[len(traces.Frames)-1].Function; got != "runtime.Callers" {
 		t.Errorf("last frame should be the innermost capture site: got=%q want=%q", got, "runtime.Callers")
+	}
+}
+
+//go:noinline
+func groupedCapture(ex DefaultStackTraceExtractor) *ExceptionStacktrace {
+	return ex.GetStackTrace(0)
+}
+
+// groupedLeaf is cheap enough for the compiler to inline into its caller; the
+// runtime then synthesizes a separate pcs entry for it within groupedParent's
+// physical frame, which the extractor must emit as one marked inline group.
+func groupedLeaf(ex DefaultStackTraceExtractor, value int) (*ExceptionStacktrace, int) {
+	st := groupedCapture(ex)
+	return st, value * 2
+}
+
+//go:noinline
+func groupedParent(ex DefaultStackTraceExtractor, value int) *ExceptionStacktrace {
+	st, _ := groupedLeaf(ex, value)
+	return st
+}
+
+func TestDefaultStackTraceExtractor_GroupedInlineFrames(t *testing.T) {
+	stubMainImage(t, coveringImage())
+	extractor := DefaultStackTraceExtractor{InAppDecider: SimpleInAppDecider}
+
+	frames := groupedParent(extractor, len(t.Name())).Frames
+
+	var leaf, parent *StackFrame
+	for i := range frames {
+		if strings.Contains(frames[i].Function, "groupedLeaf") {
+			leaf = &frames[i]
+		}
+		if strings.Contains(frames[i].Function, "groupedParent") {
+			parent = &frames[i]
+		}
+	}
+	if leaf == nil || parent == nil {
+		t.Fatal("expected both groupedLeaf and groupedParent frames on the wire")
+	}
+	if parent.InstructionAddr != leaf.InstructionAddr {
+		t.Skip("groupedLeaf was not inlined by this toolchain")
+	}
+
+	// The inlined call is preserved as a group member: it carries the physical
+	// frame's raw address and the inline marker, while the physical frame leads
+	// the group unmarked (canonical order puts the lead before its members).
+	if !leaf.Inline {
+		t.Error("inlined frame should carry the inline marker")
+	}
+	if parent.Inline {
+		t.Error("the physical frame anchoring the group must not be marked inline")
+	}
+	for i := range frames {
+		if &frames[i] == parent && (i+1 >= len(frames) || &frames[i+1] != leaf) {
+			t.Error("group lead should immediately precede its inline member on the wire")
+		}
+	}
+	for name, frame := range map[string]*StackFrame{"leaf": leaf, "parent": parent} {
+		if frame.Platform != "native" || frame.Lang != "go" || !frame.ClientResolved {
+			t.Errorf("%s frame not marked as client-resolved native: %+v", name, frame)
+		}
+		if frame.ImageAddr != coveringImage().image.ImageAddr {
+			t.Errorf("%s frame ImageAddr = %q", name, frame.ImageAddr)
+		}
+	}
+
+	hexAddr := regexp.MustCompile(`^0x[0-9a-f]+$`)
+	for i, frame := range frames {
+		if !hexAddr.MatchString(frame.InstructionAddr) {
+			t.Errorf("frame[%d].InstructionAddr = %q, want hex", i, frame.InstructionAddr)
+		}
+	}
+}
+
+// Without a resolvable image, output must keep the plain pre-native shape:
+// no addresses, no markers, platform "go".
+func TestDefaultStackTraceExtractor_PlainFramesWithoutImage(t *testing.T) {
+	stubMainImage(t, mainImageInfo{})
+	extractor := DefaultStackTraceExtractor{InAppDecider: SimpleInAppDecider}
+
+	frames := groupedParent(extractor, len(t.Name())).Frames
+	if len(frames) == 0 {
+		t.Fatal("expected frames")
+	}
+	for i, frame := range frames {
+		if frame.Platform != "go" {
+			t.Errorf("frame[%d].Platform = %q, want go", i, frame.Platform)
+		}
+		if frame.Lang != "" || frame.InstructionAddr != "" || frame.SymbolAddr != "" ||
+			frame.ImageAddr != "" || frame.ClientResolved || frame.Inline {
+			t.Errorf("frame[%d] carries native fields without an image: %+v", i, frame)
+		}
+	}
+	if extractor.GetDebugImages() != nil {
+		t.Error("expected no debug images without a resolvable image")
 	}
 }

--- a/message.go
+++ b/message.go
@@ -32,7 +32,8 @@ type Callback interface {
 //
 // The SDK passes an isolated copy of SDK-owned mutable fields where practical:
 // Properties and Groups clone common JSON-like maps and slices, and Exception
-// clones its exception list, stack traces, mechanisms, and fingerprint. Arbitrary
+// clones its exception list, stack traces, mechanisms, fingerprint, and debug
+// images. Arbitrary
 // reference values stored inside Properties or Groups (for example, pointers or
 // custom mutable structs held as interface{} values) are not deep-cloned and can
 // still share state with the caller.

--- a/posthog.go
+++ b/posthog.go
@@ -466,6 +466,10 @@ func isolateBeforeSendMessage(msg Message) Message {
 		m.Properties = cloneMessageProperties(m.Properties)
 		m.ExceptionList = cloneExceptionList(m.ExceptionList)
 		m.ExceptionFingerprint = cloneExceptionFingerprint(m.ExceptionFingerprint)
+		// DebugImage is a flat value struct, so copying the slice is a deep clone.
+		if m.DebugImages != nil {
+			m.DebugImages = append([]DebugImage(nil), m.DebugImages...)
+		}
 		return m
 	}
 	return msg

--- a/request_context.go
+++ b/request_context.go
@@ -456,6 +456,7 @@ func capturePanic(ctx context.Context, client EnqueueClient, panicValue interfac
 		statusCode = http.StatusInternalServerError
 	}
 
+	stacktrace, debugImages := stackTraceFromDebugStack(panicStack)
 	exception := Exception{
 		Properties: NewProperties().
 			Set(propertyResponseStatusCode, statusCode).
@@ -463,23 +464,27 @@ func capturePanic(ctx context.Context, client EnqueueClient, panicValue interfac
 		ExceptionList: []ExceptionItem{{
 			Type:       "panic",
 			Value:      fmt.Sprint(panicValue),
-			Stacktrace: stackTraceFromDebugStack(panicStack),
+			Stacktrace: stacktrace,
 		}},
+		DebugImages: debugImages,
 	}
 
 	_ = enqueueWithContext(ctx, client, exception)
 }
 
-func stackTraceFromDebugStack(stack []byte) *ExceptionStacktrace {
+func stackTraceFromDebugStack(stack []byte) (*ExceptionStacktrace, []DebugImage) {
 	frames := parseDebugStackFrames(stack)
 	if len(frames) == 0 {
-		return DefaultStackTraceExtractor{InAppDecider: SimpleInAppDecider}.GetStackTrace(4)
+		// The extractor fallback can emit "native" frames, which need the
+		// referenced debug images alongside them.
+		extractor := DefaultStackTraceExtractor{InAppDecider: SimpleInAppDecider}
+		return extractor.GetStackTrace(4), extractor.GetDebugImages()
 	}
 
 	return &ExceptionStacktrace{
 		Type:   "raw",
 		Frames: frames,
-	}
+	}, nil
 }
 
 func parseDebugStackFrames(stack []byte) []StackFrame {


### PR DESCRIPTION
## Problem

Go error tracking sends only runtime-resolved frames: no raw addresses, no debug image identity. PostHog can't re-symbolicate against uploaded symbols, so stacks miss exact inline expansion and source context, and stripped/obfuscated builds are stuck with whatever the runtime reports.

The rest of the native stack already speaks the grouped inline-frame contract (PostHog/posthog#67689, PostHog/posthog#67690, PostHog/posthog-rs#171): the client sends each physical frame plus the calls inlined into it as one group sharing a raw `instruction_addr`, with the synthesized layers marked `inline: true` and everything `client_resolved: true`. The server resolves the group address once and atomically replaces the group with its own expansion, or keeps the client frames verbatim when no symbols are uploaded.

## Changes

Folds the contract into `DefaultStackTraceExtractor` — no separate native extractor (a previous attempt in #219 added one; that branch's image-discovery code is reused here).

- `GetStackTrace` groups the pcs `runtime.Callers` synthesizes for inlined calls with their physical frame (matched by `Func != nil` anchor sharing the same `Entry`, so cgo frames and recursion stay separate) and emits them as `platform: "native"` frames sharing the group's raw leaf pc. Raw pcs are sent, not `frame.PC`, since the server subtracts 1 to target the call instruction.
- Executable identity: GNU build id on Linux (`elf` image; note Go only embeds one with `-ldflags=-B gobuildid` or similar), `LC_UUID` on macOS (`macho` image, universal/fat binaries supported), sent as `$debug_images`. New `DebugImage` type + `DebugImageProvider` interface; the slog handler attaches images when its extractor provides them.
- Degradation: when the executable can't be identified or a group has no physical anchor, frames keep today's exact plain shape (`platform: "go"`, no addresses, no markers).
- Frames stay in the canonical wire order introduced by #254 (now merged; this PR is rebased on main); reversal keeps each group's physical frame ahead of its inline members, as the server contract expects.

## Rollout

- #254 is merged but unreleased — this should ship in the **same minor release (1.20.0)**, which cymbal's per-`$lib_version` wire-order cutoff pins in PostHog/posthog#71365.
- Server side is already live: cymbal resolves marked groups for any `$lib`. Backends predating grouped support resolve group members independently and duplicate inline expansions when symbols are uploaded (noted in the changeset).

## Tests

- Grouped emission with a stubbed image (`mainImageFn` seam): inlined leaf + physical parent both on the wire, member marked `inline`, shared `instruction_addr`, lead first; plain-shape regression test with no image; real-inlining helpers guarded by an addr-equality skip for toolchain variance.
- Debug image discovery: GNU build-id → debug-id vector (verified against symbolic's `ElfObject::debug_id`), universal Mach-O slice selection (hermetic fat wrapper around the test binary), real-binary image/extent invariants, `$debug_images` in the APIfy payload, slog handler attachment.
- `go test -race ./...` green locally (darwin/arm64); `CGO_ENABLED=0` cross-builds for linux and windows pass.

