### PR TITLE
feat(mcp): add canonical MCP tool-call events

### DIFF
--- a/.changeset/mcp-tool-events.md
+++ b/.changeset/mcp-tool-events.md
@@ -1,0 +1,6 @@
+---
+"posthog-go": minor
+---
+
+Add framework-independent MCP tool-call analytics with payload sanitization,
+bounded event sizes, identity mapping, and optional exception fan-out.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -925,3 +925,65 @@ type Variants struct {
 package extras // import "github.com/posthog/posthog-go/extras"
 
 
+## github.com/posthog/posthog-go/mcp
+
+package mcp // import "github.com/posthog/posthog-go/mcp"
+
+Package mcp builds and enqueues canonical PostHog analytics events for Model
+Context Protocol activity without depending on a particular MCP framework.
+
+Applications own the PostHog client lifecycle and pass completed tool calls to
+Analytics. Tool parameters, responses, intent, and error messages are sanitized
+and bounded before they are queued.
+
+TYPES
+
+type Analytics struct {
+}
+
+func New(client posthog.EnqueueClient, opts ...Option) *Analytics
+
+func (a *Analytics) CaptureToolCall(call ToolCall) error
+
+type IntentSource string
+
+const (
+	IntentSourceContextParameter IntentSource = "context_parameter"
+	IntentSourceInferred IntentSource = "inferred"
+)
+type Option func(*config)
+
+func WithExceptionAutocapture(enabled bool) Option
+
+type ToolCall struct {
+	ToolName        string
+	ToolDescription string
+	ToolCategory    string
+
+	DistinctID    string
+	SessionID     string
+	Groups        posthog.Groups
+	SetProperties posthog.Properties
+
+	ServerName      string
+	ServerVersion   string
+	ClientName      string
+	ClientVersion   string
+	ProtocolVersion string
+
+	Intent       string
+	IntentSource IntentSource
+
+	Parameters any
+	Response   any
+
+	Duration  time.Duration
+	IsError   bool
+	Error     error
+	ErrorType string
+
+	Properties posthog.Properties
+	Timestamp  time.Time
+}
+
+

--- a/mcp/THIRD_PARTY_NOTICES.md
+++ b/mcp/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,35 @@
+# Third-party notices
+
+The payload sanitization, recursive truncation, and event-size pruning in this
+package include portions adapted from the PostHog JavaScript MCP implementation
+at commit `57f371e540968afaa8a0fe9aec8a53ef1db6b654`. The corresponding PostHog
+source files state that they are derived from the AgentCat TypeScript SDK
+(formerly the MCPcat TypeScript SDK):
+
+- `packages/mcp/src/extensions/mcp-payloads.ts`
+- `packages/mcp/src/extensions/sanitization.ts`
+- `packages/mcp/src/extensions/truncation.ts`
+
+The AgentCat MIT license notice follows.
+
+MIT License
+
+Copyright (c) 2025 AgentCat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp/analytics.go
+++ b/mcp/analytics.go
@@ -1,0 +1,73 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+
+	posthog "github.com/posthog/posthog-go"
+)
+
+// Option configures Analytics.
+type Option func(*config)
+
+type config struct {
+	exceptionAutocapture bool
+}
+
+func defaultConfig() config {
+	return config{exceptionAutocapture: true}
+}
+
+// WithExceptionAutocapture controls whether failed tool calls also enqueue a
+// PostHog exception. It is enabled by default.
+func WithExceptionAutocapture(enabled bool) Option {
+	return func(cfg *config) {
+		cfg.exceptionAutocapture = enabled
+	}
+}
+
+// Analytics constructs and enqueues canonical PostHog MCP analytics events.
+// It does not own the lifecycle of the PostHog client.
+type Analytics struct {
+	client posthog.EnqueueClient
+	cfg    config
+}
+
+// New creates an MCP analytics recorder using client.
+func New(client posthog.EnqueueClient, opts ...Option) *Analytics {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return &Analytics{client: client, cfg: cfg}
+}
+
+// CaptureToolCall validates, transforms, and enqueues one completed MCP tool
+// call. When exception autocapture is enabled, all messages are built before
+// either is enqueued. Enqueue failures are joined after every configured
+// message has been attempted.
+func (a *Analytics) CaptureToolCall(call ToolCall) error {
+	if a == nil || a.client == nil {
+		return errors.New("posthogmcp: nil enqueue client")
+	}
+
+	messages, err := buildToolCallMessages(call, a.cfg.exceptionAutocapture)
+	if err != nil {
+		return err
+	}
+
+	var enqueueErrors []error
+	for _, message := range messages {
+		if err := a.client.Enqueue(message.message); err != nil {
+			enqueueErrors = append(enqueueErrors, fmt.Errorf("posthogmcp: enqueue %s: %w", message.name, err))
+		}
+	}
+	return errors.Join(enqueueErrors...)
+}
+
+type namedMessage struct {
+	name    string
+	message posthog.Message
+}

