### PR TITLE
fix(flags): fall back for missing local definitions

### DIFF
--- a/.changeset/quiet-flags-fallback.md
+++ b/.changeset/quiet-flags-fallback.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Fall back to `/flags` when a requested flag is missing from loaded local definitions.

--- a/.changeset/quiet-flags-fallback.md
+++ b/.changeset/quiet-flags-fallback.md
@@ -1,5 +1,5 @@
 ---
-"posthog-go": patch
+"posthog-go": minor
 ---
 
-Fall back to `/flags` when a requested flag is missing from loaded local definitions.
+Fall back to `/flags` when a requested flag is missing from loaded local definitions. This changes the earlier behavior where the key was omitted without a request.

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -579,6 +579,84 @@ func TestEvaluateFlags_ForwardsFlagKeys(t *testing.T) {
 	}
 }
 
+func TestEvaluateFlags_MissingRequestedLocalFlagFallsBackRemotely(t *testing.T) {
+	t.Parallel()
+	var remoteCalls atomic.Int32
+	remoteRequests := make(chan FlagsRequestData, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions") || strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation"):
+			w.Write([]byte(fixture("feature_flag/test-multiple-flags-valid.json")))
+		case strings.HasPrefix(r.URL.Path, "/flags"):
+			remoteCalls.Add(1)
+			var request FlagsRequestData
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode /flags request: %v", err)
+			}
+			remoteRequests <- request
+			w.Write([]byte(`{
+				"flags": {
+					"beta-feature": {"key": "beta-feature", "enabled": false, "metadata": {"id": 1, "version": 1}},
+					"remote-only": {"key": "remote-only", "enabled": true, "metadata": {"id": 2, "version": 1}},
+					"unrequested": {"key": "unrequested", "enabled": true, "metadata": {"id": 3, "version": 1}}
+				}
+			}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, _, _ := newEvalClient(t, server, func(c *Config) {
+		c.PersonalApiKey = "personal-key"
+	})
+	waitForFlagDefinitions(t, client)
+
+	flagKeys := []string{"beta-feature", "remote-only"}
+	localSnapshot, err := client.EvaluateFlags(EvaluateFlagsPayload{
+		DistinctId:          "user-1",
+		FlagKeys:            flagKeys,
+		OnlyEvaluateLocally: true,
+	})
+	if err != nil {
+		t.Fatalf("local-only EvaluateFlags error: %v", err)
+	}
+	if got := localSnapshot.Keys(); len(got) != 1 || got[0] != "beta-feature" {
+		t.Fatalf("expected only the locally resolved flag, got %v", got)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("local-only evaluation made %d /flags requests", got)
+	}
+
+	snapshot, err := client.EvaluateFlags(EvaluateFlagsPayload{
+		DistinctId: "user-1",
+		FlagKeys:   flagKeys,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFlags error: %v", err)
+	}
+	if got := remoteCalls.Load(); got != 1 {
+		t.Fatalf("expected one /flags fallback, got %d", got)
+	}
+	request := <-remoteRequests
+	if len(request.FlagKeysToEvaluate) != 2 || request.FlagKeysToEvaluate[0] != "beta-feature" || request.FlagKeysToEvaluate[1] != "remote-only" {
+		t.Fatalf("expected the original requested keys, got %v", request.FlagKeysToEvaluate)
+	}
+	if got := snapshot.Keys(); len(got) != 2 || got[0] != "beta-feature" || got[1] != "remote-only" {
+		t.Fatalf("expected the snapshot to stay scoped to requested keys, got %v", got)
+	}
+	if !snapshot.IsEnabled("beta-feature") {
+		t.Fatal("expected the locally resolved beta-feature value to override the remote value")
+	}
+	if !snapshot.flags["beta-feature"].LocallyEvaluated {
+		t.Fatal("expected beta-feature to remain locally evaluated")
+	}
+	if !snapshot.IsEnabled("remote-only") {
+		t.Fatal("expected remote-only to be filled by /flags")
+	}
+	if snapshot.flags["remote-only"].LocallyEvaluated {
+		t.Fatal("expected remote-only to be marked as remotely evaluated")
+	}
+}
+
 func TestEvaluateFlags_EmptyDistinctId_NoEvents(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -657,6 +657,45 @@ func TestEvaluateFlags_MissingRequestedLocalFlagFallsBackRemotely(t *testing.T) 
 	}
 }
 
+func TestEvaluateFlags_MissingRequestedFlagAbsentRemotelyRequestsEachCall(t *testing.T) {
+	t.Parallel()
+	var remoteCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/flags/definitions") || strings.HasPrefix(r.URL.Path, "/api/feature_flag/local_evaluation"):
+			w.Write([]byte(fixture("feature_flag/test-multiple-flags-valid.json")))
+		case strings.HasPrefix(r.URL.Path, "/flags"):
+			remoteCalls.Add(1)
+			w.Write([]byte(`{"flags": {}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, _, _ := newEvalClient(t, server, func(c *Config) {
+		c.PersonalApiKey = "personal-key"
+		c.DefaultFeatureFlagsPollingInterval = time.Hour
+	})
+	waitForFlagDefinitions(t, client)
+
+	payload := EvaluateFlagsPayload{
+		DistinctId: "user-1",
+		FlagKeys:   []string{"never-defined"},
+	}
+	for i := 0; i < 2; i++ {
+		snapshot, err := client.EvaluateFlags(payload)
+		if err != nil {
+			t.Fatalf("EvaluateFlags call %d error: %v", i+1, err)
+		}
+		if got := snapshot.Keys(); len(got) != 0 {
+			t.Fatalf("expected missing flag to stay absent, got %v", got)
+		}
+	}
+
+	if got := remoteCalls.Load(); got != 2 {
+		t.Fatalf("EvaluateFlags does not cache snapshots; expected one /flags request per call, got %d", got)
+	}
+}
+
 func TestEvaluateFlags_EmptyDistinctId_NoEvents(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32

--- a/posthog.go
+++ b/posthog.go
@@ -1229,7 +1229,16 @@ func (c *client) evaluateFlagsWithContext(ctx context.Context, payload EvaluateF
 			errorsWhileComputing = flagsResponse.ErrorsWhileComputingFlags
 			quotaLimited = c.isFeatureFlagsQuotaLimited(flagsResponse)
 			if !quotaLimited {
+				requestedFlagKeys := make(map[string]struct{}, len(payload.FlagKeys))
+				for _, key := range payload.FlagKeys {
+					requestedFlagKeys[key] = struct{}{}
+				}
 				for key, detail := range flagsResponse.Flags {
+					if len(requestedFlagKeys) > 0 {
+						if _, requested := requestedFlagKeys[key]; !requested {
+							continue
+						}
+					}
 					if _, alreadyLocal := locallyEvaluated[key]; alreadyLocal {
 						continue
 					}
@@ -1269,8 +1278,10 @@ func (c *client) populateLocalEvaluations(records map[string]evaluatedFlagRecord
 	}
 
 	flagKeyFilter := map[string]struct{}{}
+	missingFlagKeys := map[string]struct{}{}
 	for _, k := range payload.FlagKeys {
 		flagKeyFilter[k] = struct{}{}
+		missingFlagKeys[k] = struct{}{}
 	}
 
 	cohorts := poller.getCohorts()
@@ -1283,6 +1294,7 @@ func (c *client) populateLocalEvaluations(records map[string]evaluatedFlagRecord
 			if _, ok := flagKeyFilter[storedFlag.Key]; !ok {
 				continue
 			}
+			delete(missingFlagKeys, storedFlag.Key)
 		}
 		value, err := poller.computeFlagLocally(
 			storedFlag,
@@ -1334,7 +1346,7 @@ func (c *client) populateLocalEvaluations(records map[string]evaluatedFlagRecord
 		locallyEvaluated[storedFlag.Key] = struct{}{}
 	}
 
-	return fallbackToRemote
+	return fallbackToRemote || len(missingFlagKeys) > 0
 }
 
 // recordFromFlagDetail builds an evaluatedFlagRecord from a v4 FlagDetail.

--- a/posthog.go
+++ b/posthog.go
@@ -113,9 +113,11 @@ type Client interface {
 	// on the snapshot fire deduped $feature_flag_called events; GetFlagPayload
 	// does not.
 	//
-	// If the remote /flags request fails after some flags were resolved
-	// locally, EvaluateFlags returns a non-nil snapshot containing the
-	// locally-evaluated flags alongside the error so the caller can still
+	// If FlagKeys contains a key missing from loaded local definitions,
+	// EvaluateFlags includes it in the remote /flags fallback unless
+	// OnlyEvaluateLocally is true. If the remote request fails after some flags
+	// were resolved locally, EvaluateFlags returns a non-nil snapshot containing
+	// the locally-evaluated flags alongside the error so the caller can still
 	// branch on what was resolved.
 	// If OnlyEvaluateLocally is true and no SecretKey is configured, returns ErrNoSecretKey.
 	EvaluateFlags(EvaluateFlagsPayload) (*FeatureFlagEvaluations, error)
@@ -1139,16 +1141,18 @@ type EvaluateFlagsPayload struct {
 	PersonProperties Properties
 	// GroupProperties overrides group properties used during flag evaluation, keyed by group type.
 	GroupProperties map[string]Properties
-	// OnlyEvaluateLocally prevents fallback to remote /flags requests.
+	// OnlyEvaluateLocally prevents fallback to remote /flags requests. Flags
+	// that cannot be resolved from loaded local definitions are omitted.
 	OnlyEvaluateLocally bool
 	// DisableGeoIP, when non-nil, overrides the client-level DisableGeoIP for
 	// this evaluation only.
 	DisableGeoIP *bool
-	// FlagKeys, when non-empty, trims the network call by asking the server
-	// to evaluate only the named flags (sent as flag_keys_to_evaluate).
-	// This is server-side filtering; use FeatureFlagEvaluations.Only to do
-	// client-side filtering of which flags are attached to events from an
-	// existing snapshot.
+	// FlagKeys, when non-empty, restricts local evaluation, the remote request,
+	// and the returned snapshot to the named flags. A requested key missing from
+	// loaded local definitions triggers a /flags fallback unless
+	// OnlyEvaluateLocally is true. EvaluateFlags does not cache snapshots, so a
+	// key that does not exist remotely can trigger a request on each call.
+	// Use FeatureFlagEvaluations.Only to filter an existing snapshot in memory.
 	FlagKeys []string
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

When `EvaluateFlags` received `FlagKeys` containing a key absent from loaded local definitions, the SDK treated local evaluation as complete and omitted that key. It did not ask `/flags`, even though the caller had not requested local-only evaluation.

The server SDK behavior was agreed in [PostHog/posthog-android#678](https://github.com/PostHog/posthog-android/pull/678#issuecomment-5341879578): a requested key missing from local definitions should fall back to `/flags` because callers can use `OnlyEvaluateLocally` when they need a strictly local result. The canonical contract is being updated in [PostHog/sdk-specs#44](https://github.com/PostHog/sdk-specs/pull/44).

### Changes

- Mark explicitly requested keys missing from local definitions as unresolved and use the existing single remote fallback.
- Send the caller's original key list to `/flags`, keep locally resolved values authoritative, and exclude extra response keys from the snapshot.
- Keep `OnlyEvaluateLocally` strictly local. Missing and inconclusive keys remain absent without a remote request.
- Document that `EvaluateFlags` does not cache snapshots. A key absent both locally and remotely can therefore cause one `/flags` request on each call.
- Use a minor changeset because this reverses observable request behavior.

## :green_heart: How did you test it?

- `go test ./... -run 'TestEvaluateFlags_(MissingRequestedLocalFlagFallsBackRemotely|MissingRequestedFlagAbsentRemotelyRequestsEachCall|ForwardsFlagKeys)$' -count=1`
- `go vet ./...`
- `pnpm exec changeset status`
- `make test`

The regression tests cover missing-key fallback, original request scope, local-over-remote precedence, response scoping, strict local-only behavior, and the per-call cost when neither local definitions nor `/flags` know the key.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi's worker agent from a human-directed cross-SDK consistency task. The patch follows the behavior agreed in PostHog/posthog-android#678 and the canonical contract proposed in PostHog/sdk-specs#44.
