### PR TITLE
fix(release): gate released Slack notification on an actual release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
     name: Notify Slack - Released
     needs: [notify-approval-needed, release]
     runs-on: ubuntu-latest
-    if: always() && needs.release.outputs.released == 'true' && needs.notify-approval-needed.outputs.slack_ts != ''
+    if: always() && needs.release.result == 'success' && needs.release.outputs.released == 'true' && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
       contents: write
       actions: write
       id-token: write
+    outputs:
+      released: ${{ steps.commit-version-bump.outputs.commit-hash != '' }}
     steps:
       - name: Notify Slack - Approved
         if: needs.notify-approval-needed.outputs.slack_ts != ''
@@ -239,7 +241,7 @@ jobs:
     name: Notify Slack - Released
     needs: [notify-approval-needed, release]
     runs-on: ubuntu-latest
-    if: always() && needs.release.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
+    if: always() && needs.release.outputs.released == 'true' && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Problem

`Notify Slack - Released` announces a release that may never have happened.

The job gates on `needs.release.result == 'success'`, but the `release` job reports success whenever its steps succeed, and the steps that actually cut the release, `Commit version bump` and `Create GitHub release`, are conditional on `steps.commit-version-bump.outputs.commit-hash != ''`. When they're skipped, the job is still green and Slack still gets `🚀 posthog-go released successfully!`.

That's not hypothetical. Run [32708819097](https://github.com/PostHog/posthog-go/actions/runs/32708819097) posted the message this morning while `Commit version bump`, `Create GitHub release` and `Dispatch posthog upgrade for posthog-go` were all skipped. The SDK is still on `1.23.1` and #286 never shipped. That run's underlying cause is the changesets v3 bug fixed in #292, but the notification is a separate hole: any future reason for the bump to skip produces the same false announcement, and Slack is where people go to confirm a release landed.

posthog-ios and posthog-android don't have this problem, their `notify-released` gates on a downstream `publish` job that skips along with everything else. posthog-flutter notifies from `publish-pub-dev.yml`, which only runs on tag push. This repo is the outlier because `notify-released` depends directly on the job that contains the conditional steps.

## Changes

Adds a `released` output to the `release` job, mirroring the exact condition `Create GitHub release` already uses, and gates `notify-released` on it instead of on the job result.

## How did you test it?

Verified by inspection against the run above, plus a YAML parse of the workflow. The new output mirrors the existing `if: steps.commit-version-bump.outputs.commit-hash != ''` on `Create GitHub release`, so the notification now fires on exactly the condition that creates the release. Replaying the failure mode end to end needs a real approved release, so this wants a look at the next one rather than a local test.

Stacked on #292 in spirit but independent of it: they touch different files and either can merge first.

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
