### PR TITLE
refactor: unify property group evaluation paths

### DIFF
--- a/feature_flag_property_group.go
+++ b/feature_flag_property_group.go
@@ -1,8 +1,37 @@
 package posthog
 
+func (poller *FeatureFlagsPoller) matchCohort(property FlagProperty, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
+	cohortId := valueToString(property.Value)
+	propertyGroup, ok := cohorts[cohortId]
+	if !ok {
+		return false, errCohortRequiresServerEval
+	}
+
+	return poller.matchPropertyGroup(propertyGroup, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
+}
+
+func (poller *FeatureFlagsPoller) matchPropertyGroup(propertyGroup PropertyGroup, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
+	groupType := propertyGroup.Type
+
+	// Use pre-parsed values if available (built at load time), otherwise fall back to raw values
+	if len(propertyGroup.ParsedValues) > 0 {
+		return poller.matchParsedPropertyGroup(groupType, propertyGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
+	}
+
+	if len(propertyGroup.Values) == 0 {
+		// empty groups are no-ops, always match
+		return true, nil
+	}
+
+	// Raw values are a compatibility fallback. Convert them to the same typed
+	// representation used by production cohorts so evaluation has one code path.
+	parsedGroup := preParsePG(propertyGroup)
+	return poller.matchParsedPropertyGroup(groupType, parsedGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
+}
+
 // matchParsedPropertyGroup evaluates pre-parsed property values without per-evaluation
 // reconstruction from map[string]any. This is the fast path for cohort matching.
-func matchParsedPropertyGroup(poller *FeatureFlagsPoller, groupType string, parsedValues []parsedPropertyValue, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
+func (poller *FeatureFlagsPoller) matchParsedPropertyGroup(groupType string, parsedValues []parsedPropertyValue, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
 	errorMatchingLocally := false
 
 	for i := range parsedValues {

--- a/feature_flag_property_group.go
+++ b/feature_flag_property_group.go
@@ -1,0 +1,77 @@
+package posthog
+
+// matchParsedPropertyGroup evaluates pre-parsed property values without per-evaluation
+// reconstruction from map[string]any. This is the fast path for cohort matching.
+func matchParsedPropertyGroup(poller *FeatureFlagsPoller, groupType string, parsedValues []parsedPropertyValue, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
+	errorMatchingLocally := false
+
+	for i := range parsedValues {
+		pv := &parsedValues[i]
+		if pv.IsGroup {
+			matches, err := poller.matchPropertyGroup(pv.Group, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
+			if err != nil {
+				if isServerEvalError(err) {
+					return false, err
+				} else if isInconclusiveError(err) {
+					errorMatchingLocally = true
+				} else {
+					return false, err
+				}
+			}
+
+			if groupType == "AND" {
+				if !matches {
+					return false, nil
+				}
+			} else {
+				if matches {
+					return true, nil
+				}
+			}
+		} else {
+			var matches bool
+			var err error
+			fp := &pv.Property
+			if fp.Type == "cohort" {
+				matches, err = poller.matchCohort(*fp, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
+			} else if fp.Type == "flag" {
+				matches, err = poller.evaluateFlagDependency(*fp, flagsByKey, evaluationCache, distinctId, deviceId, properties, cohorts)
+			} else {
+				matches, err = matchProperty(*fp, properties)
+			}
+
+			if err != nil {
+				if isServerEvalError(err) {
+					return false, err
+				} else if isInconclusiveError(err) {
+					errorMatchingLocally = true
+				} else {
+					return false, err
+				}
+			}
+
+			negation := fp.Negation
+			if groupType == "AND" {
+				if !matches && !negation {
+					return false, nil
+				}
+				if matches && negation {
+					return false, nil
+				}
+			} else {
+				if matches && !negation {
+					return true, nil
+				}
+				if !matches && negation {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	if errorMatchingLocally {
+		return false, errCohortPropertyValue
+	}
+
+	return groupType == "AND", nil
+}

--- a/feature_flags_property_group_test.go
+++ b/feature_flags_property_group_test.go
@@ -1,0 +1,86 @@
+package posthog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchPropertyGroupRawAndParsedParity(t *testing.T) {
+	tests := []struct {
+		name       string
+		group      PropertyGroup
+		properties Properties
+		want       bool
+		wantErr    error
+	}{
+		{
+			name: "nested group matches",
+			group: PropertyGroup{Type: "AND", Values: []any{
+				map[string]any{"key": "country", "operator": "exact", "value": "US"},
+				map[string]any{"type": "OR", "values": []any{
+					map[string]any{"key": "plan", "operator": "exact", "value": "pro"},
+					map[string]any{"key": "beta", "operator": "exact", "value": true},
+				}},
+			}},
+			properties: NewProperties().Set("country", "US").Set("plan", "free").Set("beta", true),
+			want:       true,
+		},
+		{
+			name: "negated property matches",
+			group: PropertyGroup{Type: "AND", Values: []any{
+				map[string]any{"key": "country", "operator": "exact", "value": "CA", "negation": true},
+			}},
+			properties: NewProperties().Set("country", "US"),
+			want:       true,
+		},
+		{
+			name: "inconclusive result is returned after all properties",
+			group: PropertyGroup{Type: "AND", Values: []any{
+				map[string]any{"key": "missing", "operator": "exact", "value": "value", "negation": true},
+				map[string]any{"key": "country", "operator": "exact", "value": "US"},
+			}},
+			properties: NewProperties().Set("country", "US"),
+			wantErr:    errCohortPropertyValue,
+		},
+		{
+			name: "OR match overrides an inconclusive result",
+			group: PropertyGroup{Type: "OR", Values: []any{
+				map[string]any{"key": "missing", "operator": "exact", "value": "value"},
+				map[string]any{"key": "country", "operator": "exact", "value": "US"},
+			}},
+			properties: NewProperties().Set("country", "US"),
+			want:       true,
+		},
+		{
+			name: "AND mismatch overrides an inconclusive result",
+			group: PropertyGroup{Type: "AND", Values: []any{
+				map[string]any{"key": "missing", "operator": "exact", "value": "value", "negation": true},
+				map[string]any{"key": "country", "operator": "exact", "value": "US"},
+			}},
+			properties: NewProperties().Set("country", "CA"),
+		},
+		{
+			name: "missing cohort requires server evaluation",
+			group: PropertyGroup{Type: "AND", Values: []any{
+				map[string]any{"type": "cohort", "value": "missing-cohort"},
+			}},
+			wantErr: errCohortRequiresServerEval,
+		},
+	}
+
+	poller := &FeatureFlagsPoller{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawResult, rawErr := poller.matchPropertyGroup(tt.group, tt.properties, nil, nil, nil, "distinct-id", nil)
+			require.Equal(t, tt.want, rawResult)
+			require.Equal(t, tt.wantErr, rawErr)
+
+			parsedGroup := preParsePG(tt.group)
+			require.NotEmpty(t, parsedGroup.ParsedValues)
+			parsedResult, parsedErr := poller.matchPropertyGroup(parsedGroup, tt.properties, nil, nil, nil, "distinct-id", nil)
+			require.Equal(t, rawResult, parsedResult)
+			require.Equal(t, rawErr, parsedErr)
+		})
+	}
+}

--- a/featureflags.go
+++ b/featureflags.go
@@ -1145,35 +1145,6 @@ func (poller *FeatureFlagsPoller) isConditionMatch(
 	return conditionMatch, nil
 }
 
-func (poller *FeatureFlagsPoller) matchCohort(property FlagProperty, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
-	cohortId := valueToString(property.Value)
-	propertyGroup, ok := cohorts[cohortId]
-	if !ok {
-		return false, errCohortRequiresServerEval
-	}
-
-	return poller.matchPropertyGroup(propertyGroup, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-}
-
-func (poller *FeatureFlagsPoller) matchPropertyGroup(propertyGroup PropertyGroup, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
-	groupType := propertyGroup.Type
-
-	// Use pre-parsed values if available (built at load time), otherwise fall back to raw values
-	if len(propertyGroup.ParsedValues) > 0 {
-		return matchParsedPropertyGroup(poller, groupType, propertyGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-	}
-
-	if len(propertyGroup.Values) == 0 {
-		// empty groups are no-ops, always match
-		return true, nil
-	}
-
-	// Raw values are a compatibility fallback. Convert them to the same typed
-	// representation used by production cohorts so evaluation has one code path.
-	parsedGroup := preParsePG(propertyGroup)
-	return matchParsedPropertyGroup(poller, groupType, parsedGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-}
-
 func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 	key := property.Key
 	operator := property.Operator

--- a/featureflags.go
+++ b/featureflags.go
@@ -1160,7 +1160,7 @@ func (poller *FeatureFlagsPoller) matchPropertyGroup(propertyGroup PropertyGroup
 
 	// Use pre-parsed values if available (built at load time), otherwise fall back to raw values
 	if len(propertyGroup.ParsedValues) > 0 {
-		return poller.matchParsedPropertyGroup(groupType, propertyGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
+		return matchParsedPropertyGroup(poller, groupType, propertyGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
 	}
 
 	if len(propertyGroup.Values) == 0 {
@@ -1171,83 +1171,7 @@ func (poller *FeatureFlagsPoller) matchPropertyGroup(propertyGroup PropertyGroup
 	// Raw values are a compatibility fallback. Convert them to the same typed
 	// representation used by production cohorts so evaluation has one code path.
 	parsedGroup := preParsePG(propertyGroup)
-	return poller.matchParsedPropertyGroup(groupType, parsedGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-}
-
-// matchParsedPropertyGroup evaluates pre-parsed property values without per-evaluation
-// reconstruction from map[string]any. This is the fast path for cohort matching.
-func (poller *FeatureFlagsPoller) matchParsedPropertyGroup(groupType string, parsedValues []parsedPropertyValue, properties Properties, cohorts map[string]PropertyGroup, flagsByKey map[string]FeatureFlag, evaluationCache map[string]interface{}, distinctId string, deviceId *string) (bool, error) {
-	errorMatchingLocally := false
-
-	for i := range parsedValues {
-		pv := &parsedValues[i]
-		if pv.IsGroup {
-			matches, err := poller.matchPropertyGroup(pv.Group, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-			if err != nil {
-				if isServerEvalError(err) {
-					return false, err
-				} else if isInconclusiveError(err) {
-					errorMatchingLocally = true
-				} else {
-					return false, err
-				}
-			}
-
-			if groupType == "AND" {
-				if !matches {
-					return false, nil
-				}
-			} else {
-				if matches {
-					return true, nil
-				}
-			}
-		} else {
-			var matches bool
-			var err error
-			fp := &pv.Property
-			if fp.Type == "cohort" {
-				matches, err = poller.matchCohort(*fp, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-			} else if fp.Type == "flag" {
-				matches, err = poller.evaluateFlagDependency(*fp, flagsByKey, evaluationCache, distinctId, deviceId, properties, cohorts)
-			} else {
-				matches, err = matchProperty(*fp, properties)
-			}
-
-			if err != nil {
-				if isServerEvalError(err) {
-					return false, err
-				} else if isInconclusiveError(err) {
-					errorMatchingLocally = true
-				} else {
-					return false, err
-				}
-			}
-
-			negation := fp.Negation
-			if groupType == "AND" {
-				if !matches && !negation {
-					return false, nil
-				}
-				if matches && negation {
-					return false, nil
-				}
-			} else {
-				if matches && !negation {
-					return true, nil
-				}
-				if !matches && negation {
-					return true, nil
-				}
-			}
-		}
-	}
-
-	if errorMatchingLocally {
-		return false, errCohortPropertyValue
-	}
-
-	return groupType == "AND", nil
+	return matchParsedPropertyGroup(poller, groupType, parsedGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
 }
 
 func matchProperty(property FlagProperty, properties Properties) (bool, error) {

--- a/featureflags.go
+++ b/featureflags.go
@@ -1163,97 +1163,15 @@ func (poller *FeatureFlagsPoller) matchPropertyGroup(propertyGroup PropertyGroup
 		return poller.matchParsedPropertyGroup(groupType, propertyGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
 	}
 
-	values := propertyGroup.Values
-	if len(values) == 0 {
+	if len(propertyGroup.Values) == 0 {
 		// empty groups are no-ops, always match
 		return true, nil
 	}
 
-	errorMatchingLocally := false
-
-	for _, value := range values {
-		switch prop := value.(type) {
-		case map[string]any:
-			if _, ok := prop["values"]; ok {
-				// PropertyGroup
-				matches, err := poller.matchPropertyGroup(PropertyGroup{
-					Type:   getSafeProp[string](prop, "type"),
-					Values: getSafeProp[[]any](prop, "values"),
-				}, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-				if err != nil {
-					if isServerEvalError(err) {
-						return false, err
-					} else if isInconclusiveError(err) {
-						errorMatchingLocally = true
-					} else {
-						return false, err
-					}
-				}
-
-				if groupType == "AND" {
-					if !matches {
-						return false, nil
-					}
-				} else {
-					if matches {
-						return true, nil
-					}
-				}
-			} else {
-				// FlagProperty
-				var matches bool
-				var err error
-				flagProperty := FlagProperty{
-					Key:             getSafeProp[string](prop, "key"),
-					Operator:        getSafeProp[string](prop, "operator"),
-					Value:           getSafeProp[any](prop, "value"),
-					Type:            getSafeProp[string](prop, "type"),
-					Negation:        getSafeProp[bool](prop, "negation"),
-					DependencyChain: getSafeProp[[]string](prop, "dependency_chain"),
-				}
-				if prop["type"] == "cohort" {
-					matches, err = poller.matchCohort(flagProperty, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
-				} else if prop["type"] == "flag" {
-					matches, err = poller.evaluateFlagDependency(flagProperty, flagsByKey, evaluationCache, distinctId, deviceId, properties, cohorts)
-				} else {
-					matches, err = matchProperty(flagProperty, properties)
-				}
-
-				if err != nil {
-					if isServerEvalError(err) {
-						return false, err
-					} else if isInconclusiveError(err) {
-						errorMatchingLocally = true
-					} else {
-						return false, err
-					}
-				}
-
-				negation := flagProperty.Negation
-				if groupType == "AND" {
-					if !matches && !negation {
-						return false, nil
-					}
-					if matches && negation {
-						return false, nil
-					}
-				} else {
-					if matches && !negation {
-						return true, nil
-					}
-					if !matches && negation {
-						return true, nil
-					}
-				}
-			}
-		}
-	}
-
-	if errorMatchingLocally {
-		return false, errCohortPropertyValue
-	}
-
-	return groupType == "AND", nil
+	// Raw values are a compatibility fallback. Convert them to the same typed
+	// representation used by production cohorts so evaluation has one code path.
+	parsedGroup := preParsePG(propertyGroup)
+	return poller.matchParsedPropertyGroup(groupType, parsedGroup.ParsedValues, properties, cohorts, flagsByKey, evaluationCache, distinctId, deviceId)
 }
 
 // matchParsedPropertyGroup evaluates pre-parsed property values without per-evaluation


### PR DESCRIPTION
## :bulb: Motivation and Context

Raw cohort property groups and pre-parsed production cohorts used separate implementations of the same evaluation rules. The duplicated code could drift when changing nesting, negation, error handling, or AND/OR short-circuit behavior.

## :green_heart: How did you test it?

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go test -run '^$' -bench '^BenchmarkFeatureFlagLocalEvaluation$' -benchmem -benchtime=1s -count=3 .`

The feature flag benchmark remains at 778 B/op and 7 allocs/op.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to analyze a Slopo duplication report and implement the change. The raw compatibility path now converts values with the existing `preParsePG` function and delegates to the typed evaluator used by production cohorts. Cohort and property-group matching methods are grouped in `feature_flag_property_group.go`; flag dependency evaluation remains with the broader feature flag evaluation logic. This keeps the optimized production path allocation behavior unchanged. Parity tests cover nested groups, negation, inconclusive results, short-circuit behavior, and server evaluation fallback. Pi autoreview reported no actionable findings.
