### PR TITLE
fix(flags): align presence operator semantics

### DIFF
--- a/.changeset/partial-properties-match.md
+++ b/.changeset/partial-properties-match.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Align local `is_set` and `is_not_set` evaluation with partial property context.

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -26,6 +26,50 @@ func TestMatchPropertyValue(t *testing.T) {
 
 }
 
+func TestMatchPropertyPresenceOperators(t *testing.T) {
+	values := []struct {
+		name  string
+		value interface{}
+	}{
+		{name: "nil", value: nil},
+		{name: "false", value: false},
+		{name: "zero", value: 0},
+		{name: "empty string", value: ""},
+		{name: "empty slice", value: []interface{}{}},
+		{name: "empty map", value: map[string]interface{}{}},
+	}
+	operators := []struct {
+		name     string
+		expected bool
+	}{
+		{name: "is_set", expected: true},
+		{name: "is_not_set", expected: false},
+	}
+
+	for _, value := range values {
+		t.Run(value.name, func(t *testing.T) {
+			properties := NewProperties().Set("key", value.value)
+			for _, operator := range operators {
+				t.Run(operator.name, func(t *testing.T) {
+					isMatch, err := matchProperty(FlagProperty{Key: "key", Operator: operator.name}, properties)
+					require.NoError(t, err)
+					require.Equal(t, operator.expected, isMatch)
+				})
+			}
+		})
+	}
+
+	for _, operator := range operators {
+		t.Run("missing/"+operator.name, func(t *testing.T) {
+			isMatch, err := matchProperty(FlagProperty{Key: "key", Operator: operator.name}, NewProperties())
+			require.False(t, isMatch)
+			require.ErrorIs(t, err, errMissingPropertyValue)
+			var inconclusiveErr *InconclusiveMatchError
+			require.ErrorAs(t, err, &inconclusiveErr)
+		})
+	}
+}
+
 func TestMatchPropertyInvalidOperator(t *testing.T) {
 	property := FlagProperty{
 		Key:      "Browser",

--- a/featureflags.go
+++ b/featureflags.go
@@ -33,7 +33,6 @@ var relativeDateRegex = regexp.MustCompile(`^-?([0-9]+)([hdwmy])$`)
 // InconclusiveMatchError structs on every evaluation of flags with missing properties.
 var (
 	errMissingPropertyValue     = &InconclusiveMatchError{"Can't match properties without a given property value"}
-	errOperatorIsNotSet         = &InconclusiveMatchError{"Can't match properties with operator is_not_set"}
 	errInconclusiveMatch        = &InconclusiveMatchError{"Can't determine if feature flag is enabled or not with given properties"}
 	errCohortPropertyValue      = &InconclusiveMatchError{msg: "Can't match cohort without a given cohort property value"}
 	errCohortRequiresServerEval = &RequiresServerEvaluationError{msg: "cohort not found in local cohorts - likely a static cohort that requires server evaluation"}
@@ -1154,7 +1153,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 	}
 
 	if operator == "is_not_set" {
-		return false, errOperatorIsNotSet
+		return false, nil
 	}
 
 	override_value := properties[key]


### PR DESCRIPTION
## :bulb: Motivation and Context

[sdk-specs PR #49](https://github.com/PostHog/sdk-specs/pull/49) defines `is_not_set` using partial property context. The Go local evaluator returned an inconclusive error even when the caller supplied the property key, although a present key definitively does not match `is_not_set`.

This change returns false for `is_not_set` whenever the key is present, including null and other falsey values. An omitted key remains inconclusive.

## :green_heart: How did you test it?

- `go test ./... -run '^TestMatchPropertyPresenceOperators$'`
- `go test .`
- Autoreview completed with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent worker subagents implemented and validated the matcher change. The bundled autoreview tool reviewed the final committed diff against `origin/main`.
