### PR TITLE
ci: clean up workflow warnings

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -16,4 +16,8 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
+        # The central .github reusable workflow does not declare workflow_call.secrets,
+        # so explicit secret mapping makes GitHub reject this caller at startup.
+        # It gates fork/Dependabot PRs before using secrets; keep this scoped call
+        # as an intentional exception to the broad-inheritance Semgrep rule.
         secrets: inherit # nosemgrep

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -11,13 +11,11 @@ permissions: {}
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@69336b569d22687f8982eea6ff7d450a885cda05
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@95c20087fda2dc10fbbbcc3f1ef32b7bae779339
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        # The central .github reusable workflow does not declare workflow_call.secrets,
-        # so explicit secret mapping makes GitHub reject this caller at startup.
-        # It gates fork/Dependabot PRs before using secrets; keep this scoped call
-        # as an intentional exception to the broad-inheritance Semgrep rule.
-        secrets: inherit # nosemgrep
+        secrets:
+            PROJECT_BOARD_BOT_APP_ID: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
+            PROJECT_BOARD_BOT_PRIVATE_KEY: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -16,6 +16,4 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets:
-            PROJECT_BOARD_BOT_APP_ID: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
-            PROJECT_BOARD_BOT_PRIVATE_KEY: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
+        secrets: inherit # nosemgrep

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -19,13 +19,13 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-latest
     steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go 1.21
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.21
-
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check formatting
         run: |
@@ -36,13 +36,13 @@ jobs:
     name: Check go.mod is tidy
     runs-on: ubuntu-latest
     steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go 1.21
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.21
-
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check go.mod/go.sum
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          REJECTION_EMOJI: 🚫
         run: |
           RESPONSE=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/approvals")
           REJECTED=$(echo "$RESPONSE" | jq '[.[] | select(.state == "rejected")] | length')
@@ -196,11 +197,11 @@ jobs:
             if [ -n "$COMMENT" ]; then
               {
                 echo 'message<<EOF'
-                echo "🚫 Release was rejected: $COMMENT"
+                echo "$REJECTION_EMOJI Release was rejected: $COMMENT"
                 echo 'EOF'
               } >> "$GITHUB_OUTPUT"
             else
-              echo "message=🚫 Release was rejected." >> "$GITHUB_OUTPUT"
+              echo "message=$REJECTION_EMOJI Release was rejected." >> "$GITHUB_OUTPUT"
             fi
           else
             echo "was_rejected=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,9 +14,8 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests (capture v0)
-    # Pinned to the 0.10.0 release commit of the reusable workflow + harness
-    # image version so v0/v1 runs are reproducible.
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
+    # Keep the harness image version pinned separately so v0/v1 runs are reproducible.
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@eea2a62aa490b1bfa2e2b3488fc0042b89cfa5ed
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
@@ -25,7 +24,7 @@ jobs:
 
   compliance-v1:
     name: PostHog SDK compliance tests (capture v1)
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@eea2a62aa490b1bfa2e2b3488fc0042b89cfa5ed
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile.v1"
       adapter-context: "."

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,13 +24,13 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build
         run: go build .
@@ -39,13 +39,13 @@ jobs:
     name: Public API
     runs-on: ubuntu-latest
     steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.21'
-
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check public API snapshot
         run: make api-diff
@@ -59,16 +59,17 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Test
-        run: go test -v -count=1 -timeout=5m -coverprofile=coverage.out ./...
+        # Go 1.21 test binaries need an explicit GNU build ID for debug-image coverage.
+        run: go test -count=1 -timeout=5m -ldflags='-B 0x555398ebd01c9028' ./...
 
   race:
     name: Race tests (Go ${{ matrix.go-version }})
@@ -79,16 +80,17 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Race tests
-        run: go test -v -race -count=1 -timeout=5m ./...
+        # Go 1.21 test binaries need an explicit GNU build ID for debug-image coverage.
+        run: go test -race -count=1 -timeout=5m -ldflags='-B 0x555398ebd01c9028' ./...
 
   vet:
     name: Go vet (Go ${{ matrix.go-version }})
