### PR TITLE
feat: support starts_with and ends_with operators in local evaluation

### DIFF
--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -351,9 +351,26 @@ func TestMatchPropertyStartsWith(t *testing.T) {
 		require.True(t, isMatch, "expected %v to match", val)
 	}
 
-	_, err = matchProperty(property, NewProperties().Set("key2", "value"))
+	// The negated operator is the exact inverse across numeric values too.
+	negatedNumericProperty := FlagProperty{
+		Key:      "key",
+		Value:    "3",
+		Operator: "not_starts_with",
+	}
+
+	isMatch, err = matchProperty(negatedNumericProperty, NewProperties().Set("key", 323))
+	require.NoError(t, err)
+	require.False(t, isMatch)
+
+	isMatch, err = matchProperty(negatedNumericProperty, NewProperties().Set("key", 123))
+	require.NoError(t, err)
+	require.True(t, isMatch)
+
 	var inconclusiveErr *InconclusiveMatchError
-	require.ErrorAs(t, err, &inconclusiveErr)
+	for _, missing := range []Properties{NewProperties().Set("key2", "value"), NewProperties()} {
+		_, err = matchProperty(property, missing)
+		require.ErrorAs(t, err, &inconclusiveErr)
+	}
 }
 
 func TestMatchPropertyEndsWith(t *testing.T) {
@@ -412,9 +429,30 @@ func TestMatchPropertyEndsWith(t *testing.T) {
 		require.True(t, isMatch, "expected %v to match", val)
 	}
 
-	_, err := matchProperty(property, NewProperties().Set("key2", "value"))
+	// The negated operator is the exact inverse across numeric values too.
+	negatedNumericProperty := FlagProperty{
+		Key:      "key",
+		Value:    "3",
+		Operator: "not_ends_with",
+	}
+
+	for _, val := range []interface{}{323, 13, "3"} {
+		isMatch, err := matchProperty(negatedNumericProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.False(t, isMatch, "expected %v not to match", val)
+	}
+
+	for _, val := range []interface{}{321, "3val"} {
+		isMatch, err := matchProperty(negatedNumericProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.True(t, isMatch, "expected %v to match", val)
+	}
+
 	var inconclusiveErr *InconclusiveMatchError
-	require.ErrorAs(t, err, &inconclusiveErr)
+	for _, missing := range []Properties{NewProperties().Set("key2", "value"), NewProperties()} {
+		_, err := matchProperty(property, missing)
+		require.ErrorAs(t, err, &inconclusiveErr)
+	}
 }
 
 func TestMatchPropertyDateComparison(t *testing.T) {

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -299,6 +299,124 @@ func TestMatchPropertyContains(t *testing.T) {
 	}
 }
 
+func TestMatchPropertyStartsWith(t *testing.T) {
+	property := FlagProperty{
+		Key:      "key",
+		Value:    "Val",
+		Operator: "starts_with",
+	}
+
+	for _, val := range []interface{}{"value", "VALUE", "vaLue4"} {
+		isMatch, err := matchProperty(property, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.True(t, isMatch, "expected %v to match", val)
+	}
+
+	for _, val := range []interface{}{"prevalue", "Alakazam", 123} {
+		isMatch, err := matchProperty(property, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.False(t, isMatch, "expected %v not to match", val)
+	}
+
+	// Numeric property values are stringified before matching.
+	numericProperty := FlagProperty{
+		Key:      "key",
+		Value:    "3",
+		Operator: "starts_with",
+	}
+
+	isMatch, err := matchProperty(numericProperty, NewProperties().Set("key", 323))
+	require.NoError(t, err)
+	require.True(t, isMatch)
+
+	isMatch, err = matchProperty(numericProperty, NewProperties().Set("key", 123))
+	require.NoError(t, err)
+	require.False(t, isMatch)
+
+	negatedProperty := FlagProperty{
+		Key:      "key",
+		Value:    "Val",
+		Operator: "not_starts_with",
+	}
+
+	for _, val := range []interface{}{"value", "VALUE"} {
+		isMatch, err := matchProperty(negatedProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.False(t, isMatch, "expected %v not to match", val)
+	}
+
+	for _, val := range []interface{}{"prevalue", "Alakazam"} {
+		isMatch, err := matchProperty(negatedProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.True(t, isMatch, "expected %v to match", val)
+	}
+
+	_, err = matchProperty(property, NewProperties().Set("key2", "value"))
+	var inconclusiveErr *InconclusiveMatchError
+	require.ErrorAs(t, err, &inconclusiveErr)
+}
+
+func TestMatchPropertyEndsWith(t *testing.T) {
+	property := FlagProperty{
+		Key:      "key",
+		Value:    "lUe",
+		Operator: "ends_with",
+	}
+
+	for _, val := range []interface{}{"value", "VALUE", "343tfvalue"} {
+		isMatch, err := matchProperty(property, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.True(t, isMatch, "expected %v to match", val)
+	}
+
+	for _, val := range []interface{}{"value2", "Alakazam", 123} {
+		isMatch, err := matchProperty(property, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.False(t, isMatch, "expected %v not to match", val)
+	}
+
+	// Numeric property values are stringified before matching.
+	numericProperty := FlagProperty{
+		Key:      "key",
+		Value:    "3",
+		Operator: "ends_with",
+	}
+
+	for _, val := range []interface{}{323, 13, "3"} {
+		isMatch, err := matchProperty(numericProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.True(t, isMatch, "expected %v to match", val)
+	}
+
+	for _, val := range []interface{}{321, "3val"} {
+		isMatch, err := matchProperty(numericProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.False(t, isMatch, "expected %v not to match", val)
+	}
+
+	negatedProperty := FlagProperty{
+		Key:      "key",
+		Value:    "lUe",
+		Operator: "not_ends_with",
+	}
+
+	for _, val := range []interface{}{"value", "VALUE"} {
+		isMatch, err := matchProperty(negatedProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.False(t, isMatch, "expected %v not to match", val)
+	}
+
+	for _, val := range []interface{}{"value2", "Alakazam"} {
+		isMatch, err := matchProperty(negatedProperty, NewProperties().Set("key", val))
+		require.NoError(t, err)
+		require.True(t, isMatch, "expected %v to match", val)
+	}
+
+	_, err := matchProperty(property, NewProperties().Set("key2", "value"))
+	var inconclusiveErr *InconclusiveMatchError
+	require.ErrorAs(t, err, &inconclusiveErr)
+}
+
 func TestMatchPropertyDateComparison(t *testing.T) {
 	t.Run("RFC3339 dates", func(t *testing.T) {
 		// Test is_date_before

--- a/featureflags.go
+++ b/featureflags.go
@@ -1376,6 +1376,22 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 		return !strings.Contains(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
 	}
 
+	if operator == "starts_with" {
+		return strings.HasPrefix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+	}
+
+	if operator == "not_starts_with" {
+		return !strings.HasPrefix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+	}
+
+	if operator == "ends_with" {
+		return strings.HasSuffix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+	}
+
+	if operator == "not_ends_with" {
+		return !strings.HasSuffix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+	}
+
 	if operator == "regex" {
 		r, err := getOrCompileRegex(valueToString(value))
 		// invalid regex


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog/posthog#72992 added four case-insensitive property filter operators — `starts_with`, `not_starts_with`, `ends_with`, `not_ends_with` — across HogQL, the flags service, and the UI. The UI surface is gated behind a feature flag until server-side SDKs can evaluate these operators locally; on SDK versions without support, flags using them fall back to remote evaluation.

This adds local evaluation support for the four operators, mirroring `icontains`: both sides are stringified and lowercased, and the `not_` variants are exact negations. Filter values are single strings — server-side validation rejects list values for these operators, matching the flags service behavior.

## :green_heart: How did you test it?

New unit tests mirror the flags service's own test matrix for these operators: case-insensitive anchored matching, mid-string non-matches (`prevalue` does not match `starts_with: "Val"`), numeric stringification (`323` matches `starts_with: "3"`, `123` does not), negation inverses, and missing-key inconclusive behavior.

`go test -run TestMatchProperty .` passes locally (including the new `TestMatchPropertyStartsWith` and `TestMatchPropertyEndsWith`); `gofmt` and `go vet` are clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a changeset file (minor)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