--- a/mcp/analytics_test.go
+++ b/mcp/analytics_test.go
@@ -1,0 +1,321 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	posthog "github.com/posthog/posthog-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEnqueueClient struct {
+	messages []posthog.Message
+	errors   []error
+}
+
+func (f *fakeEnqueueClient) Enqueue(message posthog.Message) error {
+	f.messages = append(f.messages, message)
+	index := len(f.messages) - 1
+	if index < len(f.errors) {
+		return f.errors[index]
+	}
+	return nil
+}
+
+func TestCaptureToolCallMinimal(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	analytics := New(client)
+
+	require.NoError(t, analytics.CaptureToolCall(ToolCall{ToolName: "search_docs"}))
+	require.Len(t, client.messages, 1)
+
+	capture := requireCapture(t, client.messages[0])
+	assert.Equal(t, "anonymous", capture.DistinctId)
+	assert.Equal(t, eventToolCall, capture.Event)
+	assert.Equal(t, analyticsSource, capture.Properties[propertySource])
+	assert.Equal(t, "search_docs", capture.Properties[propertyResourceName])
+	assert.Equal(t, "search_docs", capture.Properties[propertyToolName])
+	assert.Equal(t, float64(0), capture.Properties[propertyDurationMS])
+	assert.Equal(t, false, capture.Properties[propertyIsError])
+	assert.Equal(t, false, capture.Properties[propertyProcessProfile])
+	assert.NotContains(t, capture.Properties, propertySessionID)
+	assert.NotContains(t, capture.Properties, propertySet)
+	assert.Nil(t, capture.Groups)
+}
+
+func TestCaptureToolCallCompleteMappingAndPrecedence(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	analytics := New(client)
+	parameters := map[string]any{"query": "select 1"}
+	response := map[string]any{"rows": []any{1, 2}}
+	groups := posthog.Groups{"organization": "org_1"}
+	setProperties := posthog.Properties{"plan": "pro"}
+	custom := posthog.Properties{
+		propertyClientName:     "custom-client",
+		propertyGroups:         map[string]any{"organization": "wrong"},
+		propertySet:            map[string]any{"plan": "wrong"},
+		propertyProcessProfile: false,
+		"environment":          "test",
+	}
+
+	require.NoError(t, analytics.CaptureToolCall(ToolCall{
+		ToolName:        "query",
+		ToolDescription: "Run a query",
+		ToolCategory:    "Data",
+		DistinctID:      "user_1",
+		SessionID:       "session_1",
+		Groups:          groups,
+		SetProperties:   setProperties,
+		ServerName:      "server",
+		ServerVersion:   "1.0",
+		ClientName:      "client",
+		ClientVersion:   "2.0",
+		ProtocolVersion: "2026-07-28",
+		Intent:          "  inspect data  ",
+		Parameters:      parameters,
+		Response:        response,
+		Duration:        1500 * time.Microsecond,
+		Properties:      custom,
+	}))
+
+	capture := requireCapture(t, client.messages[0])
+	assert.Equal(t, "user_1", capture.DistinctId)
+	assert.Equal(t, float64(1.5), capture.Properties[propertyDurationMS])
+	assert.Equal(t, "custom-client", capture.Properties[propertyClientName])
+	assert.Equal(t, "inspect data", capture.Properties[propertyIntent])
+	assert.Equal(t, string(IntentSourceContextParameter), capture.Properties[propertyIntentSource])
+	assert.Equal(t, posthog.Groups{"organization": "org_1"}, capture.Groups)
+	assert.Equal(t, posthog.Groups{"organization": "org_1"}, capture.Properties[propertyGroups])
+	assert.Equal(t, posthog.Properties{"plan": "pro"}, capture.Properties[propertySet])
+	assert.NotContains(t, capture.Properties, propertyProcessProfile)
+	assert.Equal(t, "test", capture.Properties["environment"])
+
+	assert.Equal(t, map[string]any{"query": "select 1"}, parameters)
+	assert.Equal(t, map[string]any{"rows": []any{1, 2}}, response)
+	assert.Equal(t, posthog.Groups{"organization": "org_1"}, groups)
+	assert.Equal(t, posthog.Properties{"plan": "pro"}, setProperties)
+	assert.Equal(t, false, custom[propertyProcessProfile])
+}
+
+func TestCaptureToolCallSessionFallbackAndAnonymousSetSuppression(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		call       ToolCall
+		distinctID string
+		personless bool
+	}{
+		{
+			name:       "session fallback",
+			call:       ToolCall{ToolName: "tool", SessionID: "session_1", SetProperties: posthog.Properties{"email": "ignored"}},
+			distinctID: "session_1",
+			personless: true,
+		},
+		{
+			name:       "anonymous fallback",
+			call:       ToolCall{ToolName: "tool", SetProperties: posthog.Properties{"email": "ignored"}},
+			distinctID: "anonymous",
+			personless: true,
+		},
+		{
+			name:       "explicit identity",
+			call:       ToolCall{ToolName: "tool", DistinctID: "user_1"},
+			distinctID: "user_1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeEnqueueClient{}
+			require.NoError(t, New(client).CaptureToolCall(test.call))
+			capture := requireCapture(t, client.messages[0])
+			assert.Equal(t, test.distinctID, capture.DistinctId)
+			assert.NotContains(t, capture.Properties, propertySet)
+			if test.personless {
+				assert.Equal(t, false, capture.Properties[propertyProcessProfile])
+			} else {
+				assert.NotContains(t, capture.Properties, propertyProcessProfile)
+			}
+		})
+	}
+}
+
+func TestCaptureToolCallValidation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		call ToolCall
+		want string
+	}{
+		{name: "empty name", call: ToolCall{}, want: "ToolName"},
+		{name: "blank name", call: ToolCall{ToolName: "  \t"}, want: "ToolName"},
+		{name: "negative duration", call: ToolCall{ToolName: "tool", Duration: -1}, want: "Duration"},
+		{name: "invalid intent source", call: ToolCall{ToolName: "tool", IntentSource: "model"}, want: "IntentSource"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeEnqueueClient{}
+			err := New(client).CaptureToolCall(test.call)
+			require.ErrorContains(t, err, test.want)
+			assert.Empty(t, client.messages)
+		})
+	}
+
+	require.ErrorContains(t, (*Analytics)(nil).CaptureToolCall(ToolCall{ToolName: "tool"}), "nil enqueue client")
+	require.ErrorContains(t, New(nil).CaptureToolCall(ToolCall{ToolName: "tool"}), "nil enqueue client")
+}
+
+type panickingError struct{}
+
+func (panickingError) Error() string { panic("should not run") }
+
+func TestCaptureToolCallFailureAndException(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	token := "phc_abcdefghijklmnopqrstuvwxyz"
+	require.NoError(t, New(client).CaptureToolCall(ToolCall{
+		ToolName:   "query",
+		DistinctID: "user_1",
+		Groups:     posthog.Groups{"organization": "org_1"},
+		IsError:    true,
+		Error:      errors.New("request failed with " + token),
+		ErrorType:  "validation",
+	}))
+	require.Len(t, client.messages, 2)
+
+	capture := requireCapture(t, client.messages[0])
+	assert.Equal(t, true, capture.Properties[propertyIsError])
+	assert.Equal(t, "validation", capture.Properties[propertyErrorType])
+	assert.Equal(t, "request failed with [redacted]", capture.Properties[propertyErrorMessage])
+
+	exception := requireException(t, client.messages[1])
+	require.Len(t, exception.ExceptionList, 1)
+	item := exception.ExceptionList[0]
+	assert.Equal(t, "validation", item.Type)
+	assert.Equal(t, "request failed with [redacted]", item.Value)
+	require.NotNil(t, item.Mechanism)
+	assert.Equal(t, true, *item.Mechanism.Handled)
+	assert.Equal(t, true, *item.Mechanism.Synthetic)
+	assert.Nil(t, item.Stacktrace)
+	assert.Equal(t, posthog.Groups{"organization": "org_1"}, exception.Properties[propertyGroups])
+}
+
+func TestCaptureToolCallFailureDefaultsAndDisableFanout(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	require.NoError(t, New(client, WithExceptionAutocapture(false)).CaptureToolCall(ToolCall{
+		ToolName: "query",
+		IsError:  true,
+	}))
+	require.Len(t, client.messages, 1)
+	capture := requireCapture(t, client.messages[0])
+	assert.Equal(t, "Error", capture.Properties[propertyErrorType])
+	assert.Equal(t, "Tool query returned an error", capture.Properties[propertyErrorMessage])
+
+	client = &fakeEnqueueClient{}
+	require.NoError(t, New(client).CaptureToolCall(ToolCall{
+		ToolName: "query",
+		Error:    panickingError{},
+	}))
+	assert.Len(t, client.messages, 1, "successful calls must ignore Error")
+}
+
+func TestCaptureToolCallPanickingErrorFailsWithoutEnqueue(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	err := New(client).CaptureToolCall(ToolCall{ToolName: "query", IsError: true, Error: panickingError{}})
+	require.ErrorContains(t, err, "Error method panicked")
+	assert.Empty(t, client.messages)
+}
+
+func TestCaptureToolCallAttemptsAllEnqueues(t *testing.T) {
+	client := &fakeEnqueueClient{errors: []error{errors.New("capture full"), errors.New("exception full")}}
+	err := New(client).CaptureToolCall(ToolCall{ToolName: "query", IsError: true})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "enqueue $mcp_tool_call: capture full")
+	assert.ErrorContains(t, err, "enqueue $exception: exception full")
+	assert.Len(t, client.messages, 2)
+}
+
+func TestCaptureToolCallNormalizationErrorsAreSafe(t *testing.T) {
+	cycle := map[string]any{}
+	cycle["self"] = cycle
+	secret := strings.Repeat("do-not-return", 100)
+
+	for _, value := range []any{
+		func() {},
+		cycle,
+		map[string]any{"number": math.Inf(1), "secret": secret},
+		panickingJSON{},
+	} {
+		client := &fakeEnqueueClient{}
+		err := New(client).CaptureToolCall(ToolCall{ToolName: "query", Parameters: value})
+		require.Error(t, err)
+		assert.LessOrEqual(t, len(err.Error()), maxReturnedErrorBytes)
+		assert.NotContains(t, err.Error(), secret)
+		assert.Empty(t, client.messages)
+	}
+}
+
+type panickingJSON struct{}
+
+func (panickingJSON) MarshalJSON() ([]byte, error) { panic("secret payload") }
+
+func TestCaptureToolCallWireGolden(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	require.NoError(t, New(client, WithExceptionAutocapture(false)).CaptureToolCall(ToolCall{
+		ToolName:        "search_docs",
+		ToolDescription: "Search documentation",
+		ToolCategory:    "Docs",
+		DistinctID:      "user_1",
+		SessionID:       "session_1",
+		Groups:          posthog.Groups{"organization": "org_1"},
+		SetProperties:   posthog.Properties{"plan": "pro"},
+		ServerName:      "docs-server",
+		ServerVersion:   "1.0.0",
+		ClientName:      "test-client",
+		ClientVersion:   "2.0.0",
+		ProtocolVersion: "2026-07-28",
+		Intent:          "Find setup instructions",
+		IntentSource:    IntentSourceInferred,
+		Parameters:      map[string]any{"query": "setup"},
+		Response:        map[string]any{"content": []any{map[string]any{"type": "text", "text": "Found"}}},
+		Duration:        42 * time.Millisecond,
+		Properties:      posthog.Properties{"environment": "test"},
+		Timestamp:       time.Date(2026, 8, 2, 1, 2, 3, 0, time.UTC),
+	}))
+
+	actual := normalizedCaptureWire(t, requireCapture(t, client.messages[0]))
+	expected, err := os.ReadFile("testdata/tool_call.golden.json")
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expected), string(actual))
+}
+
+func normalizedCaptureWire(t *testing.T, capture posthog.Capture) []byte {
+	t.Helper()
+	data, err := json.Marshal(capture.APIfy())
+	require.NoError(t, err)
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(data, &wire))
+	delete(wire, "uuid")
+	delete(wire, "timestamp")
+	properties := wire["properties"].(map[string]any)
+	for _, key := range []string{"$lib", "$lib_version", "$go_version", "$os", "$os_version", "$os_distro", "$is_server"} {
+		delete(properties, key)
+	}
+	result, err := json.MarshalIndent(wire, "", "  ")
+	require.NoError(t, err)
+	return result
+}
+
+func requireCapture(t *testing.T, message posthog.Message) posthog.Capture {
+	t.Helper()
+	capture, ok := message.(posthog.Capture)
+	require.True(t, ok, "message type = %T", message)
+	return capture
+}
+
+func requireException(t *testing.T, message posthog.Message) posthog.Exception {
+	t.Helper()
+	exception, ok := message.(posthog.Exception)
+	require.True(t, ok, "message type = %T", message)
+	return exception
+}

--- a/mcp/constants.go
+++ b/mcp/constants.go
@@ -1,0 +1,49 @@
+package mcp
+
+const (
+	eventToolCall = "$mcp_tool_call"
+
+	propertySource          = "$mcp_source"
+	propertyResourceName    = "$mcp_resource_name"
+	propertyToolName        = "$mcp_tool_name"
+	propertyToolDescription = "$mcp_tool_description"
+	propertyToolCategory    = "$mcp_tool_category"
+	propertyDurationMS      = "$mcp_duration_ms"
+	propertyIsError         = "$mcp_is_error"
+	propertyParameters      = "$mcp_parameters"
+	propertyResponse        = "$mcp_response"
+	propertyErrorType       = "$mcp_error_type"
+	propertyErrorMessage    = "$mcp_error_message"
+	propertyIntent          = "$mcp_intent"
+	propertyIntentSource    = "$mcp_intent_source"
+	propertyServerName      = "$mcp_server_name"
+	propertyServerVersion   = "$mcp_server_version"
+	propertyClientName      = "$mcp_client_name"
+	propertyClientVersion   = "$mcp_client_version"
+	propertyProtocolVersion = "$mcp_protocol_version"
+	propertySessionID       = "$session_id"
+	propertyGroups          = "$groups"
+	propertySet             = "$set"
+	propertyProcessProfile  = "$process_person_profile"
+
+	analyticsSource = "posthog_mcp_analytics"
+)
+
+const (
+	maxDepth              = 10
+	maxBreadth            = 100
+	maxStringBytes        = 32_768
+	maxEventBytes         = 102_400
+	maxIntentBytes        = 2_048
+	maxErrorMessageBytes  = 2_048
+	maxResourceNameBytes  = 256
+	maxMetadataBytes      = 256
+	maxReturnedErrorBytes = 512
+	largeBinaryGateBytes  = 10_240
+)
+
+const (
+	redactedValue       = "[redacted]"
+	binaryRedactedValue = "[binary data redacted - not supported by PostHog MCP analytics]"
+	truncationSuffix    = "..."
+)

--- a/mcp/doc.go
+++ b/mcp/doc.go
@@ -1,0 +1,7 @@
+// Package mcp builds and enqueues canonical PostHog analytics events for Model
+// Context Protocol activity without depending on a particular MCP framework.
+//
+// Applications own the PostHog client lifecycle and pass completed tool calls
+// to Analytics. Tool parameters, responses, intent, and error messages are
+// sanitized and bounded before they are queued.
+package mcp

