### PR TITLE
fix: normalize SDK timestamps to UTC

### DIFF
--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Normalize event timestamps to the equivalent UTC instant before serializing legacy batch and Capture V1 payloads.

--- a/alias.go
+++ b/alias.go
@@ -21,7 +21,8 @@ type Alias struct {
 	Alias string
 	// DistinctId is the existing user distinct ID that Alias should resolve to.
 	DistinctId string
-	// Timestamp is the event timestamp. If zero, Enqueue uses the current time.
+	// Timestamp is the event timestamp. UTC is preferred; non-UTC values are
+	// converted to the equivalent UTC instant. If zero, Enqueue uses the current time.
 	Timestamp time.Time
 	// DisableGeoIP controls whether this alias event disables GeoIP lookup.
 	// Enqueue overwrites it from Config.GetDisableGeoIP.
@@ -69,7 +70,7 @@ type AliasInApi struct {
 	Library string `json:"library"`
 	// LibraryVersion is the SDK version sent to the batch API.
 	LibraryVersion string `json:"library_version"`
-	// Timestamp is the event timestamp sent to the batch API.
+	// Timestamp is the event timestamp sent to the batch API in UTC.
 	Timestamp time.Time `json:"timestamp"`
 
 	// Properties contains alias-specific event properties.
@@ -94,7 +95,7 @@ func (msg Alias) APIfy() APIMessage {
 		Event:          "$create_alias",
 		Library:        SDKName,
 		LibraryVersion: libraryVersion,
-		Timestamp:      msg.Timestamp,
+		Timestamp:      msg.Timestamp.UTC(),
 		Properties: AliasInApiProperties{
 			sysContext:   getSystemContext(),
 			DistinctId:   msg.DistinctId,

--- a/capture.go
+++ b/capture.go
@@ -96,7 +96,8 @@ type Capture struct {
 	DistinctId string
 	// Event is the event name to capture. It must be non-empty.
 	Event string
-	// Timestamp is the event timestamp. If zero, Enqueue uses the current time.
+	// Timestamp is the event timestamp. UTC is preferred; non-UTC values are
+	// converted to the equivalent UTC instant. If zero, Enqueue uses the current time.
 	Timestamp time.Time
 	// Properties are event properties. Enqueue merges request context properties
 	// and Config.DefaultEventProperties into this map before sending.
@@ -155,7 +156,7 @@ type CaptureInApi struct {
 	// Deprecated: PostHog reads SDK version from Properties["$lib_version"], so
 	// this top-level field is no longer serialized.
 	LibraryVersion string `json:"-"`
-	// Timestamp is the event timestamp sent to the batch API.
+	// Timestamp is the event timestamp sent to the batch API in UTC.
 	Timestamp time.Time `json:"timestamp"`
 
 	// DistinctId identifies the user or entity for the event.
@@ -260,7 +261,7 @@ func (msg Capture) APIfy() APIMessage {
 		Uuid:             msg.Uuid,
 		Library:          SDKName,
 		LibraryVersion:   libraryVersion,
-		Timestamp:        msg.Timestamp,
+		Timestamp:        msg.Timestamp.UTC(),
 		DistinctId:       msg.DistinctId,
 		Event:            msg.Event,
 		Properties:       myProperties,

--- a/capture_v1.go
+++ b/capture_v1.go
@@ -231,7 +231,7 @@ func buildV1Event(e apiEvent, logger Logger) eventPayload {
 		Event:      e.event,
 		Uuid:       e.uuid,
 		DistinctId: e.distinctId,
-		Timestamp:  e.timestamp,
+		Timestamp:  e.timestamp.UTC(),
 		SessionId:  sessionId,
 		WindowId:   windowId,
 		Options:    options,

--- a/capture_v1_send_test.go
+++ b/capture_v1_send_test.go
@@ -72,6 +72,7 @@ type recordedRequest struct {
 	attempt   string
 	requestId string
 	timestamp string
+	createdAt string
 	auth      string
 	encoding  string
 	uuids     []string
@@ -110,6 +111,7 @@ func (s *v1TestServer) handler(t *testing.T) http.HandlerFunc {
 			attempt:   r.Header.Get("PostHog-Attempt"),
 			requestId: r.Header.Get("PostHog-Request-Id"),
 			timestamp: r.Header.Get("PostHog-Request-Timestamp"),
+			createdAt: env.CreatedAt,
 			auth:      r.Header.Get("Authorization"),
 			encoding:  r.Header.Get("Content-Encoding"),
 			uuids:     uuids,
@@ -249,7 +251,10 @@ func TestV1SendHeadersAndAllOk(t *testing.T) {
 	ts := httptest.NewServer(srv.handler(t))
 	defer ts.Close()
 
-	c := newV1TestClient(t, ts.URL, cb, 9, nil)
+	now := time.Date(2025, time.April, 6, 7, 8, 9, 0, time.FixedZone("UTC+5", 5*60*60))
+	c := newV1TestClient(t, ts.URL, cb, 9, func(cfg *Config) {
+		cfg.now = func() time.Time { return now }
+	})
 	c.sendV1(v1Batch(t, cap1(uuidA)))
 
 	reqs := srv.snapshot()
@@ -266,8 +271,12 @@ func TestV1SendHeadersAndAllOk(t *testing.T) {
 	if r.requestId == "" {
 		t.Error("PostHog-Request-Id missing")
 	}
-	if _, err := time.Parse(time.RFC3339, r.timestamp); err != nil {
-		t.Errorf("PostHog-Request-Timestamp %q not RFC3339: %v", r.timestamp, err)
+	const wantTimestamp = "2025-04-06T02:08:09Z"
+	if r.timestamp != wantTimestamp {
+		t.Errorf("PostHog-Request-Timestamp = %q, want %q", r.timestamp, wantTimestamp)
+	}
+	if r.createdAt != wantTimestamp {
+		t.Errorf("created_at = %q, want %q", r.createdAt, wantTimestamp)
 	}
 	if s, f := cb.counts(); s != 1 || f != 0 {
 		t.Errorf("callbacks: success=%d failure=%d, want 1/0", s, f)

--- a/error_tracking.go
+++ b/error_tracking.go
@@ -24,7 +24,8 @@ type Exception struct {
 	// DebugImages lists the binary images referenced by "native" stack
 	// frames, sent as $debug_images for server-side symbolication.
 	DebugImages []DebugImage
-	// Timestamp is the event timestamp. If zero, Enqueue uses the current time.
+	// Timestamp is the event timestamp. UTC is preferred; non-UTC values are
+	// converted to the equivalent UTC instant. If zero, Enqueue uses the current time.
 	Timestamp time.Time
 	// Properties are custom event properties flattened into the exception event.
 	Properties Properties
@@ -117,7 +118,7 @@ type ExceptionInApi struct {
 	Library string `json:"library"`
 	// LibraryVersion is the SDK version sent to the batch API.
 	LibraryVersion string `json:"library_version"`
-	// Timestamp is the event timestamp sent to the batch API.
+	// Timestamp is the event timestamp sent to the batch API in UTC.
 	Timestamp time.Time `json:"timestamp"`
 	// Event is always $exception for Exception messages.
 	Event string `json:"event"`
@@ -246,7 +247,7 @@ func (msg Exception) APIfy() APIMessage {
 		Event:          "$exception",
 		Library:        SDKName,
 		LibraryVersion: libVersion,
-		Timestamp:      msg.Timestamp,
+		Timestamp:      msg.Timestamp.UTC(),
 		Properties: ExceptionInApiProperties{
 			sysContext:           getSystemContext(),
 			Lib:                  SDKName,
@@ -264,7 +265,8 @@ func (msg Exception) APIfy() APIMessage {
 
 // NewDefaultException builds an Exception with a default stack trace.
 //
-// The timestamp parameter becomes Exception.Timestamp, distinctID becomes
+// The timestamp parameter becomes Exception.Timestamp; UTC is preferred, and
+// Enqueue converts non-UTC values to the equivalent UTC instant. distinctID becomes
 // Exception.DistinctId, title becomes the first ExceptionItem.Type, and
 // description becomes the first ExceptionItem.Value. The returned Exception is
 // ready to pass to Client.Enqueue. Build Exception manually if you need custom

--- a/group_identify.go
+++ b/group_identify.go
@@ -19,7 +19,8 @@ type GroupIdentify struct {
 
 	// DistinctId is accepted for compatibility but the wire payload uses a generated group distinct ID.
 	DistinctId string
-	// Timestamp is the event timestamp. If zero, Enqueue uses the current time.
+	// Timestamp is the event timestamp. UTC is preferred; non-UTC values are
+	// converted to the equivalent UTC instant. If zero, Enqueue uses the current time.
 	Timestamp time.Time
 	// Properties are sent as the $group_set properties for the group.
 	Properties Properties
@@ -48,7 +49,7 @@ type GroupIdentifyInApi struct {
 	Library string `json:"library"`
 	// LibraryVersion is the SDK version sent to the batch API.
 	LibraryVersion string `json:"library_version"`
-	// Timestamp is the event timestamp sent to the batch API.
+	// Timestamp is the event timestamp sent to the batch API in UTC.
 	Timestamp time.Time `json:"timestamp"`
 
 	// Event is always $groupidentify for GroupIdentify messages.
@@ -84,7 +85,7 @@ func (msg GroupIdentify) APIfy() APIMessage {
 		Event:          "$groupidentify",
 		Properties:     myProperties,
 		DistinctId:     distinctId,
-		Timestamp:      msg.Timestamp,
+		Timestamp:      msg.Timestamp.UTC(),
 		Library:        SDKName,
 		LibraryVersion: getVersion(),
 	}

--- a/identify.go
+++ b/identify.go
@@ -19,7 +19,8 @@ type Identify struct {
 
 	// DistinctId is the user distinct ID whose person profile should be updated.
 	DistinctId string
-	// Timestamp is the event timestamp. If zero, Enqueue uses the current time.
+	// Timestamp is the event timestamp. UTC is preferred; non-UTC values are
+	// converted to the equivalent UTC instant. If zero, Enqueue uses the current time.
 	Timestamp time.Time
 	// Properties are sent as the $set person properties for DistinctId.
 	Properties Properties
@@ -53,7 +54,7 @@ type IdentifyInApi struct {
 	Library string `json:"library"`
 	// LibraryVersion is the SDK version sent to the batch API.
 	LibraryVersion string `json:"library_version"`
-	// Timestamp is the event timestamp sent to the batch API.
+	// Timestamp is the event timestamp sent to the batch API in UTC.
 	Timestamp time.Time `json:"timestamp"`
 
 	// Event is always $identify for Identify messages.
@@ -87,7 +88,7 @@ func (msg Identify) APIfy() APIMessage {
 		Event:          "$identify",
 		Library:        SDKName,
 		LibraryVersion: getVersion(),
-		Timestamp:      msg.Timestamp,
+		Timestamp:      msg.Timestamp.UTC(),
 		DistinctId:     msg.DistinctId,
 
 		Properties: myProperties,

--- a/message.go
+++ b/message.go
@@ -62,12 +62,13 @@ type Message interface {
 }
 
 // Returns the time value passed as first argument, unless it's the zero-value,
-// in that case the default value passed as second argument is returned.
+// in that case the default value passed as second argument is returned. The
+// result is normalized to UTC while preserving the instant.
 func makeTimestamp(t time.Time, def time.Time) time.Time {
 	if t == (time.Time{}) {
-		return def
+		return def.UTC()
 	}
-	return t
+	return t.UTC()
 }
 
 // makeUUID returns the UUID passed as first argument if non-empty and valid,

--- a/timestamp_test.go
+++ b/timestamp_test.go
@@ -1,0 +1,122 @@
+package posthog
+
+import (
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+)
+
+func TestEventTimestampSerializationUsesUTC(t *testing.T) {
+	timestamp := time.Date(2025, time.January, 2, 3, 4, 5, 600000000, time.FixedZone("UTC-7", -7*60*60))
+	const want = "2025-01-02T10:04:05.6Z"
+
+	messages := []struct {
+		name string
+		msg  Message
+	}{
+		{name: "capture", msg: Capture{Uuid: "u", Event: "event", DistinctId: "user", Timestamp: timestamp}},
+		{name: "identify", msg: Identify{Uuid: "u", DistinctId: "user", Timestamp: timestamp}},
+		{name: "group identify", msg: GroupIdentify{Uuid: "u", Type: "company", Key: "acme", Timestamp: timestamp}},
+		{name: "alias", msg: Alias{Uuid: "u", DistinctId: "user", Alias: "anonymous", Timestamp: timestamp}},
+		{name: "exception", msg: Exception{Uuid: "u", DistinctId: "user", Timestamp: timestamp, ExceptionList: []ExceptionItem{{Type: "error", Value: "boom"}}}},
+	}
+
+	for _, tc := range messages {
+		t.Run(tc.name, func(t *testing.T) {
+			legacyData, _, err := prepareForSend(tc.msg)
+			if err != nil {
+				t.Fatalf("prepareForSend: %v", err)
+			}
+			assertWireTimestamp(t, legacyData, want)
+
+			v1Data, _, _, err := prepareForSendV1(tc.msg, nil)
+			if err != nil {
+				t.Fatalf("prepareForSendV1: %v", err)
+			}
+			assertWireTimestamp(t, v1Data, want)
+		})
+	}
+}
+
+func assertWireTimestamp(t *testing.T, data []byte, want string) {
+	t.Helper()
+	var payload struct {
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Timestamp != want {
+		t.Errorf("timestamp = %q, want %q", payload.Timestamp, want)
+	}
+}
+
+func TestTimestampNormalizationDoesNotRewriteCallerProperties(t *testing.T) {
+	callerTime := time.Date(2025, time.May, 6, 7, 8, 9, 0, time.FixedZone("UTC+5:30", 5*60*60+30*60))
+	data, _, err := prepareForSend(Capture{
+		Event:      "event",
+		DistinctId: "user",
+		Timestamp:  callerTime,
+		Properties: Properties{"caller_time": callerTime},
+	})
+	if err != nil {
+		t.Fatalf("prepareForSend: %v", err)
+	}
+
+	var payload struct {
+		Timestamp  string            `json:"timestamp"`
+		Properties map[string]string `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Timestamp != "2025-05-06T01:38:09Z" {
+		t.Errorf("timestamp = %q, want UTC", payload.Timestamp)
+	}
+	if payload.Properties["caller_time"] != "2025-05-06T07:08:09+05:30" {
+		t.Errorf("caller_time = %q, want original offset", payload.Properties["caller_time"])
+	}
+}
+
+func TestDefaultEventTimestampsUseUTC(t *testing.T) {
+	body, server := mockServer()
+	defer server.Close()
+
+	defaultTimestamp := time.Date(2025, time.March, 8, 9, 10, 11, 0, time.FixedZone("UTC+9", 9*60*60))
+	client, err := NewWithConfig("test-key", Config{
+		Endpoint:  server.URL,
+		BatchSize: 5,
+		now:       func() time.Time { return defaultTimestamp },
+	})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	defer client.Close()
+
+	messages := []Message{
+		Capture{Event: "event", DistinctId: "user"},
+		Identify{DistinctId: "user"},
+		GroupIdentify{Type: "company", Key: "acme"},
+		Alias{DistinctId: "user", Alias: "anonymous"},
+		Exception{DistinctId: "user", ExceptionList: []ExceptionItem{{Type: "error", Value: "boom"}}},
+	}
+	for _, msg := range messages {
+		if err := client.Enqueue(msg); err != nil {
+			t.Fatalf("Enqueue(%T): %v", msg, err)
+		}
+	}
+
+	var payload struct {
+		Batch []json.RawMessage `json:"batch"`
+	}
+	if err := json.Unmarshal(<-body, &payload); err != nil {
+		t.Fatalf("unmarshal batch: %v", err)
+	}
+	if len(payload.Batch) != len(messages) {
+		t.Fatalf("batch length = %d, want %d", len(payload.Batch), len(messages))
+	}
+	for _, event := range payload.Batch {
+		assertWireTimestamp(t, event, "2025-03-08T00:10:11Z")
+	}
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Event timestamps supplied with a non-UTC location were serialized with their original offset. This made SDK payload timestamps inconsistent even though they represented the correct instant.

This change converts event timestamps to the equivalent UTC instant before serializing legacy batch and Capture V1 payloads. It covers Capture, Identify, GroupIdentify, Alias, and Exception messages. Default timestamps from the client clock are also normalized. Timestamp values stored in caller properties are left unchanged.

## :green_heart: How did you test it?

- `TestEventTimestampSerializationUsesUTC` verifies explicit non-UTC timestamps for Capture, Identify, GroupIdentify, Alias, and Exception messages in both legacy and Capture V1 payloads.
- `TestTimestampNormalizationDoesNotRewriteCallerProperties` verifies that only the event timestamp is normalized and a time value in caller properties keeps its original offset.
- `TestDefaultEventTimestampsUseUTC` verifies that zero-value event timestamps use the client clock and serialize in UTC for all five message types.
- `TestV1SendHeadersAndAllOk` verifies that `PostHog-Request-Timestamp` and the Capture V1 `created_at` field use the same UTC instant from a non-UTC client clock.
- Ran the focused timestamp tests and `go vet ./...`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prepared with Pi's PR workflow and isolated autoreview. The requested behavior and scope were directed by @marandaneto. The local Pi session has no public URL. Autoreview reported no actionable findings.
