### PR TITLE
fix: match exact/is_not case-insensitively and after string coercion

### DIFF
--- a/.changeset/fix-exact-case-insensitive.md
+++ b/.changeset/fix-exact-case-insensitive.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Fix `exact`/`is_not` local flag evaluation to match case-insensitively and after string coercion, consistent with the other string operators here and the reference SDKs. A plain Go `==` made them case- and type-sensitive, so e.g. `exact "US"` did not match a `"us"` property value and `exact 1` did not match a `"1"` property value.

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -161,6 +161,32 @@ func TestMatchPropertySliceExact(t *testing.T) {
 	require.False(t, isMatch)
 }
 
+func TestMatchPropertyExactCaseInsensitiveAndCoerced(t *testing.T) {
+	// "exact"/"is_not" match case-insensitively and after string coercion, like
+	// the icontains/starts_with operators here and the reference SDKs. Plain Go
+	// "==" made them case- and type-sensitive, so these used to be wrong.
+	exact := func(value, override interface{}) bool {
+		m, err := matchProperty(FlagProperty{Key: "k", Value: value, Operator: "exact"}, NewProperties().Set("k", override))
+		require.NoError(t, err)
+		return m
+	}
+	require.True(t, exact("US", "us"))
+	require.True(t, exact("Value", "value"))
+	require.True(t, exact(1, "1"))
+	require.True(t, exact("1", 1))
+	require.False(t, exact("US", "CA"))
+
+	require.True(t, exact([]interface{}{"US", "CA"}, "us"))
+	require.False(t, exact([]interface{}{"US", "CA"}, "gb"))
+
+	isNot, err := matchProperty(FlagProperty{Key: "k", Value: "US", Operator: "is_not"}, NewProperties().Set("k", "us"))
+	require.NoError(t, err)
+	require.False(t, isNot)
+	isNot, err = matchProperty(FlagProperty{Key: "k", Value: "US", Operator: "is_not"}, NewProperties().Set("k", "gb"))
+	require.NoError(t, err)
+	require.True(t, isNot)
+}
+
 func TestMatchPropertyNumber(t *testing.T) {
 	property := FlagProperty{
 		Key:      "Number",

--- a/featureflags.go
+++ b/featureflags.go
@@ -1159,21 +1159,11 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 	override_value := properties[key]
 
 	if operator == "exact" {
-		switch t := value.(type) {
-		case []interface{}:
-			return contains(t, override_value), nil
-		default:
-			return value == override_value, nil
-		}
+		return exactMatch(value, override_value), nil
 	}
 
 	if operator == "is_not" {
-		switch t := value.(type) {
-		case []interface{}:
-			return !contains(t, override_value), nil
-		default:
-			return value != override_value, nil
-		}
+		return !exactMatch(value, override_value), nil
 	}
 
 	if operator == "is_set" {
@@ -1760,13 +1750,24 @@ func interfaceToFloat(val interface{}) (float64, error) {
 	return i, nil
 }
 
-func contains(s []interface{}, e interface{}) bool {
-	for _, a := range s {
-		if a == e {
-			return true
+// exactMatch reports whether override_value matches value for the "exact"
+// operator: equal to value for a scalar, or contained in value for a list.
+// The comparison is case-insensitive and made after string coercion, matching
+// the icontains/starts_with operators in this file and the exact operator in
+// the reference SDKs (e.g. posthog-python's str_iequals). Plain Go "=="
+// was case-sensitive and type-strict, so e.g. exact "US" did not match a "us"
+// property value and exact 1 did not match a "1" property value.
+func exactMatch(value interface{}, override_value interface{}) bool {
+	overrideStr := valueToString(override_value)
+	if list, ok := value.([]interface{}); ok {
+		for _, item := range list {
+			if strings.EqualFold(valueToString(item), overrideStr) {
+				return true
+			}
 		}
+		return false
 	}
-	return false
+	return strings.EqualFold(valueToString(value), overrideStr)
 }
 
 func containsVariant(variantList []FlagVariant, key string) bool {


### PR DESCRIPTION
## Problem

In local flag evaluation, the `exact` and `is_not` operators compare with a plain Go `==`, so they are case-sensitive and type-strict:

```go
if operator == "exact" {
    switch t := value.(type) {
    case []interface{}:
        return contains(t, override_value), nil   // contains also uses ==
    default:
        return value == override_value, nil
    }
}
```

Every other string operator in this file (`icontains`, `starts_with`, `ends_with`) already lower-cases and string-coerces both sides, and the reference SDKs do the same for `exact` (e.g. posthog-python's `str_iequals` compares `str(a).casefold() == str(b).casefold()`). So the same flag can evaluate differently depending on which SDK an app uses:

- `exact "US"` did not match a `"us"` property value
- `exact 1` did not match a `"1"` property value

## Fix

Add an `exactMatch` helper that folds case and coerces to string (matching the other operators and the reference), and route `exact`/`is_not` through it. This replaces the now-unused `contains`.

```go
func exactMatch(value interface{}, override_value interface{}) bool {
    overrideStr := valueToString(override_value)
    if list, ok := value.([]interface{}); ok {
        for _, item := range list {
            if strings.EqualFold(valueToString(item), overrideStr) {
                return true
            }
        }
        return false
    }
    return strings.EqualFold(valueToString(value), overrideStr)
}
```

Same-case, same-type inputs are unchanged, so existing behavior for those is preserved. Added `TestMatchPropertyExactCaseInsensitiveAndCoerced` covering the case-fold and coercion cases (scalar, list, and `is_not`), plus a changeset.

`go build ./...` passes. I wasn't able to finish `go test ./...` locally (slow module downloads in my environment), but I verified the existing `exact` tests all use same-case/same-type values, so they are unaffected.