--- a/mcp/event.go
+++ b/mcp/event.go
@@ -1,0 +1,261 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	posthog "github.com/posthog/posthog-go"
+)
+
+type preparedToolCall struct {
+	call          ToolCall
+	distinctID    string
+	explicitID    bool
+	toolName      string
+	intent        string
+	intentSource  IntentSource
+	errorType     string
+	errorMessage  string
+	parameters    any
+	response      any
+	groups        posthog.Groups
+	setProperties posthog.Properties
+	custom        posthog.Properties
+}
+
+func buildToolCallMessages(call ToolCall, exceptionAutocapture bool) ([]namedMessage, error) {
+	prepared, err := prepareToolCall(call)
+	if err != nil {
+		return nil, err
+	}
+
+	capture, err := prepared.buildCapture()
+	if err != nil {
+		return nil, err
+	}
+	messages := []namedMessage{{name: eventToolCall, message: capture}}
+
+	if call.IsError && exceptionAutocapture {
+		exception, err := prepared.buildException()
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, namedMessage{name: "$exception", message: exception})
+	}
+	return messages, nil
+}
+
+func prepareToolCall(call ToolCall) (preparedToolCall, error) {
+	if strings.TrimSpace(call.ToolName) == "" {
+		return preparedToolCall{}, errors.New("posthogmcp: ToolName must not be blank")
+	}
+	if call.Duration < 0 {
+		return preparedToolCall{}, errors.New("posthogmcp: Duration must not be negative")
+	}
+	if call.IntentSource != "" &&
+		call.IntentSource != IntentSourceContextParameter &&
+		call.IntentSource != IntentSourceInferred {
+		return preparedToolCall{}, errors.New("posthogmcp: invalid IntentSource")
+	}
+
+	prepared := preparedToolCall{
+		call:       call,
+		explicitID: call.DistinctID != "",
+		toolName:   truncateUTF8(call.ToolName, maxResourceNameBytes),
+	}
+	switch {
+	case call.DistinctID != "":
+		prepared.distinctID = call.DistinctID
+	case call.SessionID != "":
+		prepared.distinctID = call.SessionID
+	default:
+		prepared.distinctID = "anonymous"
+	}
+
+	intent := strings.TrimSpace(call.Intent)
+	if intent != "" {
+		prepared.intent = truncateUTF8(sanitizeString(intent), maxIntentBytes)
+		prepared.intentSource = call.IntentSource
+		if prepared.intentSource == "" {
+			prepared.intentSource = IntentSourceContextParameter
+		}
+	}
+
+	var err error
+	prepared.parameters, err = prepareValue("Parameters", call.Parameters, false)
+	if err != nil {
+		return preparedToolCall{}, err
+	}
+	prepared.response, err = prepareValue("Response", call.Response, true)
+	if err != nil {
+		return preparedToolCall{}, err
+	}
+	prepared.groups, err = prepareGroups(call.Groups)
+	if err != nil {
+		return preparedToolCall{}, err
+	}
+	prepared.setProperties, err = prepareProperties("SetProperties", call.SetProperties)
+	if err != nil {
+		return preparedToolCall{}, err
+	}
+	prepared.custom, err = prepareProperties("Properties", call.Properties)
+	if err != nil {
+		return preparedToolCall{}, err
+	}
+	removeIdentityControlProperties(prepared.custom)
+
+	if call.IsError {
+		prepared.errorType = strings.TrimSpace(call.ErrorType)
+		if prepared.errorType == "" {
+			prepared.errorType = "Error"
+		}
+		prepared.errorType = truncateUTF8(prepared.errorType, maxMetadataBytes)
+
+		message := fmt.Sprintf("Tool %s returned an error", prepared.toolName)
+		if call.Error != nil {
+			message, err = safeErrorMessage(call.Error)
+			if err != nil {
+				return preparedToolCall{}, err
+			}
+		}
+		prepared.errorMessage = truncateUTF8(sanitizeString(message), maxErrorMessageBytes)
+	}
+
+	return prepared, nil
+}
+
+func prepareValue(field string, value any, response bool) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	normalized, err := normalizePayload(field, value)
+	if err != nil {
+		return nil, err
+	}
+	if response {
+		normalized = sanitizeResponse(normalized)
+	} else {
+		normalized = sanitizeCapturedValue(normalized)
+	}
+	return truncateValue(normalized), nil
+}
+
+func prepareProperties(field string, properties posthog.Properties) (posthog.Properties, error) {
+	if len(properties) == 0 {
+		return nil, nil
+	}
+	normalized, err := normalizePayload(field, properties)
+	if err != nil {
+		return nil, err
+	}
+	value, ok := truncateValue(sanitizeCapturedValue(normalized)).(map[string]any)
+	if !ok {
+		return nil, errors.New("posthogmcp: normalized properties must be an object")
+	}
+	return posthog.Properties(value), nil
+}
+
+func prepareGroups(groups posthog.Groups) (posthog.Groups, error) {
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	normalized, err := normalizePayload("Groups", groups)
+	if err != nil {
+		return nil, err
+	}
+	value, ok := truncateValue(sanitizeCapturedValue(normalized)).(map[string]any)
+	if !ok {
+		return nil, errors.New("posthogmcp: normalized groups must be an object")
+	}
+	return posthog.Groups(value), nil
+}
+
+func safeErrorMessage(err error) (message string, resultErr error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			message = ""
+			resultErr = errors.New("posthogmcp: Error method panicked")
+		}
+	}()
+	return err.Error(), nil
+}
+
+func removeIdentityControlProperties(properties posthog.Properties) {
+	delete(properties, propertyGroups)
+	delete(properties, propertySet)
+	delete(properties, propertyProcessProfile)
+}
+
+func (p preparedToolCall) baseProperties() posthog.Properties {
+	properties := posthog.NewProperties().
+		Set(propertySource, analyticsSource).
+		Set(propertyResourceName, p.toolName).
+		Set(propertyToolName, p.toolName).
+		Set(propertyDurationMS, float64(p.call.Duration)/float64(time.Millisecond)).
+		Set(propertyIsError, p.call.IsError)
+
+	setStringProperty(properties, propertyToolDescription, truncateUTF8(p.call.ToolDescription, maxStringBytes))
+	setStringProperty(properties, propertyToolCategory, truncateUTF8(p.call.ToolCategory, maxMetadataBytes))
+	setStringProperty(properties, propertySessionID, p.call.SessionID)
+	setStringProperty(properties, propertyServerName, truncateUTF8(p.call.ServerName, maxMetadataBytes))
+	setStringProperty(properties, propertyServerVersion, truncateUTF8(p.call.ServerVersion, maxMetadataBytes))
+	setStringProperty(properties, propertyClientName, truncateUTF8(p.call.ClientName, maxMetadataBytes))
+	setStringProperty(properties, propertyClientVersion, truncateUTF8(p.call.ClientVersion, maxMetadataBytes))
+	setStringProperty(properties, propertyProtocolVersion, truncateUTF8(p.call.ProtocolVersion, maxMetadataBytes))
+	setStringProperty(properties, propertyIntent, p.intent)
+	if p.intent != "" {
+		properties[propertyIntentSource] = string(p.intentSource)
+	}
+	if p.parameters != nil {
+		properties[propertyParameters] = p.parameters
+	}
+	if p.response != nil {
+		properties[propertyResponse] = p.response
+	}
+	if p.call.IsError {
+		properties[propertyErrorType] = p.errorType
+		properties[propertyErrorMessage] = p.errorMessage
+	}
+	return properties
+}
+
+func setStringProperty(properties posthog.Properties, key, value string) {
+	if value != "" {
+		properties[key] = value
+	}
+}
+
+func applyIdentityProperties(properties posthog.Properties, p preparedToolCall, includeSet bool) {
+	removeIdentityControlProperties(properties)
+	if len(p.groups) > 0 {
+		properties[propertyGroups] = p.groups
+	}
+	if p.explicitID {
+		if includeSet && len(p.setProperties) > 0 {
+			properties[propertySet] = p.setProperties
+		}
+	} else {
+		properties[propertyProcessProfile] = false
+	}
+}
+
+func mergeProperties(base, custom posthog.Properties) posthog.Properties {
+	result := make(posthog.Properties, len(base)+len(custom))
+	for key, value := range base {
+		result[key] = value
+	}
+	for key, value := range custom {
+		result[key] = value
+	}
+	return result
+}
+
+func messageSize(message posthog.Message) (int, error) {
+	data, err := marshalJSONSafely(message.APIfy())
+	if err != nil {
+		return 0, packageError("measure event", err)
+	}
+	return len(data), nil
+}

--- a/mcp/example_test.go
+++ b/mcp/example_test.go
@@ -1,0 +1,24 @@
+package mcp_test
+
+import (
+	"log"
+	"time"
+
+	posthog "github.com/posthog/posthog-go"
+	posthogmcp "github.com/posthog/posthog-go/mcp"
+)
+
+func ExampleAnalytics_CaptureToolCall() {
+	client := posthog.New("phc_project_key")
+	defer client.Close()
+
+	analytics := posthogmcp.New(client)
+	err := analytics.CaptureToolCall(posthogmcp.ToolCall{
+		ToolName:   "search_docs",
+		DistinctID: "user_123",
+		Duration:   42 * time.Millisecond,
+	})
+	if err != nil {
+		log.Printf("capture MCP analytics: %v", err)
+	}
+}

