### PR TITLE
ci: update flags project board workflow

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@95c20087fda2dc10fbbbcc3f1ef32b7bae779339
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
## :bulb: Motivation and Context

The shared flags project board workflow changed after this repository's pinned commit. The latest version avoids GitHub App credential failures for fork and Dependabot pull request reviews.

This updates only the reusable workflow pin. The semantic PR title workflow remains on its older pin because its file content is unchanged at the latest shared-workflow commit.

## :green_heart: How did you test it?

Compared the referenced workflow blobs at both commits and ran `git diff --check` on the one-line pin update.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi worker agent compared each referenced `PostHog/.github` workflow by Git blob content. It updated only `flags-project-board.yml`, whose content changed, and left `semantic-pr-title.yml` unchanged because its blobs match. A human requested and directed this maintenance task.