@@ -99,13 +101,13 @@ jobs:
         # Test the minimum supported Go version from go.mod and the latest stable Go 1 release.
         go-version: ['1.21', '1.x']
     steps:
+      - name: Check out source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Check out source code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Vet
         run: go vet ./...

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -68,8 +68,17 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Test
-        # Go 1.21 test binaries need an explicit GNU build ID for debug-image coverage.
-        run: go test -count=1 -timeout=5m -ldflags='-B 0x555398ebd01c9028' ./...
+        run: go test -count=1 -timeout=5m ./...
+
+      - name: Test debug-image discovery
+        if: matrix.go-version == '1.21'
+        env:
+          BUILD_ID_SEED: ${{ github.sha }}-${{ github.job }}-${{ matrix.go-version }}
+        run: |
+          build_id=$(printf '%s' "$BUILD_ID_SEED" | sha256sum | cut -c1-16)
+          output=$(go test -v -count=1 -timeout=1m -run '^TestRealDebugImages$' -ldflags="-B 0x${build_id}" .)
+          printf '%s\n' "$output"
+          printf '%s\n' "$output" | grep -q -- '--- PASS: TestRealDebugImages'
 
   race:
     name: Race tests (Go ${{ matrix.go-version }})
@@ -89,8 +98,17 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Race tests
-        # Go 1.21 test binaries need an explicit GNU build ID for debug-image coverage.
-        run: go test -race -count=1 -timeout=5m -ldflags='-B 0x555398ebd01c9028' ./...
+        run: go test -race -count=1 -timeout=5m ./...
+
+      - name: Race-test debug-image discovery
+        if: matrix.go-version == '1.21'
+        env:
+          BUILD_ID_SEED: ${{ github.sha }}-${{ github.job }}-${{ matrix.go-version }}
+        run: |
+          build_id=$(printf '%s' "$BUILD_ID_SEED" | sha256sum | cut -c1-16)
+          output=$(go test -v -race -count=1 -timeout=1m -run '^TestRealDebugImages$' -ldflags="-B 0x${build_id}" .)
+          printf '%s\n' "$output"
+          printf '%s\n' "$output" | grep -q -- '--- PASS: TestRealDebugImages'
 
   vet:
     name: Go vet (Go ${{ matrix.go-version }})


### PR DESCRIPTION
## :bulb: Motivation and Context

The PR #260 CI logs exposed several avoidable warnings and gaps: `setup-go` could not find `go.mod` when restoring caches, reusable workflows used deprecated inputs and Node runtimes, Semgrep partially parsed the release workflow, successful tests produced excessive failure-path logging, and the real debug-image integration test skipped on Go 1.21.

This change:

- checks out the repository before `setup-go` so dependency caching can resolve `go.sum`;
- updates the pinned SDK compliance workflow for Node 24-compatible actions and explicit concurrency;
- updates the project-board workflow so its token action uses `client-id`, while retaining the caller's existing `secrets: inherit` behavior;
- moves the rejection emoji outside the shell block so Semgrep parses the complete release workflow;
- removes verbose test output and unused coverage profiles; and
- adds focused Go 1.21 debug-image checks whose single test binaries receive unique GNU build IDs.

## :green_heart: How did you test it?

- `actionlint .github/workflows/*.yml .github/workflows/*.yaml`
- Full organization Semgrep configuration with Semgrep 1.163.0: 14 files, 73 rules, 100% parsed, zero findings/errors
- Focused `p/github-actions` scan of `release.yml`: 100% parsed, zero findings
- Go 1.26.4: tests, race tests, build, vet, formatting, and public API snapshot
- Go 1.21.13 on Linux/amd64: tests, race tests, build, vet, and tidy
- Confirmed the focused normal and race `TestRealDebugImages` checks pass rather than skip under Go 1.21
- Autoreview: clean, with no actionable findings

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent, using scout, reviewer, and autoreview passes for investigation and independent review. Validation used Docker, Go, actionlint, and Semgrep. The changes were kept CI-only, so no SDK changeset was added.
