### PR TITLE
feat(error-tracking): standardize exception event metadata

### DIFF
--- a/.changeset/canonical-exception-metadata.md
+++ b/.changeset/canonical-exception-metadata.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Standardize exception capture metadata, including severity, capture source, mechanism semantics, deterministic linkage, and reserved property ownership.

--- a/capture_v1.go
+++ b/capture_v1.go
@@ -349,9 +349,16 @@ func (msg Alias) apifyEvent() apiEvent {
 // ExceptionInApiProperties marshal precedence).
 func (msg Exception) apifyEvent() apiEvent {
 	myProperties := baseV1Props(msg.IsServer, msg.DisableGeoIP).
-		Merge(msg.Properties).
+		Merge(canonicalExceptionCustomProperties(msg.Properties)).
 		mergeDefaults(getSystemContext().ToProperties()).
-		Set("$exception_list", msg.ExceptionList)
+		Set("$exception_list", canonicalExceptionList(msg.ExceptionList))
+
+	if level := normalizeExceptionLevel(msg.Level); level != "" {
+		myProperties.Set("$exception_level", level)
+	}
+	if msg.Source != "" {
+		myProperties.Set("$exception_source", msg.Source)
+	}
 
 	if msg.ExceptionFingerprint != nil {
 		myProperties.Set("$exception_fingerprint", msg.ExceptionFingerprint)

--- a/error_tracking.go
+++ b/error_tracking.go
@@ -2,6 +2,7 @@ package posthog
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -21,6 +22,10 @@ type Exception struct {
 	// DistinctId identifies the user or entity associated with the exception.
 	// When using EnqueueWithContext, this can be inherited from RequestContext.
 	DistinctId string
+	// Level is the capture-boundary severity. Recognized aliases are normalized on the wire.
+	Level string
+	// Source identifies the concrete integration or runtime hook that captured the exception.
+	Source string
 	// DebugImages lists the binary images referenced by "native" stack
 	// frames, sent as $debug_images for server-side symbolication.
 	DebugImages []DebugImage
@@ -56,10 +61,17 @@ type ExceptionItem struct {
 
 // ExceptionMechanism describes whether an exception was handled or synthesized.
 type ExceptionMechanism struct {
+	// Type identifies the semantic capture category (for example generic, logger, middleware, or panic).
+	Type string `json:"type,omitempty"`
 	// Handled reports whether the exception was handled by application code.
 	Handled *bool `json:"handled,omitempty"`
 	// Synthetic reports whether the exception was synthesized by instrumentation.
 	Synthetic *bool `json:"synthetic,omitempty"`
+	// Source identifies how a nested exception was reached from its parent.
+	Source string `json:"source,omitempty"`
+	// ExceptionID and ParentID encode deterministic flattened exception-tree linkage.
+	ExceptionID *int `json:"exception_id,omitempty"`
+	ParentID    *int `json:"parent_id,omitempty"`
 }
 
 // ExceptionStacktrace is a PostHog-compatible stack trace.
@@ -146,6 +158,10 @@ type ExceptionInApiProperties struct {
 	ExceptionList []ExceptionItem `json:"$exception_list"`
 	// ExceptionFingerprint is sent as $exception_fingerprint when provided.
 	ExceptionFingerprint *string `json:"$exception_fingerprint,omitempty"`
+	// ExceptionLevel is the normalized event severity.
+	ExceptionLevel string `json:"$exception_level,omitempty"`
+	// ExceptionSource is the concrete capture integration or runtime hook.
+	ExceptionSource string `json:"$exception_source,omitempty"`
 
 	// Custom is flattened into the wire "properties" on marshal.
 	// Typed fields win on collision.
@@ -171,7 +187,7 @@ func (p ExceptionInApiProperties) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	for k, v := range p.Custom {
+	for k, v := range canonicalExceptionCustomProperties(p.Custom) {
 		if _, exists := merged[k]; exists {
 			continue
 		}
@@ -221,15 +237,65 @@ func (msg ExceptionItem) Validate() error {
 			Value: msg.Type,
 		}
 	}
-	if msg.Value == "" {
-		return FieldError{
-			Type:  "posthog.Exception",
-			Name:  "Value",
-			Value: msg.Value,
+	return nil
+}
+
+var exceptionLevels = map[string]string{
+	"fatal": "fatal", "critical": "fatal", "alert": "fatal", "emergency": "fatal",
+	"error": "error", "warning": "warning", "warn": "warning", "log": "log",
+	"notice": "info", "info": "info", "trace": "debug", "debug": "debug",
+}
+
+func normalizeExceptionLevel(level string) string {
+	return exceptionLevels[strings.ToLower(level)]
+}
+
+func canonicalExceptionList(items []ExceptionItem) []ExceptionItem {
+	if len(items) > 50 {
+		items = items[:50]
+	}
+	result := cloneExceptionList(items)
+	for i := range result {
+		mechanism := result[i].Mechanism
+		if mechanism == nil {
+			mechanism = &ExceptionMechanism{}
+			result[i].Mechanism = mechanism
+		}
+		id := i
+		mechanism.ExceptionID = &id
+		if i == 0 {
+			mechanism.ParentID = nil
+			mechanism.Source = ""
+			continue
+		}
+		parentID := i - 1
+		if mechanism.ParentID != nil && *mechanism.ParentID >= 0 && *mechanism.ParentID < i {
+			parentID = *mechanism.ParentID
+		}
+		mechanism.ParentID = &parentID
+		mechanism.Type = "chained"
+		mechanism.Handled = nil
+		if mechanism.Source == "" {
+			mechanism.Source = "unwrap"
 		}
 	}
+	return result
+}
 
-	return nil
+func canonicalExceptionCustomProperties(properties Properties) Properties {
+	reserved := map[string]struct{}{
+		"$exception_list": {}, "$exception_level": {}, "$exception_source": {}, "$debug_images": {},
+		"$exception_handled": {}, "$exception_types": {}, "$exception_values": {}, "$exception_sources": {},
+		"$exception_functions": {}, "$exception_fingerprint_version": {}, "$exception_fingerprint_record": {},
+		"$exception_issue_id": {}, "$exception_release": {}, "$cymbal_errors": {},
+	}
+	filtered := NewProperties()
+	for key, value := range properties {
+		if _, found := reserved[key]; !found {
+			filtered[key] = value
+		}
+	}
+	return filtered
 }
 
 // APIfy converts an Exception message into the PostHog batch API representation.
@@ -256,8 +322,10 @@ func (msg Exception) APIfy() APIMessage {
 			DistinctId:           msg.DistinctId,
 			DisableGeoIP:         msg.DisableGeoIP,
 			DebugImages:          msg.DebugImages,
-			ExceptionList:        msg.ExceptionList,
+			ExceptionList:        canonicalExceptionList(msg.ExceptionList),
 			ExceptionFingerprint: msg.ExceptionFingerprint,
+			ExceptionLevel:       normalizeExceptionLevel(msg.Level),
+			ExceptionSource:      msg.Source,
 			Custom:               msg.Properties,
 		},
 	}
@@ -280,10 +348,12 @@ func NewDefaultException(
 	return Exception{
 		DistinctId: distinctID,
 		Timestamp:  timestamp,
+		Level:      "error",
 		ExceptionList: []ExceptionItem{
 			{
 				Type:       title,
 				Value:      description,
+				Mechanism:  &ExceptionMechanism{Type: "generic", Handled: Ptr(true), Synthetic: Ptr(true)},
 				Stacktrace: defaultStackTrace.GetStackTrace(3),
 			},
 		},

--- a/error_tracking_slog.go
+++ b/error_tracking_slog.go
@@ -2,7 +2,9 @@ package posthog
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"reflect"
 	"strings"
 )
 
@@ -70,10 +72,13 @@ func (h *SlogCaptureHandler) Handle(ctx context.Context, r slog.Record) error {
 	ex := Exception{
 		DistinctId: distinctID,
 		Timestamp:  r.Time,
+		Level:      slogExceptionLevel(r.Level),
+		Source:     "go.slog",
 		ExceptionList: []ExceptionItem{
 			{
-				Type:       r.Message,
+				Type:       h.exceptionType(r),
 				Value:      h.cfg.descriptionExtractor.ExtractDescription(r),
+				Mechanism:  &ExceptionMechanism{Type: "logger", Handled: Ptr(true), Synthetic: Ptr(false)},
 				Stacktrace: h.cfg.stackTraceExtractor.GetStackTrace(h.cfg.skip),
 			},
 		},
@@ -86,6 +91,35 @@ func (h *SlogCaptureHandler) Handle(ctx context.Context, r slog.Record) error {
 	_ = enqueueWithContext(ctx, h.client, ex) // ignore enqueue error to keep logging safe
 
 	return err
+}
+
+func slogExceptionLevel(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError:
+		return "error"
+	case level >= slog.LevelWarn:
+		return "warning"
+	case level >= slog.LevelInfo:
+		return "info"
+	default:
+		return "debug"
+	}
+}
+
+func (h *SlogCaptureHandler) exceptionType(record slog.Record) string {
+	if extractor, ok := h.cfg.descriptionExtractor.(ErrorExtractor); ok {
+		if err := extractor.extractError(record); err != nil {
+			typeOf := reflect.TypeOf(err)
+			if typeOf.Kind() == reflect.Ptr {
+				typeOf = typeOf.Elem()
+			}
+			return typeOf.Name()
+		}
+	}
+	if record.Message != "" {
+		return "LogError"
+	}
+	return fmt.Sprintf("slog.Level(%d)", record.Level)
 }
 
 // WithAttrs returns a handler with attrs applied to the wrapped handler.
@@ -148,6 +182,15 @@ type ErrorExtractor struct {
 
 // ExtractDescription returns the first matching error string from the slog record or Fallback.
 func (e ErrorExtractor) ExtractDescription(r slog.Record) string {
+	found := e.extractError(r)
+	if found != nil {
+		return found.Error()
+	}
+
+	return e.Fallback
+}
+
+func (e ErrorExtractor) extractError(r slog.Record) error {
 	var found error
 
 	normalisedKeys := make([]string, len(e.ErrorKeys))
@@ -166,11 +209,7 @@ func (e ErrorExtractor) ExtractDescription(r slog.Record) string {
 		}
 		return true
 	})
-	if found != nil {
-		return found.Error()
-	}
-
-	return e.Fallback
+	return found
 }
 
 func (e ErrorExtractor) errorFromValue(v slog.Value) error {

--- a/error_tracking_test.go
+++ b/error_tracking_test.go
@@ -62,7 +62,7 @@ func TestException_Validate(t *testing.T) {
 				Value: "",
 			},
 		},
-		"error: item missing Value": {
+		"valid: runtime supplied an empty Value": {
 			msg: Exception{
 				DistinctId: "user-123",
 				Timestamp:  now,
@@ -70,11 +70,7 @@ func TestException_Validate(t *testing.T) {
 					{Type: "Foo", Value: ""},
 				},
 			},
-			expectedError: FieldError{
-				Type:  "posthog.Exception",
-				Name:  "Value",
-				Value: "",
-			},
+			expectedError: nil,
 		},
 		"valid: full nested structure": {
 			msg: Exception{
@@ -115,6 +111,37 @@ func TestException_Validate(t *testing.T) {
 				t.Errorf("expected error:\n%v \ngot:\n%v", tc.expectedError, err)
 			}
 		})
+	}
+}
+
+func TestException_APIfy_CanonicalMetadata(t *testing.T) {
+	handled := true
+	synthetic := false
+	exception := Exception{
+		DistinctId: "user-123",
+		Level:      "warn",
+		Source:     "go.slog",
+		ExceptionList: []ExceptionItem{
+			{Type: "Outer", Value: "outer", Mechanism: &ExceptionMechanism{Type: "logger", Handled: &handled, Synthetic: &synthetic}},
+			{Type: "Inner", Value: "inner", Mechanism: &ExceptionMechanism{Source: "unwrap"}},
+		},
+	}
+
+	props := exceptionWireProps(t, exception)
+	if props["$exception_level"] != "warning" || props["$exception_source"] != "go.slog" {
+		t.Fatalf("unexpected event metadata: %v", props)
+	}
+	list := props["$exception_list"].([]interface{})
+	outer := list[0].(map[string]interface{})["mechanism"].(map[string]interface{})
+	inner := list[1].(map[string]interface{})["mechanism"].(map[string]interface{})
+	if outer["exception_id"] != float64(0) || outer["type"] != "logger" || outer["handled"] != true {
+		t.Fatalf("unexpected outer mechanism: %v", outer)
+	}
+	if inner["exception_id"] != float64(1) || inner["parent_id"] != float64(0) || inner["type"] != "chained" || inner["source"] != "unwrap" {
+		t.Fatalf("unexpected inner mechanism: %v", inner)
+	}
+	if _, present := inner["handled"]; present {
+		t.Fatalf("nested handled state must remain unknown: %v", inner)
 	}
 }
 

--- a/fixtures/test-enqueue-capture-v1.json
+++ b/fixtures/test-enqueue-capture-v1.json
@@ -96,7 +96,10 @@
         "$exception_list": [
           {
             "type": "SnapshotError",
-            "value": "synthetic exception"
+            "value": "synthetic exception",
+            "mechanism": {
+              "exception_id": 0
+            }
           }
         ],
         "$geoip_disable": true,
@@ -132,7 +135,8 @@
           {
             "mechanism": {
               "handled": false,
-              "synthetic": true
+              "synthetic": true,
+              "exception_id": 0
             },
             "stacktrace": {
               "frames": [

--- a/fixtures/test-enqueue-exception-complete.json
+++ b/fixtures/test-enqueue-exception-complete.json
@@ -23,7 +23,8 @@
           {
             "mechanism": {
               "handled": false,
-              "synthetic": true
+              "synthetic": true,
+              "exception_id": 0
             },
             "stacktrace": {
               "frames": [

--- a/fixtures/test-enqueue-exception.json
+++ b/fixtures/test-enqueue-exception.json
@@ -22,7 +22,10 @@
               "type": "raw"
             },
             "type": "Exception Title",
-            "value": "Exception Description"
+            "value": "Exception Description",
+            "mechanism": {
+              "exception_id": 0
+            }
           }
         ],
         "$geoip_disable": true,

--- a/posthog.go
+++ b/posthog.go
@@ -436,6 +436,14 @@ func cloneExceptionList(items []ExceptionItem) []ExceptionItem {
 				synthetic := *item.Mechanism.Synthetic
 				mechanism.Synthetic = &synthetic
 			}
+			if item.Mechanism.ExceptionID != nil {
+				exceptionID := *item.Mechanism.ExceptionID
+				mechanism.ExceptionID = &exceptionID
+			}
+			if item.Mechanism.ParentID != nil {
+				parentID := *item.Mechanism.ParentID
+				mechanism.ParentID = &parentID
+			}
 			item.Mechanism = &mechanism
 		}
 		if item.Stacktrace != nil {

--- a/request_context.go
+++ b/request_context.go
@@ -458,12 +458,14 @@ func capturePanic(ctx context.Context, client EnqueueClient, panicValue interfac
 
 	stacktrace, debugImages := stackTraceFromDebugStack(panicStack)
 	exception := Exception{
+		Level:  "error",
+		Source: "go.http_recover_middleware",
 		Properties: NewProperties().
-			Set(propertyResponseStatusCode, statusCode).
-			Set(propertyExceptionSource, "panic"),
+			Set(propertyResponseStatusCode, statusCode),
 		ExceptionList: []ExceptionItem{{
 			Type:       "panic",
 			Value:      fmt.Sprint(panicValue),
+			Mechanism:  &ExceptionMechanism{Type: "middleware", Handled: Ptr(true), Synthetic: Ptr(true)},
 			Stacktrace: stacktrace,
 		}},
 		DebugImages: debugImages,

--- a/request_context_test.go
+++ b/request_context_test.go
@@ -402,7 +402,12 @@ func TestRequestContextMiddleware_CapturesPanicsWithRequestContextAndRethrows(t 
 	require.Equal(t, "client-user", properties["distinct_id"])
 	require.Equal(t, "client-session", properties[propertySessionID])
 	require.Equal(t, float64(http.StatusServiceUnavailable), properties[propertyResponseStatusCode])
-	require.Equal(t, "panic", properties[propertyExceptionSource])
+	require.Equal(t, "go.http_recover_middleware", properties[propertyExceptionSource])
+	require.Equal(t, "error", properties["$exception_level"])
+	exceptionList := properties["$exception_list"].([]interface{})
+	mechanism := exceptionList[0].(map[string]interface{})["mechanism"].(map[string]interface{})
+	require.Equal(t, "middleware", mechanism["type"])
+	require.Equal(t, true, mechanism["handled"])
 	requireExceptionStackContainsFunction(t, properties, "TestRequestContextMiddleware_CapturesPanicsWithRequestContextAndRethrows")
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Standardize Go exception events across manual capture, slog, HTTP panic recovery, and native debug-image paths with the cross-SDK metadata contract.

Canonical contract: https://github.com/PostHog/sdk-specs/blob/main/openspec/specs/exception-event-metadata/spec.md

## :green_heart: How did you test it?

- `go test ./...`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi from the shared OpenSpec contract. Capture-boundary defaults remain explicit, while generic properties cannot overwrite SDK- or processor-owned metadata.