--- a/mcp/exception.go
+++ b/mcp/exception.go
@@ -1,0 +1,120 @@
+// Event-size pruning is adapted from AgentCat-derived MCP analytics code in
+// PostHog/posthog-js. See THIRD_PARTY_NOTICES.md.
+
+package mcp
+
+import (
+	"errors"
+
+	posthog "github.com/posthog/posthog-go"
+)
+
+func (p preparedToolCall) buildCapture() (posthog.Capture, error) {
+	base := p.baseProperties()
+
+	build := func(depth int, includeResponse, includeParameters, includeCustom, includeSet bool) posthog.Capture {
+		var properties posthog.Properties
+		if includeCustom {
+			properties = mergeProperties(base, p.custom)
+		} else {
+			properties = mergeProperties(base, nil)
+		}
+		if includeResponse {
+			if value, ok := properties[propertyResponse]; ok {
+				properties[propertyResponse] = truncateNested(value, depth)
+			}
+		} else {
+			delete(properties, propertyResponse)
+		}
+		if includeParameters {
+			if value, ok := properties[propertyParameters]; ok {
+				properties[propertyParameters] = truncateNested(value, depth)
+			}
+		} else {
+			delete(properties, propertyParameters)
+		}
+		applyIdentityProperties(properties, p, includeSet)
+		return posthog.Capture{
+			DistinctId: p.distinctID,
+			Event:      eventToolCall,
+			Timestamp:  p.call.Timestamp,
+			Properties: properties,
+			Groups:     p.groups,
+		}
+	}
+
+	attempts := []posthog.Capture{build(maxDepth, true, true, true, true)}
+	for depth := maxDepth - 1; depth >= 1; depth-- {
+		attempts = append(attempts, build(depth, true, true, true, true))
+	}
+	attempts = append(attempts,
+		build(1, false, true, true, true),
+		build(1, false, false, true, true),
+		build(1, false, false, false, true),
+		build(1, false, false, false, false),
+	)
+	for _, capture := range attempts {
+		size, err := messageSize(capture)
+		if err != nil {
+			return posthog.Capture{}, err
+		}
+		if size <= maxEventBytes {
+			return capture, nil
+		}
+	}
+	return posthog.Capture{}, errors.New("posthogmcp: required tool-call event exceeds 102400 bytes")
+}
+
+func (p preparedToolCall) buildException() (posthog.Exception, error) {
+	handled := true
+	synthetic := true
+	item := posthog.ExceptionItem{
+		Type:  p.errorType,
+		Value: p.errorMessage,
+		Mechanism: &posthog.ExceptionMechanism{
+			Handled:   &handled,
+			Synthetic: &synthetic,
+		},
+	}
+
+	base := posthog.NewProperties()
+	setStringProperty(base, propertySessionID, p.call.SessionID)
+	setStringProperty(base, propertyResourceName, p.toolName)
+	setStringProperty(base, propertyToolName, p.toolName)
+	setStringProperty(base, propertyToolDescription, truncateUTF8(p.call.ToolDescription, maxStringBytes))
+	setStringProperty(base, propertyToolCategory, truncateUTF8(p.call.ToolCategory, maxMetadataBytes))
+	setStringProperty(base, propertyServerName, truncateUTF8(p.call.ServerName, maxMetadataBytes))
+	setStringProperty(base, propertyServerVersion, truncateUTF8(p.call.ServerVersion, maxMetadataBytes))
+	setStringProperty(base, propertyClientName, truncateUTF8(p.call.ClientName, maxMetadataBytes))
+	setStringProperty(base, propertyClientVersion, truncateUTF8(p.call.ClientVersion, maxMetadataBytes))
+	setStringProperty(base, propertyProtocolVersion, truncateUTF8(p.call.ProtocolVersion, maxMetadataBytes))
+
+	build := func(includeCustom bool) posthog.Exception {
+		var properties posthog.Properties
+		if includeCustom {
+			properties = mergeProperties(base, p.custom)
+		} else {
+			properties = mergeProperties(base, nil)
+		}
+		applyIdentityProperties(properties, p, false)
+		return posthog.Exception{
+			DistinctId: p.distinctID,
+			Timestamp:  p.call.Timestamp,
+			Properties: properties,
+			ExceptionList: []posthog.ExceptionItem{
+				item,
+			},
+		}
+	}
+
+	for _, exception := range []posthog.Exception{build(true), build(false)} {
+		size, err := messageSize(exception)
+		if err != nil {
+			return posthog.Exception{}, err
+		}
+		if size <= maxEventBytes {
+			return exception, nil
+		}
+	}
+	return posthog.Exception{}, errors.New("posthogmcp: required MCP exception exceeds 102400 bytes")
+}

