### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
 updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
-    reviewers:
-      - "PostHog/team-client-libraries"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    reviewers:
+      - "PostHog/team-client-libraries"


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot should monitor all dependency sources used by this SDK: Go modules for SDK dependencies, npm for the root release-tooling package, and GitHub Actions for workflow dependencies. This configuration checks each ecosystem at `/` every week and applies a seven-day default cooldown.

Explicit Dependabot reviewers are intentionally omitted. Repository ownership and review assignment remain governed by `.github/CODEOWNERS`, whose repository-wide rule assigns `@PostHog/team-client-libraries`.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` with Ruby's YAML library and asserted the exact ecosystem order (`gomod`, `npm`, `github-actions`), root directories, weekly schedules, seven-day cooldowns, allowed keys, and absence of reviewers.
- Ran `git diff --check`.
- Ran Pi branch autoreview against `origin/main`; it reported no actionable findings.
- GitHub’s dedicated `.github/dependabot.yml` validation and all 25 repository CI checks passed, including formatting, `go mod tidy`, unit/race tests, SDK compliance, CodeQL, Semgrep, and Wiz scans.

No SDK tests were run locally because this change only updates Dependabot configuration; the repository test suites ran in CI.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi coding agent updated and validated the configuration at human direction. The final scope is limited to Dependabot configuration for the repository's three package ecosystems; existing CODEOWNERS remains responsible for team assignment.
