### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,27 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot currently opens separate pull requests for each dependency update. Grouping updates by ecosystem reduces pull request noise and lets related updates be reviewed together.

This configures wildcard groups for Go modules, release tooling managed by npm, and GitHub Actions.

## :green_heart: How did you test it?
Parsed `.github/dependabot.yml` as YAML and confirmed that every update entry has its expected group with `patterns: ["*"]`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent from a human-provided task. The requested group names and wildcard patterns were applied without changing schedules or cooldown settings. Autoreview was skipped because the diff only changes repository administration configuration.
