### PR TITLE
ci: remove automerge from upgrade workflow

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -137,16 +137,6 @@ jobs:
             --title "$PR_TITLE" \
             --body "$PR_BODY"
 
-      - name: Enable automerge
-        if: steps.main-repo-pr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ steps.upgrader.outputs.token }}
-          PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
-        run: |
-          if [ "$(gh pr view "$PR_NUMBER" --repo PostHog/posthog --json autoMergeRequest --jq '.autoMergeRequest != null')" = "false" ]; then
-            gh pr merge "$PR_NUMBER" --repo PostHog/posthog --auto --squash
-          fi
-
       - name: Assign reviewers
         if: steps.main-repo-pr.outputs.pull-request-number != ''
         env:


### PR DESCRIPTION
## :bulb: Motivation and Context

The PostHog upgrade workflow fails after creating a dependency update pull request because the PostHog monorepo does not allow auto-merge. The failed run is https://github.com/PostHog/posthog-go/actions/runs/31714783311/job/94496614442.

This removes the step that requests auto-merge. The workflow will continue to create or update the pull request and assign the client libraries reviewers.

## :green_heart: How did you test it?

- Ran `actionlint .github/workflows/posthog-upgrade.yml`.
- Ran `git diff --check`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent removed the auto-merge step after reviewing the failing GitHub Actions job. The change is limited to the upgrade workflow because the target repository has auto-merge disabled.
