### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.changeset/empty-flags-rest.md
+++ b/.changeset/empty-flags-rest.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Return an empty feature flag snapshot without evaluating flags when `FlagKeys` is an explicit empty slice.

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -605,6 +605,9 @@ func TestEvaluateFlags_ExplicitEmptyFlagKeysSkipsEvaluation(t *testing.T) {
 	if got := fs.callCount(); got != 0 {
 		t.Fatalf("expected no /flags request, got %d", got)
 	}
+	if evaluation.snapshot.groups == nil || len(evaluation.snapshot.groups) != 0 {
+		t.Fatalf("expected groups to be normalized to an empty map, got %#v", evaluation.snapshot.groups)
+	}
 }
 
 func TestEvaluateFlags_ForwardsFlagKeys(t *testing.T) {

--- a/feature_flag_evaluations_test.go
+++ b/feature_flag_evaluations_test.go
@@ -554,16 +554,70 @@ func TestCaptureWithFlags_AttachesPropertiesNoExtraRequest(t *testing.T) {
 	}
 }
 
+func TestEvaluateFlags_ExplicitEmptyFlagKeysSkipsEvaluation(t *testing.T) {
+	t.Parallel()
+	fs := newFlagsServer(t, "test-flags-v4.json")
+
+	configuredClient, _, _ := newEvalClient(t, fs.server)
+	concreteClient := configuredClient.(*client)
+	initialFetchFinished := make(chan bool)
+	clientWithBlockedPoller := &client{
+		Config:  concreteClient.Config,
+		decider: concreteClient.decider,
+		featureFlagsPoller: &FeatureFlagsPoller{
+			firstFeatureFlagRequestFinished: initialFetchFinished,
+		},
+	}
+
+	type evaluationResult struct {
+		snapshot *FeatureFlagEvaluations
+		err      error
+	}
+	result := make(chan evaluationResult, 1)
+	go func() {
+		snapshot, err := clientWithBlockedPoller.EvaluateFlags(EvaluateFlagsPayload{
+			DistinctId: "user-1",
+			FlagKeys:   []string{},
+		})
+		result <- evaluationResult{snapshot: snapshot, err: err}
+	}()
+
+	var evaluation evaluationResult
+	select {
+	case evaluation = <-result:
+		close(initialFetchFinished)
+	case <-time.After(time.Second):
+		// Unblock a regressed implementation before failing the test.
+		close(initialFetchFinished)
+		evaluation = <-result
+		t.Fatalf("explicit empty flag keys consulted local definitions; error: %v, /flags calls: %d", evaluation.err, fs.callCount())
+	}
+
+	if evaluation.err != nil {
+		t.Fatalf("EvaluateFlags error: %v", evaluation.err)
+	}
+	if evaluation.snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if keys := evaluation.snapshot.Keys(); len(keys) != 0 {
+		t.Fatalf("expected empty snapshot, got keys %v", keys)
+	}
+	if got := fs.callCount(); got != 0 {
+		t.Fatalf("expected no /flags request, got %d", got)
+	}
+}
+
 func TestEvaluateFlags_ForwardsFlagKeys(t *testing.T) {
 	t.Parallel()
 	fs := newFlagsServer(t, "test-flags-v4.json")
 
 	client, _, _ := newEvalClient(t, fs.server)
 
-	if _, err := client.EvaluateFlags(EvaluateFlagsPayload{
+	snapshot, err := client.EvaluateFlags(EvaluateFlagsPayload{
 		DistinctId: "user-1",
 		FlagKeys:   []string{"enabled-flag", "disabled-flag"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("EvaluateFlags error: %v", err)
 	}
 
@@ -576,6 +630,9 @@ func TestEvaluateFlags_ForwardsFlagKeys(t *testing.T) {
 	}
 	if parsed.FlagKeysToEvaluate[0] != "enabled-flag" || parsed.FlagKeysToEvaluate[1] != "disabled-flag" {
 		t.Errorf("unexpected flag keys: %v", parsed.FlagKeysToEvaluate)
+	}
+	if keys := snapshot.Keys(); len(keys) != 2 || keys[0] != "disabled-flag" || keys[1] != "enabled-flag" {
+		t.Errorf("expected snapshot scoped to requested flags, got %v", keys)
 	}
 }
 

--- a/posthog.go
+++ b/posthog.go
@@ -1147,9 +1147,10 @@ type EvaluateFlagsPayload struct {
 	// DisableGeoIP, when non-nil, overrides the client-level DisableGeoIP for
 	// this evaluation only.
 	DisableGeoIP *bool
-	// FlagKeys, when non-empty, restricts local evaluation, the remote request,
-	// and the returned snapshot to the named flags. A requested key missing from
-	// loaded local definitions triggers a /flags fallback unless
+	// FlagKeys restricts local evaluation, the remote request, and the returned
+	// snapshot to the named flags. Nil evaluates all flags, while an explicitly
+	// empty slice returns an empty snapshot without evaluating flags. A requested
+	// key missing from loaded local definitions triggers a /flags fallback unless
 	// OnlyEvaluateLocally is true. EvaluateFlags does not cache snapshots, so a
 	// key that does not exist remotely can trigger a request on each call.
 	// Use FeatureFlagEvaluations.Only to filter an existing snapshot in memory.
@@ -1179,6 +1180,17 @@ func (c *client) evaluateFlagsWithContext(ctx context.Context, payload EvaluateF
 	if payload.DistinctId == "" {
 		c.Warnf("EvaluateFlags called without a DistinctId")
 		return noopFeatureFlagEvaluations, ErrNoDistinctID
+	}
+
+	if payload.FlagKeys != nil && len(payload.FlagKeys) == 0 {
+		return &FeatureFlagEvaluations{
+			host:       host,
+			distinctId: payload.DistinctId,
+			deviceId:   payload.DeviceId,
+			groups:     payload.Groups,
+			flags:      map[string]evaluatedFlagRecord{},
+			accessed:   map[string]struct{}{},
+		}, nil
 	}
 
 	if payload.Groups == nil {

--- a/posthog.go
+++ b/posthog.go
@@ -1182,6 +1182,10 @@ func (c *client) evaluateFlagsWithContext(ctx context.Context, payload EvaluateF
 		return noopFeatureFlagEvaluations, ErrNoDistinctID
 	}
 
+	if payload.Groups == nil {
+		payload.Groups = Groups{}
+	}
+
 	if payload.FlagKeys != nil && len(payload.FlagKeys) == 0 {
 		return &FeatureFlagEvaluations{
 			host:       host,
@@ -1193,9 +1197,6 @@ func (c *client) evaluateFlagsWithContext(ctx context.Context, payload EvaluateF
 		}, nil
 	}
 
-	if payload.Groups == nil {
-		payload.Groups = Groups{}
-	}
 	if payload.PersonProperties == nil {
 		payload.PersonProperties = NewProperties()
 	}


### PR DESCRIPTION
## :bulb: Motivation and Context

[`sdk-specs#47`](https://github.com/PostHog/sdk-specs/pull/47) defines how SDKs should distinguish an omitted evaluation key scope from an explicit empty scope.

Previously, Go treated `FlagKeys: []string{}` like omitted `FlagKeys` and evaluated every available flag. This made it impossible for callers to request no evaluations.

This change preserves all three cases:

- Omitted or null `FlagKeys` evaluates all flags.
- An explicit empty `FlagKeys` slice returns a non-nil empty snapshot without reading local definitions or calling `/flags`.
- A non-empty `FlagKeys` slice evaluates and returns only the requested flags.

Empty snapshots also normalize omitted groups to an empty map, preserving the `$groups` shape used by ordinary snapshot events.

## :green_heart: How did you test it?

- `go test ./... -count=1` passed.
- `go test -race ./... -run 'TestEvaluateFlags_ExplicitEmptyFlagKeysSkipsEvaluation$' -count=1` passed.
- `go vet ./...` passed.
- `gofmt -l posthog.go feature_flag_evaluations_test.go` produced no output.
- `git diff --check` passed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's implementation agent was used to inspect, validate, commit, review, and submit the change. The human-directed source specification is linked in [`sdk-specs#47`](https://github.com/PostHog/sdk-specs/pull/47). The implementation preserves the SDK specification's distinction between omitted, empty, and non-empty evaluation key scopes. After the PR was marked ready, Greptile identified that the empty-scope fast path bypassed group normalization; the fast path now preserves the ordinary snapshot event shape and includes a regression assertion.
