### PR TITLE
fix(release): opt private package into changesets v3 versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": { "version": true, "tag": false }
 }


### PR DESCRIPTION
## Problem

The `@changesets/cli` 2.31.1 → 3.0.0 bump in #289 silently broke releases. `package.json` here is `"private": true` (it only holds release metadata for changesets), and v3 no longer versions private packages unless you opt in. So `pnpm changeset version` became a no-op: the version stays put, the changeset files stay in place, and it prints its usual success line and exits 0.

That cascades quietly through `release.yml`. `Apply changesets and update version` re-reads the unchanged `1.23.1`, `Check for version bump changes` finds an empty `git status --porcelain`, and `Commit version bump`, `Create GitHub release` and `Dispatch posthog upgrade for posthog-go` all get skipped. The run reports success because every step genuinely succeeded.

Run [32708819097](https://github.com/PostHog/posthog-go/actions/runs/32708819097) went out this way this morning, so `fix(flags): fall back for missing local definitions` (#286) never shipped and the SDK is still on `1.23.1`.

Worth flagging separately: `Notify Slack - Released` isn't gated on the bump actually happening, so that run announced a release to Slack that never existed. Left alone here to keep this PR to the one-line fix, but it's worth a follow-up.

The same bug hit posthog-ios (PostHog/posthog-ios#778) and posthog-flutter (PostHog/posthog-flutter#546).

## Changes

Sets `privatePackages: { "version": true, "tag": false }` in `.changeset/config.json` to restore the v2 behaviour. `tag: false` because `Create GitHub release` handles tagging, nothing here calls `changeset tag`.

## How did you test it?

Ran `changeset version` on CLI 3.0.0 against a copy of this branch's `.changeset/`, `pnpm-workspace.yaml` and `package.json`:

| config | result |
| --- | --- |
| without this fix | stays on `1.23.1`, changeset untouched, exits 0 |
| with this fix | bumps to `1.24.0`, changeset consumed, `CHANGELOG.md` written |

No changeset on this PR, it's a release-config fix with nothing user-facing for the changelog. `release.yml` filters on `.changeset/*.md`, so touching `config.json` won't kick off a release on merge. Once this lands, the next approved release picks up the queued changeset as `1.24.0`.

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