--- a/mcp/sanitize.go
+++ b/mcp/sanitize.go
@@ -1,0 +1,167 @@
+// Portions are adapted from AgentCat-derived MCP analytics code in
+// PostHog/posthog-js. See THIRD_PARTY_NOTICES.md.
+
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var (
+	postHogTokenPattern = regexp.MustCompile(`\bph[a-z]_[A-Za-z0-9_-]{20,}\b`)
+	sensitiveKeyPattern = regexp.MustCompile(`(?i)^(authorization|cookie|set-cookie|x-api-key|api[-_]?key|api[-_]?token|access[-_]?token|refresh[-_]?token|token|password|secret|client[-_]?secret|private[-_]?key)$`)
+	base64Pattern       = regexp.MustCompile(`^[A-Za-z0-9+/\r\n]+=*$`)
+	base64URLPattern    = regexp.MustCompile(`^[A-Za-z0-9_-]+={0,2}$`)
+	base64DataPrefix    = regexp.MustCompile(`(?i)^data:[^,\s]*;base64,`)
+	base64DataPayload   = regexp.MustCompile(`^[A-Za-z0-9+/_-]+={0,2}$`)
+)
+
+func normalizePayload(field string, value any) (normalized any, err error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	data, err := marshalJSONSafely(value)
+	if err != nil {
+		return nil, packageError("normalize "+field, err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&normalized); err != nil {
+		return nil, packageError("normalize "+field, err)
+	}
+	return normalized, nil
+}
+
+func marshalJSONSafely(value any) (data []byte, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			data = nil
+			err = fmt.Errorf("JSON marshaler panic (%T)", recovered)
+		}
+	}()
+	return json.Marshal(value)
+}
+
+func packageError(stage string, cause error) error {
+	message := fmt.Sprintf("posthogmcp: %s: %T", stage, cause)
+	return errors.New(truncateUTF8(message, maxReturnedErrorBytes))
+}
+
+func sanitizeCapturedValue(value any) any {
+	switch value := value.(type) {
+	case string:
+		return sanitizeString(value)
+	case []any:
+		result := make([]any, len(value))
+		for i, item := range value {
+			result[i] = sanitizeCapturedValue(item)
+		}
+		return result
+	case map[string]any:
+		result := make(map[string]any, len(value))
+		for key, item := range value {
+			if sensitiveKeyPattern.MatchString(key) {
+				result[key] = redactedValue
+			} else {
+				result[key] = sanitizeCapturedValue(item)
+			}
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+func sanitizeString(value string) string {
+	if len(value) >= largeBinaryGateBytes && isBase64Like(value) {
+		return binaryRedactedValue
+	}
+	return postHogTokenPattern.ReplaceAllString(value, redactedValue)
+}
+
+func isBase64Like(value string) bool {
+	if base64Pattern.MatchString(value) {
+		return true
+	}
+	if strings.ContainsAny(value, "-_") && base64URLPattern.MatchString(value) {
+		return true
+	}
+
+	prefix := base64DataPrefix.FindString(value)
+	if prefix == "" {
+		return false
+	}
+	payload, err := url.PathUnescape(value[len(prefix):])
+	if err != nil {
+		return false
+	}
+	payload = strings.NewReplacer("\r", "", "\n", "").Replace(payload)
+	return base64DataPayload.MatchString(payload)
+}
+
+func sanitizeResponse(value any) any {
+	sanitized := sanitizeCapturedValue(value)
+	response, ok := sanitized.(map[string]any)
+	if !ok {
+		return sanitized
+	}
+
+	result := cloneMap(response)
+	if content, ok := result["content"].([]any); ok {
+		sanitizedContent := make([]any, len(content))
+		for i, block := range content {
+			sanitizedContent[i] = sanitizeContentBlock(block)
+		}
+		result["content"] = sanitizedContent
+	}
+	return result
+}
+
+func sanitizeContentBlock(value any) any {
+	block, ok := value.(map[string]any)
+	if !ok {
+		return value
+	}
+
+	contentType, _ := block["type"].(string)
+	switch contentType {
+	case "text", "resource_link":
+		return sanitizeCapturedValue(block)
+	case "image":
+		return redactedContentBlock("[image content redacted - not supported by PostHog MCP analytics]")
+	case "audio":
+		return redactedContentBlock("[audio content redacted - not supported by PostHog MCP analytics]")
+	case "resource":
+		if resource, ok := block["resource"].(map[string]any); ok {
+			if _, hasBlob := resource["blob"]; hasBlob {
+				return redactedContentBlock("[binary resource content redacted - not supported by PostHog MCP analytics]")
+			}
+		}
+		return sanitizeCapturedValue(block)
+	default:
+		return redactedContentBlock(fmt.Sprintf(
+			"[unsupported content type %q redacted - not supported by PostHog MCP analytics]",
+			contentType,
+		))
+	}
+}
+
+func redactedContentBlock(message string) map[string]any {
+	return map[string]any{"type": "text", "text": message}
+}
+
+func cloneMap(value map[string]any) map[string]any {
+	result := make(map[string]any, len(value))
+	for key, item := range value {
+		result[key] = item
+	}
+	return result
+}

--- a/mcp/sanitize_test.go
+++ b/mcp/sanitize_test.go
@@ -1,0 +1,73 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	posthog "github.com/posthog/posthog-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureToolCallSanitizesPayloadsWithoutMutation(t *testing.T) {
+	token := "phc_abcdefghijklmnopqrstuvwxyz"
+	binary := strings.Repeat("A", largeBinaryGateBytes)
+	parameters := map[string]any{
+		"authorization": "Bearer secret",
+		"nested": map[string]any{
+			"api_key": "secret",
+			"query":   "token " + token,
+			"binary":  binary,
+		},
+	}
+	response := map[string]any{
+		"content": []any{
+			map[string]any{"type": "text", "text": "token " + token},
+			map[string]any{"type": "image", "data": "raw", "mimeType": "image/png"},
+			map[string]any{"type": "audio", "data": "raw"},
+			map[string]any{"type": "resource", "resource": map[string]any{"blob": "raw"}},
+			map[string]any{"type": "resource_link", "uri": "https://example.test/" + token},
+			map[string]any{"type": "video", "data": "raw"},
+		},
+	}
+	properties := posthog.Properties{"password": "secret", "token_value": token}
+
+	client := &fakeEnqueueClient{}
+	require.NoError(t, New(client).CaptureToolCall(ToolCall{
+		ToolName:   "query",
+		Parameters: parameters,
+		Response:   response,
+		Properties: properties,
+	}))
+	capture := requireCapture(t, client.messages[0])
+
+	gotParameters := capture.Properties[propertyParameters].(map[string]any)
+	assert.Equal(t, redactedValue, gotParameters["authorization"])
+	nested := gotParameters["nested"].(map[string]any)
+	assert.Equal(t, redactedValue, nested["api_key"])
+	assert.Equal(t, "token [redacted]", nested["query"])
+	assert.Equal(t, binaryRedactedValue, nested["binary"])
+	assert.Equal(t, redactedValue, capture.Properties["password"])
+	assert.Equal(t, redactedValue, capture.Properties["token_value"])
+
+	gotResponse := capture.Properties[propertyResponse].(map[string]any)
+	content := gotResponse["content"].([]any)
+	assert.Equal(t, "token [redacted]", content[0].(map[string]any)["text"])
+	assert.Equal(t, "[image content redacted - not supported by PostHog MCP analytics]", content[1].(map[string]any)["text"])
+	assert.Equal(t, "[audio content redacted - not supported by PostHog MCP analytics]", content[2].(map[string]any)["text"])
+	assert.Equal(t, "[binary resource content redacted - not supported by PostHog MCP analytics]", content[3].(map[string]any)["text"])
+	assert.Equal(t, "https://example.test/[redacted]", content[4].(map[string]any)["uri"])
+	assert.Equal(t, `[unsupported content type "video" redacted - not supported by PostHog MCP analytics]`, content[5].(map[string]any)["text"])
+
+	assert.Equal(t, "Bearer secret", parameters["authorization"])
+	assert.Equal(t, "secret", parameters["nested"].(map[string]any)["api_key"])
+	assert.Equal(t, "raw", response["content"].([]any)[1].(map[string]any)["data"])
+	assert.Equal(t, "secret", properties["password"])
+}
+
+func TestSanitizeStringBase64Variants(t *testing.T) {
+	assert.Equal(t, binaryRedactedValue, sanitizeString(strings.Repeat("A", largeBinaryGateBytes)))
+	assert.Equal(t, binaryRedactedValue, sanitizeString(strings.Repeat("a_", largeBinaryGateBytes/2)))
+	assert.Equal(t, binaryRedactedValue, sanitizeString("data:image/png;base64,"+strings.Repeat("A", largeBinaryGateBytes)))
+	assert.Equal(t, strings.Repeat("A", largeBinaryGateBytes-1), sanitizeString(strings.Repeat("A", largeBinaryGateBytes-1)))
+}

--- a/mcp/testdata/README.md
+++ b/mcp/testdata/README.md
@@ -1,0 +1,15 @@
+# MCP test provenance
+
+The event/property contract and sanitization/truncation cases in this package
+are pinned to PostHog/posthog-js commit
+`57f371e540968afaa8a0fe9aec8a53ef1db6b654` (2026-08-01), primarily:
+
+- `packages/mcp/src/__tests__/posthog-mcp.test.ts`
+- `packages/mcp/src/__tests__/posthog-events.test.ts`
+- `packages/mcp/src/__tests__/sanitization.test.ts`
+- `packages/mcp/src/__tests__/truncation.test.ts`
+- `packages/mcp/src/__tests__/sink.test.ts`
+
+Go-specific validation, UTF-8 byte limits, deterministic size pruning, and
+stackless synthetic exceptions intentionally differ from JavaScript behavior as
+documented in `mcp_support_spec.md` at the repository root.

--- a/mcp/testdata/tool_call.golden.json
+++ b/mcp/testdata/tool_call.golden.json
@@ -1,0 +1,39 @@
+{
+  "distinct_id": "user_1",
+  "event": "$mcp_tool_call",
+  "properties": {
+    "$groups": {
+      "organization": "org_1"
+    },
+    "$mcp_client_name": "test-client",
+    "$mcp_client_version": "2.0.0",
+    "$mcp_duration_ms": 42,
+    "$mcp_intent": "Find setup instructions",
+    "$mcp_intent_source": "inferred",
+    "$mcp_is_error": false,
+    "$mcp_parameters": {
+      "query": "setup"
+    },
+    "$mcp_protocol_version": "2026-07-28",
+    "$mcp_resource_name": "search_docs",
+    "$mcp_response": {
+      "content": [
+        {
+          "text": "Found",
+          "type": "text"
+        }
+      ]
+    },
+    "$mcp_server_name": "docs-server",
+    "$mcp_server_version": "1.0.0",
+    "$mcp_source": "posthog_mcp_analytics",
+    "$mcp_tool_category": "Docs",
+    "$mcp_tool_description": "Search documentation",
+    "$mcp_tool_name": "search_docs",
+    "$session_id": "session_1",
+    "$set": {
+      "plan": "pro"
+    },
+    "environment": "test"
+  }
+}

--- a/mcp/tool_call.go
+++ b/mcp/tool_call.go
@@ -1,0 +1,50 @@
+package mcp
+
+import (
+	"time"
+
+	posthog "github.com/posthog/posthog-go"
+)
+
+// IntentSource identifies how an MCP tool-call intent was obtained.
+type IntentSource string
+
+const (
+	// IntentSourceContextParameter means the MCP client supplied the intent in a
+	// tool context parameter.
+	IntentSourceContextParameter IntentSource = "context_parameter"
+	// IntentSourceInferred means the host application inferred the intent.
+	IntentSourceInferred IntentSource = "inferred"
+)
+
+// ToolCall describes one completed MCP tool invocation.
+type ToolCall struct {
+	ToolName        string
+	ToolDescription string
+	ToolCategory    string
+
+	DistinctID    string
+	SessionID     string
+	Groups        posthog.Groups
+	SetProperties posthog.Properties
+
+	ServerName      string
+	ServerVersion   string
+	ClientName      string
+	ClientVersion   string
+	ProtocolVersion string
+
+	Intent       string
+	IntentSource IntentSource
+
+	Parameters any
+	Response   any
+
+	Duration  time.Duration
+	IsError   bool
+	Error     error
+	ErrorType string
+
+	Properties posthog.Properties
+	Timestamp  time.Time
+}

--- a/mcp/truncate.go
+++ b/mcp/truncate.go
@@ -1,0 +1,80 @@
+// Portions are adapted from AgentCat-derived MCP analytics code in
+// PostHog/posthog-js. See THIRD_PARTY_NOTICES.md.
+
+package mcp
+
+import (
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+func truncateValue(value any) any {
+	return truncateNested(value, maxDepth)
+}
+
+func truncateNested(value any, remainingDepth int) any {
+	switch value := value.(type) {
+	case string:
+		return truncateUTF8(value, maxStringBytes)
+	case []any:
+		if remainingDepth <= 0 {
+			return "[Array]"
+		}
+		limit := len(value)
+		truncated := false
+		if limit > maxBreadth {
+			limit = maxBreadth - 1
+			truncated = true
+		}
+		result := make([]any, 0, limit+1)
+		for _, item := range value[:limit] {
+			result = append(result, truncateNested(item, remainingDepth-1))
+		}
+		if truncated {
+			result = append(result, "[MaxProperties ~]")
+		}
+		return result
+	case map[string]any:
+		if remainingDepth <= 0 {
+			return "[Object]"
+		}
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		limit := len(keys)
+		truncated := false
+		if limit > maxBreadth {
+			limit = maxBreadth - 1
+			truncated = true
+		}
+		result := make(map[string]any, limit+1)
+		for _, key := range keys[:limit] {
+			result[key] = truncateNested(value[key], remainingDepth-1)
+		}
+		if truncated {
+			result["..."] = "[MaxProperties ~]"
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+func truncateUTF8(value string, limit int) string {
+	value = strings.ToValidUTF8(value, "�")
+	if len(value) <= limit {
+		return value
+	}
+	if limit <= len(truncationSuffix) {
+		return truncationSuffix[:limit]
+	}
+
+	end := limit - len(truncationSuffix)
+	for end > 0 && !utf8.RuneStart(value[end]) {
+		end--
+	}
+	return value[:end] + truncationSuffix
+}

--- a/mcp/truncate_test.go
+++ b/mcp/truncate_test.go
@@ -1,0 +1,114 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	posthog "github.com/posthog/posthog-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateUTF8IncludesMarker(t *testing.T) {
+	got := truncateUTF8(strings.Repeat("🙂", 10), 10)
+	assert.LessOrEqual(t, len(got), 10)
+	assert.True(t, utf8.ValidString(got))
+	assert.True(t, strings.HasSuffix(got, truncationSuffix))
+
+	invalid := string([]byte{'a', 0xff, 'b'})
+	assert.True(t, utf8.ValidString(truncateUTF8(invalid, 100)))
+}
+
+func TestTruncateValueDepthAndBreadth(t *testing.T) {
+	deep := any("value")
+	for i := 0; i < maxDepth+1; i++ {
+		deep = map[string]any{"next": deep}
+	}
+	truncated := truncateValue(deep).(map[string]any)
+	for i := 0; i < maxDepth-1; i++ {
+		truncated = truncated["next"].(map[string]any)
+	}
+	assert.Equal(t, "[Object]", truncated["next"])
+
+	wide := make(map[string]any, maxBreadth+1)
+	for i := 0; i < maxBreadth+1; i++ {
+		wide[fmt.Sprintf("key-%03d", i)] = i
+	}
+	got := truncateValue(wide).(map[string]any)
+	assert.Len(t, got, maxBreadth)
+	assert.Equal(t, "[MaxProperties ~]", got["..."])
+}
+
+func TestCaptureToolCallDeterministicSizePruning(t *testing.T) {
+	large := strings.Repeat("x:", maxStringBytes/2)
+	client := &fakeEnqueueClient{}
+	require.NoError(t, New(client).CaptureToolCall(ToolCall{
+		ToolName: "query",
+		Parameters: map[string]any{
+			"a": large,
+			"b": large,
+			"c": large,
+			"d": large,
+		},
+		Response: map[string]any{
+			"a": large,
+			"b": large,
+			"c": large,
+			"d": large,
+		},
+		Properties: posthog.Properties{
+			"custom_a": large,
+			"custom_b": large,
+			"custom_c": large,
+			"custom_d": large,
+		},
+	}))
+	capture := requireCapture(t, client.messages[0])
+	assert.NotContains(t, capture.Properties, propertyResponse)
+	assert.NotContains(t, capture.Properties, propertyParameters)
+	assert.NotContains(t, capture.Properties, "custom_a")
+	assert.Equal(t, "query", capture.Properties[propertyToolName])
+	size, err := messageSize(capture)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, size, maxEventBytes)
+}
+
+func TestCaptureToolCallIrreducibleOversizeFailsBeforeEnqueue(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	err := New(client).CaptureToolCall(ToolCall{
+		ToolName:   "query",
+		DistinctID: strings.Repeat("x", maxEventBytes),
+	})
+	require.ErrorContains(t, err, "required tool-call event exceeds")
+	assert.Empty(t, client.messages)
+}
+
+func TestCaptureToolCallFieldLimits(t *testing.T) {
+	client := &fakeEnqueueClient{}
+	require.NoError(t, New(client).CaptureToolCall(ToolCall{
+		ToolName:        strings.Repeat("🙂", maxResourceNameBytes),
+		ToolDescription: strings.Repeat("🙂", maxStringBytes),
+		ToolCategory:    strings.Repeat("🙂", maxMetadataBytes),
+		Intent:          strings.Repeat("🙂", maxIntentBytes),
+		IsError:         true,
+		Error:           errorsWithMessage(strings.Repeat("🙂", maxErrorMessageBytes)),
+	}))
+	capture := requireCapture(t, client.messages[0])
+	for key, limit := range map[string]int{
+		propertyToolName:        maxResourceNameBytes,
+		propertyToolDescription: maxStringBytes,
+		propertyToolCategory:    maxMetadataBytes,
+		propertyIntent:          maxIntentBytes,
+		propertyErrorMessage:    maxErrorMessageBytes,
+	} {
+		value := capture.Properties[key].(string)
+		assert.LessOrEqual(t, len(value), limit, key)
+		assert.True(t, utf8.ValidString(value), key)
+	}
+}
+
+type errorsWithMessage string
+
+func (e errorsWithMessage) Error() string { return string(e) }

--- a/mcp_support_spec.md
+++ b/mcp_support_spec.md
@@ -1,0 +1,753 @@
+# MCP analytics support plan
+
+> Status: Plan-bound working specification
+> Date: 2026-08-02
+> Lifetime: Retain while this implementation and upstreaming plan is active. This
+> repository does not otherwise use specifications, and this file is not intended
+> to become permanent upstream documentation.
+
+## Source baseline
+
+The behavioral baseline is the custom-dispatcher path in `@posthog/mcp` at
+PostHog/posthog-js commit
+`57f371e540968afaa8a0fe9aec8a53ef1db6b654` (2026-08-01).
+
+Relevant source files:
+
+- `packages/mcp/src/extensions/posthog-mcp.ts`
+- `packages/mcp/src/extensions/posthog-events.ts`
+- `packages/mcp/src/extensions/sink.ts`
+- `packages/mcp/src/extensions/sanitization.ts`
+- `packages/mcp/src/extensions/mcp-payloads.ts`
+- `packages/mcp/src/extensions/truncation.ts`
+- `packages/mcp/src/extensions/exceptions.ts`
+- `packages/mcp/src/extensions/constants.ts`
+- `packages/mcp/src/types.ts`
+
+The PostHog MCP event contract is beta. Tests in this repository must pin the
+baseline above rather than silently following later JavaScript changes.
+
+Compatibility means preserving the canonical event/property vocabulary and the
+supported information mapping. It does not require byte-for-byte reproduction
+of JavaScript internals. The explicit Go-specific validation, UTF-8 sizing,
+identity precedence, duration, and stack decisions in this specification are
+normative and must have their own tests.
+
+The PostHog JavaScript payload sanitization and truncation files state that they
+are derived from the AgentCat TypeScript SDK. Go files that adapt substantial
+sanitization, recursive truncation, or event-size pruning logic from those files
+must carry a short source pointer. The package must include the complete
+AgentCat copyright and MIT permission notice in
+`mcp/THIRD_PARTY_NOTICES.md`. PostHog event names, property names, public API
+design, and idiomatic Go event construction do not receive third-party source
+headers merely because they preserve protocol compatibility.
+
+## Objective
+
+Add upstreamable MCP analytics support to `posthog-go` with two independent
+layers:
+
+1. A framework-independent package that models and emits PostHog's canonical
+   MCP events.
+2. An optional adapter for `github.com/modelcontextprotocol/go-sdk/mcp` that
+   observes MCP server requests through receiving middleware and translates them
+   into the framework-independent model.
+
+The initial end-to-end milestone is one canonical `$mcp_tool_call` event for
+each terminal logical `tools/call`, including failures, without changing the MCP
+result seen by the caller.
+
+## Architecture
+
+```text
+github.com/modelcontextprotocol/go-sdk/mcp
+                    |
+                    | receiving middleware
+                    v
+contrib/modelcontextprotocol/go-sdk
+                    |
+                    | posthogmcp.ToolCall
+                    v
+github.com/posthog/posthog-go/mcp
+                    |
+                    | posthog.Capture (+ optional posthog.Exception)
+                    v
+github.com/posthog/posthog-go
+                    |
+                    | existing queue, batching, retries, and ingestion
+                    v
+                 PostHog
+```
+
+Dependencies point downward only. The core MCP package must not import an MCP
+protocol SDK. A contrib adapter may import the core MCP package and one external
+MCP SDK.
+
+## Repository layout
+
+```text
+mcp/
+  THIRD_PARTY_NOTICES.md
+  analytics.go
+  constants.go
+  event.go
+  exception.go
+  sanitize.go
+  tool_call.go
+  truncate.go
+  *_test.go
+  testdata/
+
+contrib/modelcontextprotocol/go-sdk/
+  go.mod
+  instrumentation.go
+  middleware.go
+  options.go
+  *_test.go
+```
+
+Names may change during implementation, but the package and dependency
+boundaries are required.
+
+## Core `mcp` package
+
+### Responsibilities
+
+The core package owns:
+
+- public capture input types;
+- canonical MCP event and property constants;
+- identity, session, group, and custom-property mapping;
+- MCP payload sanitization;
+- field and total-event truncation;
+- conversion into existing `posthog.Capture` and `posthog.Exception` messages;
+- optional exception fan-out; and
+- enqueue error reporting.
+
+It does not own:
+
+- MCP request interception;
+- MCP server or client lifecycle;
+- tool registration or schema mutation;
+- MCP session-token minting;
+- PostHog HTTP transport, authentication, retries, batching, or shutdown; or
+- application identity and privacy policy.
+
+### Proposed API
+
+Use the existing `posthog.EnqueueClient` interface so applications retain
+ownership of the PostHog client lifecycle and tests can provide a small fake.
+
+```go
+package mcp
+
+type Analytics struct {
+    // unexported fields
+}
+
+func New(client posthog.EnqueueClient, opts ...Option) *Analytics
+
+func (a *Analytics) CaptureToolCall(call ToolCall) error
+
+func WithExceptionAutocapture(enabled bool) Option
+```
+
+Example:
+
+```go
+client := posthog.New(projectKey)
+analytics := posthogmcp.New(client)
+
+err := analytics.CaptureToolCall(posthogmcp.ToolCall{
+    ToolName:   "search_docs",
+    DistinctID: "user_123",
+    Duration:   42 * time.Millisecond,
+    IsError:    false,
+})
+```
+
+`CaptureToolCall` returns validation and enqueue errors. Applications decide how
+to observe those errors. An instrumentation adapter must not return an analytics
+error in place of the original MCP result.
+
+The core method intentionally does not accept `context.Context`. MCP identity
+and properties must come from `ToolCall`, not from `posthog.RequestContext`.
+Messages are queued with `EnqueueClient.Enqueue`; the adapter retains the MCP
+request context for its resolver and error-handler callbacks.
+
+### Tool-call input
+
+The initial public input should cover the JavaScript custom-dispatcher model:
+
+```go
+type ToolCall struct {
+    ToolName        string
+    ToolDescription string
+    ToolCategory    string
+
+    DistinctID   string
+    SessionID    string
+    Groups       posthog.Groups
+    SetProperties posthog.Properties
+
+    ServerName     string
+    ServerVersion  string
+    ClientName     string
+    ClientVersion  string
+    ProtocolVersion string
+
+    Intent       string
+    IntentSource IntentSource
+
+    Parameters any
+    Response   any
+
+    Duration  time.Duration
+    IsError   bool
+    Error     error
+    ErrorType string
+
+    Properties posthog.Properties
+    Timestamp  time.Time
+}
+```
+
+Field names may be adjusted for Go conventions before the public API is merged.
+The supported information and wire mapping must remain equivalent.
+
+### Validation and zero values
+
+An accepted tool call must have a non-blank `ToolName` and a non-negative
+`Duration`. Duration zero is valid. `IntentSource`, when set, must be
+`context_parameter` or `inferred`. A non-blank intent with no source defaults to
+`context_parameter`; a source without a non-blank intent is omitted.
+
+Every accepted call emits `$mcp_duration_ms` and `$mcp_is_error`. Convert the Go
+duration to a floating-point millisecond value so sub-millisecond measurements
+are not rounded to zero.
+
+When `IsError` is false, ignore `Error` and `ErrorType`. When `IsError` is true:
+
+- use `Error.Error()` as the message when `Error` is non-nil;
+- otherwise synthesize `Tool <name> returned an error`; and
+- use `ErrorType` when non-blank, otherwise use the stable literal `Error`.
+
+The error type and sanitized, bounded error message are written to the main
+tool-call event. This follows the existing `posthog-go` pattern of retaining
+useful error details in error-tracking events. Disabling exception fan-out does
+not remove them from the main event.
+
+### Main event contract
+
+Every accepted tool call emits a `posthog.Capture` with event name
+`$mcp_tool_call`.
+
+Required generated properties:
+
+| Property | Value |
+|---|---|
+| `$mcp_source` | `posthog_mcp_analytics` |
+| `$mcp_resource_name` | tool name |
+| `$mcp_tool_name` | tool name |
+| `$mcp_duration_ms` | wall-clock milliseconds |
+| `$mcp_is_error` | tool failure state |
+
+Optional canonical properties:
+
+- `$session_id`
+- `$mcp_tool_description`
+- `$mcp_tool_category`
+- `$mcp_parameters`
+- `$mcp_response`
+- `$mcp_error_type`
+- `$mcp_error_message`
+- `$mcp_intent`
+- `$mcp_intent_source`
+- `$mcp_server_name`
+- `$mcp_server_version`
+- `$mcp_client_name`
+- `$mcp_client_version`
+- `$mcp_protocol_version`
+- `$groups`
+- `$set`
+
+The event timestamp comes from `ToolCall.Timestamp`, defaulting to the capture
+time. Groups must be supplied both through `posthog.Capture.Groups` and the
+canonical property-building path where necessary so existing SDK enrichment
+does not discard them.
+
+### Identity
+
+Resolve `distinct_id` in this order:
+
+1. Explicit `DistinctID`.
+2. `SessionID`.
+3. The literal `anonymous`.
+
+When no explicit distinct ID exists, set `$process_person_profile` to `false` so
+anonymous MCP sessions do not create person profiles. Apply `SetProperties` as
+`$set` only when an explicit identity exists.
+
+The core package must not infer identity from an authorization token, email,
+login, header, or framework-specific request. Contrib adapters expose an
+application callback for that decision.
+
+### Property precedence
+
+Build generated canonical properties first, then merge caller-supplied
+`Properties`. This matches the JavaScript custom-dispatcher behavior, where
+custom properties may override generated properties.
+
+Identity-control properties are exceptions to that general rule. After merging
+custom properties, re-apply these generated values:
+
+- `$groups` comes only from `ToolCall.Groups` and is supplied through both
+  `posthog.Capture.Groups` and the property map;
+- `$set` is present only when an explicit `DistinctID` exists and comes only
+  from `ToolCall.SetProperties`; and
+- `$process_person_profile=false` is forced whenever there is no explicit
+  `DistinctID`.
+
+This precedence applies to the messages produced by the core package. Existing
+client-level `DefaultEventProperties` and `BeforeSend` behavior still runs after
+enqueue and remains the application's final policy layer. Do not change the root
+SDK's merge order or add a second public before-send mechanism.
+
+### Sanitization
+
+Sanitize `Parameters`, `Response`, `Intent`, and error messages before enqueue.
+The initial port must preserve these JavaScript safety properties:
+
+- redact values below keys matching the sensitive-key pattern;
+- redact PostHog API-key patterns in strings;
+- redact large base64-like strings;
+- replace image and audio content blocks with text markers;
+- replace embedded resource blobs with a text marker;
+- preserve text and resource-link content after recursive sanitization; and
+- return new values rather than mutating caller-owned maps or slices.
+
+Go inputs may be typed structs rather than JavaScript-style objects. Normalize
+all caller-owned payloads (`Parameters`, `Response`, `Groups`, `SetProperties`,
+and `Properties`) through JSON-compatible representations before recursively
+sanitizing. Invalid or non-serializable input, including a panicking custom JSON
+marshaler, must produce an error rather than a panic. Error text returned by the
+MCP package must not include captured payload values and must be capped at 512
+UTF-8 bytes.
+
+For the initial port, use the pinned JavaScript patterns and marker strings. The
+large-binary gate is 10,240 UTF-8 bytes in Go. PostHog token redaction matches
+`ph[a-z]_` tokens with at least 20 token characters. Sensitive-key matching is
+case-insensitive and covers the exact-key set in the pinned
+`mcp-payloads.ts`. Keep the image, audio, embedded-resource, unsupported-content,
+binary-data, and generic `[redacted]` markers equal to the pinned fixtures.
+
+### Truncation
+
+Match the JavaScript baseline limits:
+
+| Limit | Value |
+|---|---:|
+| Maximum nesting depth | 10 |
+| Maximum collection breadth | 100 |
+| Maximum general string length | 32,768 |
+| Maximum total event size | 102,400 bytes |
+| Maximum intent length | 2,048 |
+| Maximum error message length | 2,048 |
+| Maximum resource/tool name length | 256 |
+| Maximum metadata string length | 256 |
+| Maximum stack frames | 50 |
+
+The output must remain valid UTF-8 and JSON. Truncation must prefer retaining
+canonical routing, identity, tool name, duration, and failure fields over
+parameters and responses.
+
+For Go, string limits are UTF-8 byte limits and include the `...` truncation
+marker. Collection breadth includes any truncation marker entry. This is an
+intentional Go-safe interpretation of the JavaScript implementation's UTF-16
+string operations; parity fixtures must include multibyte Unicode cases.
+
+The 102,400-byte limit applies independently to each core-produced capture or
+exception payload immediately before `Enqueue`. Client-added UUID, SDK/system
+context, `DefaultEventProperties`, and `BeforeSend` changes are outside this
+core guarantee.
+
+Size reduction is deterministic:
+
+1. reduce depth, breadth, and strings within response and parameters;
+2. remove response, then parameters, if still necessary;
+3. reduce or remove custom properties and `$set`; and
+4. return a bounded validation error without enqueueing anything if the
+   required routing, identity, group, duration, and failure payload alone cannot
+   fit.
+
+Do not rely on iteration order or repeatedly search for the largest string.
+
+### Exception fan-out
+
+When `IsError` is true and exception autocapture is enabled, enqueue a sibling
+`posthog.Exception` after the main `$mcp_tool_call` capture.
+
+The default is enabled for JavaScript parity. An option disables it without
+removing `$mcp_is_error`, `$mcp_error_type`, or `$mcp_error_message` from the
+main event.
+
+Use the existing `posthog.Exception` model and error-tracking serialization. Do
+not duplicate the core SDK's stack representation. Sanitize and truncate the
+exception message before enqueue. Include bounded MCP context such as tool,
+server, client, session, protocol, custom properties, and groups.
+
+Go's standard `error` interface does not carry a portable stack trace. The
+initial implementation creates one handled, synthetic `ExceptionItem` with no
+fabricated stack. Its type is the resolved MCP error type and its value is the
+same sanitized, bounded message used by `$mcp_error_message`. The 50-frame
+baseline limit remains reserved for a future explicit stack-bearing error
+interface; the first pass does not infer one.
+
+If either enqueue fails, attempt all configured messages and return the joined
+errors. Partial enqueue is possible and must be documented.
+
+### SDK identity
+
+The JavaScript package reports `$lib=posthog-node-mcp`. `posthog-go` currently
+hardcodes `$lib=posthog-go` in core message serialization.
+
+The initial implementation retains `posthog-go` and identifies MCP events with
+`$mcp_source=posthog_mcp_analytics`. A scoped `$lib=posthog-go-mcp` mechanism
+would change core serialization and requires explicit maintainer agreement; it
+must not block the initial tool-call event.
+
+## `modelcontextprotocol/go-sdk` contrib adapter
+
+### Module isolation
+
+The root `posthog-go` module supports Go 1.21. The current
+`github.com/modelcontextprotocol/go-sdk` v1.7.0 module requires Go 1.25.
+
+The contrib adapter must therefore be a nested Go module. It must not add the Go
+MCP SDK to the root `go.mod` or raise the root module's minimum Go version.
+
+The nested module creates separate release and dependency-management work. The
+core package should be merged and released first; the contrib module can then
+require that released root version. During fork development, use a local
+workspace or temporary replacement without committing an absolute path.
+
+### Responsibilities
+
+The contrib adapter owns:
+
+- registering receiving middleware on `*mcp.Server`;
+- recognizing `tools/call` requests;
+- measuring handler duration;
+- reading raw request arguments and final tool results;
+- classifying protocol and tool-result failures;
+- reading session, client, and negotiated-protocol metadata exposed by the Go
+  MCP SDK;
+- resolving application identity, groups, properties, and tool metadata through
+  callbacks; and
+- reporting capture failures without changing MCP behavior.
+
+It must not duplicate core event construction, sanitization, truncation, or
+PostHog transport behavior.
+
+### Proposed API
+
+Prefer `Instrument` or `AddAnalytics` over `AddTracing`: this package emits
+PostHog analytics events, not distributed trace spans.
+
+```go
+package posthogmcpsdk
+
+type Recorder interface {
+    CaptureToolCall(posthogmcp.ToolCall) error
+}
+
+func Instrument(server *mcp.Server, recorder Recorder, opts ...Option) {
+    cfg := defaultConfig(recorder)
+    for _, opt := range opts {
+        opt(cfg)
+    }
+    server.AddReceivingMiddleware(toolCallMiddleware(cfg))
+}
+```
+
+Registration occurs after `mcp.NewServer`. It may occur before or after tool
+registration because the middleware does not snapshot the tool registry.
+
+### Middleware behavior
+
+For requests other than `tools/call`, call the next handler without additional
+work.
+
+For `*mcp.CallToolRequest`:
+
+1. Record the start time.
+2. Call the next middleware or handler exactly once.
+3. Preserve its result and error unchanged.
+4. If the result has `NeedsInput()=true`, return it without capture because the
+   logical tool call is not terminal.
+5. Build a `posthogmcp.ToolCall` from the request and terminal result.
+6. Invoke the configured recorder.
+7. Route recorder failures to the configured error handler.
+8. Return the original MCP result and error.
+
+A call is a failure when the downstream handler returns an error or the final
+`*mcp.CallToolResult` has `IsError=true`. When available, use
+`CallToolResult.GetError()` as the underlying error while retaining the public
+result for response capture.
+
+The adapter reads:
+
+- tool name and raw arguments from `CallToolRequest.Params`;
+- response and `IsError` from `CallToolResult`;
+- session ID from `CallToolRequest.Session.ID()`;
+- protocol version from `CallToolRequest.ProtocolVersion()`;
+- client name/version from `CallToolRequest.ClientInfo()`; and
+- authorization token information only through an application-supplied identity
+  resolver.
+
+The SDK does not expose a public synchronous lookup for registered tool
+descriptions or categories. Use an optional tool-metadata resolver rather than
+accessing SDK internals.
+
+Receiving middleware is outside the SDK's built-in multi-round-trip middleware
+when registered normally after `mcp.NewServer`. Emit once after the downstream
+chain returns for each terminal logical `tools/call`. For older protocols the
+SDK may invoke the handler more than once inside its receiving middleware; for
+the newer protocol it may return `NeedsInput()` and receive a later retry. Emit
+neither internal nor input-required intermediate events.
+
+Do not add cross-request timing state in the initial adapter. Duration covers
+the complete internal flow for an older-protocol request handled inside the SDK
+middleware. For a newer-protocol input-required flow, it covers only the
+terminal retry observed by the adapter.
+
+Do not recover downstream panics in the initial implementation. Analytics must
+not change the server's panic semantics. Resolver, recorder, and error-handler
+panics are instrumentation failures: recover them after the downstream handler
+has returned and preserve the original MCP result. Resolver errors or panics
+omit that resolver's contribution, are routed to the error handler where
+possible, and do not suppress the base tool-call capture.
+
+### Adapter options
+
+The initial option set should support:
+
+```go
+type Identity struct {
+    DistinctID    string
+    Groups        posthog.Groups
+    SetProperties posthog.Properties
+}
+
+type ToolMetadata struct {
+    Description string
+    Category    string
+}
+
+type IdentityResolver func(
+    context.Context,
+    *mcp.CallToolRequest,
+) (Identity, error)
+
+type ToolMetadataResolver func(
+    context.Context,
+    *mcp.CallToolRequest,
+) (ToolMetadata, error)
+
+type PropertiesResolver func(
+    context.Context,
+    *mcp.CallToolRequest,
+    *mcp.CallToolResult,
+    error,
+) (posthog.Properties, error)
+
+type ErrorHandler func(context.Context, error)
+
+WithIdentity(IdentityResolver)
+WithToolMetadata(ToolMetadataResolver)
+WithCaptureParameters(bool)
+WithCaptureResponses(bool)
+WithProperties(PropertiesResolver)
+WithServerInfo(name, version)
+WithErrorHandler(ErrorHandler)
+```
+
+Defaults should match the JavaScript package where practical:
+
+- capture parameters: enabled;
+- capture responses: enabled;
+- session attribution: enabled when the SDK supplies a session ID;
+- authenticated user identity: disabled unless a resolver supplies it; and
+- capture failures: reported through a no-op-safe error handler, never returned
+  as MCP errors.
+
+Exception autocapture is configured on the core `Analytics`, not the adapter.
+The default error handler is a no-op so instrumentation remains safe for STDIO
+servers. Run resolvers after the downstream handler returns. Invoke them
+independently in identity, metadata, then properties order; one resolver failure
+must not prevent later resolvers or the base capture. Wrap resolver and recorder
+errors with their stage before passing them to `ErrorHandler`.
+
+Applications with stricter privacy requirements can disable parameters,
+responses, and core exception fan-out while retaining tool name, duration,
+failure state, and the sanitized bounded error type/message on failed calls.
+
+## Testing
+
+### Core package
+
+Use a fake `posthog.EnqueueClient` and inspect the enqueued `posthog.Capture` and
+`posthog.Exception` messages. Golden fixtures must assert the serialized
+PostHog wire shape rather than only internal Go structs. Normalize volatile UUID,
+timestamp, SDK version, Go version, and OS fields before comparing goldens.
+
+Minimum coverage:
+
+- successful minimal tool call;
+- required-name, negative-duration, intent-source, and error-state validation;
+- complete optional property mapping;
+- explicit identity, session fallback, and anonymous fallback;
+- person-profile suppression for anonymous calls;
+- groups and `$set` behavior;
+- custom-property precedence;
+- identity-control properties cannot be overridden by custom properties;
+- failed call with and without exception fan-out;
+- one enqueue failing while the other is still attempted;
+- sensitive-key, API-key, binary, and content-block redaction;
+- depth, breadth, string, error, and total-size truncation;
+- deterministic size-pruning order and irreducible oversize failure;
+- valid UTF-8 after truncation;
+- caller inputs are not mutated;
+- invalid and non-serializable inputs fail without panic;
+- multibyte UTF-8 boundaries remain valid and within byte limits; and
+- exception items are handled, synthetic, and stackless.
+
+Where possible, port JavaScript test vectors from the pinned source commit and
+assert equivalent event names and properties.
+
+### Contrib adapter
+
+Use `modelcontextprotocol/go-sdk` in-memory transports and a fake core recorder
+for normal method tests. Use the streamable HTTP transport for session-ID
+mapping because the in-memory transport has no session ID. Do not test the
+middleware only by invoking its closure directly.
+
+Minimum coverage:
+
+- successful typed tool handler emits once;
+- typed handler error converted to `CallToolResult.IsError` emits a failure;
+- protocol-level handler error emits a failure and remains unchanged;
+- raw parameters and final response are passed when enabled;
+- parameter and response capture can be disabled independently;
+- session, protocol, and client metadata are mapped;
+- identity and metadata resolvers are applied;
+- resolver errors do not suppress the base capture or later resolvers;
+- unrelated MCP methods do not emit tool calls;
+- recorder failure does not alter the MCP response;
+- resolver, recorder, and error-handler panics do not alter the MCP response;
+- middleware calls the next handler exactly once;
+- middleware ordering is documented and verified;
+- older-protocol internal multi-round processing emits once; and
+- newer-protocol `NeedsInput()` results emit nothing until the terminal retry.
+
+## Downstream Starlogz validation
+
+Starlogz is the first integration target, not part of the upstream packages.
+
+It will:
+
+- retain its existing EventBridge/CloudWatch wide events;
+- install the Go SDK contrib middleware for PostHog;
+- resolve `distinct_id` from verified `TokenInfo.UserID`;
+- disable parameter capture, response capture, and exception autocapture for the
+  initial rollout;
+- retain the normal sanitized and bounded `$mcp_error_type` and
+  `$mcp_error_message` properties on failed main events;
+- supply server name, service version, and deployment environment;
+- configure the PostHog key and host through optional environment variables;
+- treat all capture failures as warnings; and
+- validate one `$mcp_tool_call` per invocation in PostHog before expanding the
+  event set.
+
+Lambda freeze behavior is a delivery risk for an in-memory background queue.
+The first rollout should use a batch size of one and verify the final event in a
+low-traffic period. If delivery remains unreliable, propose reusable bounded
+flush support separately rather than adding Lambda-specific behavior to MCP
+event construction.
+
+## Delivery phases
+
+### Phase 1: Core tool-call events
+
+Work on fork branch `mcp-tool-events`.
+
+Deliver:
+
+- core `mcp` package;
+- canonical tool-call capture;
+- sanitization and truncation;
+- optional exception fan-out;
+- public documentation and example;
+- parity-oriented unit and golden tests;
+- the updated root public-API snapshot and release changeset; and
+- targeted AgentCat-derived source pointers and `mcp/THIRD_PARTY_NOTICES.md`.
+
+Candidate upstream commit and PR title:
+
+```text
+feat(mcp): add canonical MCP tool-call events
+```
+
+### Phase 2: Go MCP SDK adapter
+
+Deliver the nested contrib module after the core API is stable and preferably
+released.
+
+The nested module is not covered by root `go test ./...`, `go vet ./...`, race
+tests, or the root release tag. Add explicit build, unit, race, and vet CI jobs
+using the adapter's minimum Go version. Release it with a subdirectory-prefixed
+tag such as `contrib/modelcontextprotocol/go-sdk/v0.1.0`; the root release
+workflow does not publish nested modules. During a same-repository development
+run, generate an uncommitted `go.work` file rather than committing a filesystem
+replacement.
+
+Candidate upstream commit and PR title:
+
+```text
+feat(contrib): instrument modelcontextprotocol/go-sdk servers
+```
+
+### Phase 3: Starlogz integration
+
+Consume the fork commit, configure Terraform and process lifecycle, deploy to
+development, and verify actual PostHog ingestion. Replace the fork dependency
+with an upstream release when available.
+
+### Deferred expansion
+
+Consider separate changes for:
+
+- `$mcp_initialize`;
+- `$mcp_tools_list`;
+- `$mcp_missing_capability`;
+- resource and prompt events;
+- schema mutation for intent and conversation IDs;
+- automatic tool-description/category tracking;
+- alternate MCP framework adapters;
+- MCP-specific SDK `$lib` identity; and
+- reusable flush support for serverless runtimes.
+
+## Acceptance criteria
+
+The initial plan is complete when:
+
+1. The core package produces a `$mcp_tool_call` wire event compatible with the
+   pinned JavaScript contract.
+2. Safety and size limits are enforced before enqueue.
+3. The Go SDK adapter emits exactly once per terminal logical tool call.
+4. Analytics failures never replace or modify the MCP result.
+5. The root module remains compatible with Go 1.21 and has no MCP SDK
+   dependency.
+6. Starlogz can consume the fork and observe tool calls in a PostHog development
+   project without exporting tool parameters or responses.
+7. The core change is focused and documented well enough to submit upstream.


### PR DESCRIPTION
Verified with go test ./..., MCP race tests, go vet, and the public API check.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- add a framework-independent MCP analytics API with identity mapping and optional exception fanout
- sanitize and bound captured parameters, responses, properties, and errors
- add API documentation, provenance, fixtures, and tests

I have left the original specification in the mcp_support_spec.md happy to remove it.

<img width="1412" height="667" alt="Screenshot 2026-08-02 at 11 50 14 am" src="https://github.com/user-attachments/assets/6dd1a630-1bee-4f6d-9853-6f0ddc4928dc" />

This is half of the solution to #262

## :green_heart: How did you test it?

This is been verified on my personal side project https://github.com/wolfeidau/starlogz 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

This code was initially scaffolded by OpenAI Codex, and most of the test code was written with help from this agent harness.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
