### PR TITLE
fix(flags): align local exact matching with the flags service

### DIFF
--- a/.changeset/align-flag-case-folding.md
+++ b/.changeset/align-flag-case-folding.md
@@ -2,4 +2,4 @@
 "posthog-go": patch
 ---
 
-Align local feature flag property matching with the flags service: use ASCII-only case folding for contains, prefix, and suffix operators, and Unicode lowercasing rather than broader case folding for `exact` and `is_not`.
+Align local feature flag property matching with the flags service, including boolean-array precedence, canonical JSON stringification, and operator-specific case folding.

--- a/.changeset/align-flag-case-folding.md
+++ b/.changeset/align-flag-case-folding.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Align local feature flag property matching with the flags service: use ASCII-only case folding for contains, prefix, and suffix operators, and Unicode lowercasing rather than broader case folding for `exact` and `is_not`.

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -173,9 +173,12 @@ func TestMatchPropertyExactCaseInsensitiveAndCoerced(t *testing.T) {
 	require.True(t, exact("US", "us"))
 	require.True(t, exact("Value", "value"))
 	require.True(t, exact("Ä", "ä"))
+	require.True(t, exact("İ", "i\u0307"))
+	require.True(t, exact("ΟΣ", "ος"))
 	require.True(t, exact(1, "1"))
 	require.True(t, exact("1", 1))
 	require.False(t, exact("US", "CA"))
+	require.False(t, exact("İ", "i"))
 	require.False(t, exact("Σ", "ς"))
 	require.False(t, exact("ß", "ss"))
 

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -172,19 +172,55 @@ func TestMatchPropertyExactCaseInsensitiveAndCoerced(t *testing.T) {
 	}
 	require.True(t, exact("US", "us"))
 	require.True(t, exact("Value", "value"))
+	require.True(t, exact("Ä", "ä"))
 	require.True(t, exact(1, "1"))
 	require.True(t, exact("1", 1))
 	require.False(t, exact("US", "CA"))
+	require.False(t, exact("Σ", "ς"))
+	require.False(t, exact("ß", "ss"))
 
-	require.True(t, exact([]interface{}{"US", "CA"}, "us"))
-	require.False(t, exact([]interface{}{"US", "CA"}, "gb"))
+	require.True(t, exact([]interface{}{"US", "Ä"}, "ä"))
+	require.False(t, exact([]interface{}{"US", "Σ"}, "ς"))
 
 	isNot, err := matchProperty(FlagProperty{Key: "k", Value: "US", Operator: "is_not"}, NewProperties().Set("k", "us"))
 	require.NoError(t, err)
 	require.False(t, isNot)
-	isNot, err = matchProperty(FlagProperty{Key: "k", Value: "US", Operator: "is_not"}, NewProperties().Set("k", "gb"))
+	isNot, err = matchProperty(FlagProperty{Key: "k", Value: "Σ", Operator: "is_not"}, NewProperties().Set("k", "ς"))
 	require.NoError(t, err)
 	require.True(t, isNot)
+}
+
+func TestMatchPropertyStringOperatorsUseASCIICaseFolding(t *testing.T) {
+	tests := []struct {
+		operator string
+		filter   string
+		actual   string
+		expected bool
+	}{
+		{operator: "icontains", filter: "VALUE", actual: "a-value-b", expected: true},
+		{operator: "not_icontains", filter: "VALUE", actual: "a-value-b", expected: false},
+		{operator: "starts_with", filter: "VALUE", actual: "value-b", expected: true},
+		{operator: "not_starts_with", filter: "VALUE", actual: "value-b", expected: false},
+		{operator: "ends_with", filter: "VALUE", actual: "a-value", expected: true},
+		{operator: "not_ends_with", filter: "VALUE", actual: "a-value", expected: false},
+		{operator: "icontains", filter: "ä", actual: "Ä", expected: false},
+		{operator: "not_icontains", filter: "ä", actual: "Ä", expected: true},
+		{operator: "starts_with", filter: "ä", actual: "Äbc", expected: false},
+		{operator: "not_starts_with", filter: "ä", actual: "Äbc", expected: true},
+		{operator: "ends_with", filter: "ä", actual: "bcÄ", expected: false},
+		{operator: "not_ends_with", filter: "ä", actual: "bcÄ", expected: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.operator+"/"+test.filter, func(t *testing.T) {
+			matched, err := matchProperty(
+				FlagProperty{Key: "k", Value: test.filter, Operator: test.operator},
+				NewProperties().Set("k", test.actual),
+			)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, matched)
+		})
+	}
 }
 
 func TestMatchPropertyNumber(t *testing.T) {

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -2,12 +2,21 @@ package posthog
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+type exactNamedString string
+
+type exactMarshaledString struct{}
+
+func (exactMarshaledString) MarshalJSON() ([]byte, error) {
+	return []byte(`"pro"`), nil
+}
 
 func TestMatchPropertyValue(t *testing.T) {
 	property := FlagProperty{
@@ -191,6 +200,114 @@ func TestMatchPropertyExactCaseInsensitiveAndCoerced(t *testing.T) {
 	isNot, err = matchProperty(FlagProperty{Key: "k", Value: "Σ", Operator: "is_not"}, NewProperties().Set("k", "ς"))
 	require.NoError(t, err)
 	require.True(t, isNot)
+}
+
+func TestMatchPropertyExactUsesBackendBooleanPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		filter   interface{}
+		actual   interface{}
+		expected bool
+	}{
+		{name: "false matches arbitrary falsey string", filter: false, actual: "banana", expected: true},
+		{name: "false string matches zero", filter: "false", actual: 0, expected: true},
+		{name: "boolean parsing uses lowercase not case folding", filter: "falſe", actual: false, expected: false},
+		{name: "false array matches null", filter: []interface{}{"false"}, actual: nil, expected: true},
+		{name: "mixed boolean array is aggregate false", filter: []interface{}{"true", "false"}, actual: "pro", expected: true},
+		{name: "mixed boolean array does not use any", filter: []interface{}{"true", "false"}, actual: "true", expected: false},
+		{name: "empty array is aggregate true for boolean", filter: []interface{}{}, actual: true, expected: true},
+		{name: "empty array is aggregate true for string", filter: []interface{}{}, actual: "TRUE", expected: true},
+		{name: "empty array is aggregate true for empty array", filter: []interface{}{}, actual: []interface{}{}, expected: true},
+		{name: "empty array is aggregate true for true array", filter: []interface{}{}, actual: []interface{}{true}, expected: true},
+		{name: "typed boolean array uses aggregate truthiness", filter: true, actual: []bool{true}, expected: true},
+		{name: "ordinary arrays still use any", filter: []interface{}{"FREE", "PRO"}, actual: "pro", expected: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			exact, err := matchProperty(
+				FlagProperty{Key: "k", Value: test.filter, Operator: "exact"},
+				NewProperties().Set("k", test.actual),
+			)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, exact)
+
+			isNot, err := matchProperty(
+				FlagProperty{Key: "k", Value: test.filter, Operator: "is_not"},
+				NewProperties().Set("k", test.actual),
+			)
+			require.NoError(t, err)
+			require.Equal(t, !test.expected, isNot)
+		})
+	}
+}
+
+func TestMatchPropertyExactUsesBackendJSONRepresentation(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		actual interface{}
+	}{
+		{name: "null", filter: "null", actual: nil},
+		{name: "array", filter: "[1,2]", actual: []interface{}{1, 2}},
+		{name: "typed integer array", filter: "[1,2]", actual: []int{1, 2}},
+		{name: "typed large integer map", filter: `{"a":9007199254740993}`, actual: map[string]int64{"a": 9007199254740993}},
+		{name: "sorted object", filter: `{"a":2,"b":1}`, actual: map[string]interface{}{"b": 1, "a": 2}},
+		{name: "integer", filter: "323", actual: 323},
+		{name: "integral float", filter: "323.0", actual: float64(323)},
+		{name: "negative zero", filter: "-0.0", actual: math.Copysign(0, -1)},
+		{name: "small exponent", filter: "1e-7", actual: 1e-7},
+		{name: "large exponent", filter: "1e+16", actual: 1e16},
+		{name: "fixed small decimal", filter: "0.00001", actual: 1e-5},
+		{name: "fixed decimal", filter: "0.000099", actual: 9.9e-5},
+		{name: "nested values", filter: `[{"a":1},1e-7]`, actual: []interface{}{map[string]interface{}{"a": 1}, 1e-7}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matched, err := matchProperty(
+				FlagProperty{Key: "k", Value: test.filter, Operator: "exact"},
+				NewProperties().Set("k", test.actual),
+			)
+			require.NoError(t, err)
+			require.True(t, matched)
+		})
+	}
+}
+
+func TestMatchPropertyExactFallsBackForAmbiguousFilterNumbers(t *testing.T) {
+	for _, filter := range []interface{}{
+		float64(323),
+		[]interface{}{float64(323)},
+		map[string]interface{}{"a": float64(1)},
+		[]interface{}{map[string]interface{}{"a": float64(1)}},
+	} {
+		matched, err := matchProperty(
+			FlagProperty{Key: "k", Value: filter, Operator: "exact"},
+			NewProperties().Set("k", "323"),
+		)
+		require.False(t, matched)
+		var inconclusiveErr *InconclusiveMatchError
+		require.ErrorAs(t, err, &inconclusiveErr)
+	}
+
+	matched, err := matchProperty(
+		FlagProperty{Key: "k", Value: "323", Operator: "exact"},
+		NewProperties().Set("k", float64(323)),
+	)
+	require.NoError(t, err)
+	require.False(t, matched, "a runtime float retains its .0 when the filter spelling is known")
+}
+
+func TestMatchPropertyExactNormalizesNamedAndMarshaledStrings(t *testing.T) {
+	for _, actual := range []interface{}{exactNamedString("pro"), exactMarshaledString{}} {
+		matched, err := matchProperty(
+			FlagProperty{Key: "k", Value: "pro", Operator: "exact"},
+			NewProperties().Set("k", actual),
+		)
+		require.NoError(t, err)
+		require.True(t, matched)
+	}
 }
 
 func TestMatchPropertyStringOperatorsUseASCIICaseFolding(t *testing.T) {

--- a/featureflags.go
+++ b/featureflags.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	json "github.com/goccy/go-json"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -1756,16 +1758,21 @@ func interfaceToFloat(val interface{}) (float64, error) {
 // before comparing them. This intentionally differs from EqualFold for cases
 // such as capital sigma and final sigma.
 func exactMatch(value interface{}, override_value interface{}) bool {
-	overrideStr := strings.ToLower(valueToString(override_value))
+	overrideStr := unicodeLower(valueToString(override_value))
 	if list, ok := value.([]interface{}); ok {
 		for _, item := range list {
-			if strings.ToLower(valueToString(item)) == overrideStr {
+			if unicodeLower(valueToString(item)) == overrideStr {
 				return true
 			}
 		}
 		return false
 	}
-	return strings.ToLower(valueToString(value)) == overrideStr
+	return unicodeLower(valueToString(value)) == overrideStr
+}
+
+func unicodeLower(value string) string {
+	// Casers may be stateful and cannot be shared between evaluator goroutines.
+	return cases.Lower(language.Und).String(value)
 }
 
 func asciiLower(value string) string {

--- a/featureflags.go
+++ b/featureflags.go
@@ -9,9 +9,12 @@ import (
 	"fmt"
 
 	"io"
+	"math"
 	"net/http"
 	"net/url"
+	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,6 +39,7 @@ var relativeDateRegex = regexp.MustCompile(`^-?([0-9]+)([hdwmy])$`)
 var (
 	errMissingPropertyValue     = &InconclusiveMatchError{"Can't match properties without a given property value"}
 	errInconclusiveMatch        = &InconclusiveMatchError{"Can't determine if feature flag is enabled or not with given properties"}
+	errAmbiguousExactNumber     = &InconclusiveMatchError{"Can't match an integral JSON number locally because Go does not preserve whether it was an integer or float"}
 	errCohortPropertyValue      = &InconclusiveMatchError{msg: "Can't match cohort without a given cohort property value"}
 	errCohortRequiresServerEval = &RequiresServerEvaluationError{msg: "cohort not found in local cohorts - likely a static cohort that requires server evaluation"}
 )
@@ -1160,12 +1164,15 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 
 	override_value := properties[key]
 
-	if operator == "exact" {
-		return exactMatch(value, override_value), nil
-	}
-
-	if operator == "is_not" {
-		return !exactMatch(value, override_value), nil
+	if operator == "exact" || operator == "is_not" {
+		matched, err := exactMatch(value, override_value)
+		if err != nil {
+			return false, err
+		}
+		if operator == "is_not" {
+			return !matched, nil
+		}
+		return matched, nil
 	}
 
 	if operator == "is_set" {
@@ -1752,22 +1759,143 @@ func interfaceToFloat(val interface{}) (float64, error) {
 	return i, nil
 }
 
-// exactMatch reports whether override_value matches value for the "exact"
-// operator: equal to value for a scalar, or contained in value for a list.
-// The flags service stringifies both values and applies Unicode lowercasing
-// before comparing them. This intentionally differs from EqualFold for cases
-// such as capital sigma and final sigma.
-func exactMatch(value interface{}, override_value interface{}) bool {
-	overrideStr := unicodeLower(valueToString(override_value))
+// exactMatch mirrors the flags service's exact operator, including its
+// boolean-array precedence. Integral float64 filter values are inconclusive
+// because JSON decoding collapses integer and floating-point number kinds.
+func exactMatch(value interface{}, overrideValue interface{}) (bool, error) {
+	if isTruthyOrFalsyPropertyValue(value) {
+		return isTruthyPropertyValue(value) == isTruthyPropertyValue(overrideValue), nil
+	}
+
 	if list, ok := value.([]interface{}); ok {
+		hadAmbiguousNumber := false
+		overrideStr := unicodeLower(exactValueToString(overrideValue))
 		for _, item := range list {
-			if unicodeLower(valueToString(item)) == overrideStr {
-				return true
+			if containsAmbiguousExactNumber(item) {
+				hadAmbiguousNumber = true
+				continue
 			}
+			if unicodeLower(exactValueToString(item)) == overrideStr {
+				return true, nil
+			}
+		}
+		if hadAmbiguousNumber {
+			return false, errAmbiguousExactNumber
+		}
+		return false, nil
+	}
+
+	if containsAmbiguousExactNumber(value) {
+		return false, errAmbiguousExactNumber
+	}
+	return unicodeLower(exactValueToString(value)) == unicodeLower(exactValueToString(overrideValue)), nil
+}
+
+func isTruthyOrFalsyPropertyValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case bool:
+		return true
+	case string:
+		lowered := unicodeLower(typed)
+		return lowered == "true" || lowered == "false"
+	case []interface{}:
+		for _, item := range typed {
+			if !isTruthyOrFalsyPropertyValue(item) {
+				return false
+			}
+		}
+		return true
+	default:
+		if array, ok := normalizeJSONArray(value); ok {
+			return isTruthyOrFalsyPropertyValue(array)
 		}
 		return false
 	}
-	return unicodeLower(valueToString(value)) == overrideStr
+}
+
+func isTruthyPropertyValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return unicodeLower(typed) == "true"
+	case []interface{}:
+		for _, item := range typed {
+			if !isTruthyPropertyValue(item) {
+				return false
+			}
+		}
+		return true
+	default:
+		if array, ok := normalizeJSONArray(value); ok {
+			return isTruthyPropertyValue(array)
+		}
+		return false
+	}
+}
+
+func normalizeJSONArray(value interface{}) ([]interface{}, bool) {
+	decoded, ok := normalizeJSONValue(value)
+	if !ok {
+		return nil, false
+	}
+	array, ok := decoded.([]interface{})
+	return array, ok
+}
+
+func normalizeJSONValue(value interface{}) (interface{}, bool) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var decoded interface{}
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, false
+	}
+	return decoded, true
+}
+
+func containsAmbiguousExactNumber(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+
+	reflected := reflect.ValueOf(value)
+	for reflected.Kind() == reflect.Interface || reflected.Kind() == reflect.Pointer {
+		if reflected.IsNil() {
+			return false
+		}
+		reflected = reflected.Elem()
+	}
+
+	switch reflected.Kind() {
+	case reflect.Float64:
+		floatValue := reflected.Float()
+		return !math.IsNaN(floatValue) && !math.IsInf(floatValue, 0) && math.Trunc(floatValue) == floatValue
+	case reflect.Array, reflect.Slice:
+		for index := 0; index < reflected.Len(); index++ {
+			if containsAmbiguousExactNumber(reflected.Index(index).Interface()) {
+				return true
+			}
+		}
+	case reflect.Map:
+		iterator := reflected.MapRange()
+		for iterator.Next() {
+			if containsAmbiguousExactNumber(iterator.Value().Interface()) {
+				return true
+			}
+		}
+	case reflect.Struct:
+		for index := 0; index < reflected.NumField(); index++ {
+			field := reflected.Field(index)
+			if field.CanInterface() && containsAmbiguousExactNumber(field.Interface()) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func unicodeLower(value string) string {
@@ -1840,6 +1968,145 @@ func valueToString(v interface{}) string {
 	default:
 		return fmt.Sprint(v)
 	}
+}
+
+// exactValueToString mirrors serde_json::Value::to_string for representable JSON
+// values, except that top-level strings remain unquoted like the flags service helper.
+func exactValueToString(value interface{}) string {
+	if value != nil && reflect.ValueOf(value).Kind() == reflect.String {
+		return reflect.ValueOf(value).String()
+	}
+
+	if !isDirectCanonicalValue(value) {
+		if normalized, ok := normalizeJSONValue(value); ok {
+			if stringValue, ok := normalized.(string); ok {
+				return stringValue
+			}
+			if stringValue, ok := canonicalJSONValue(normalized); ok {
+				return stringValue
+			}
+		}
+	}
+
+	if stringValue, ok := canonicalJSONValue(value); ok {
+		return stringValue
+	}
+	return fmt.Sprint(value)
+}
+
+func isDirectCanonicalValue(value interface{}) bool {
+	switch value.(type) {
+	case nil, string, bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number,
+		[]interface{}, map[string]interface{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalJSONValue(value interface{}) (string, bool) {
+	switch typed := value.(type) {
+	case nil:
+		return "null", true
+	case string:
+		encoded, err := json.MarshalNoEscape(typed)
+		return string(encoded), err == nil
+	case bool:
+		return strconv.FormatBool(typed), true
+	case int:
+		return strconv.Itoa(typed), true
+	case int8:
+		return strconv.FormatInt(int64(typed), 10), true
+	case int16:
+		return strconv.FormatInt(int64(typed), 10), true
+	case int32:
+		return strconv.FormatInt(int64(typed), 10), true
+	case int64:
+		return strconv.FormatInt(typed, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(typed), 10), true
+	case uint8:
+		return strconv.FormatUint(uint64(typed), 10), true
+	case uint16:
+		return strconv.FormatUint(uint64(typed), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(typed), 10), true
+	case uint64:
+		return strconv.FormatUint(typed, 10), true
+	case float32:
+		return serdeFloatString(float64(typed), 32)
+	case float64:
+		return serdeFloatString(typed, 64)
+	case json.Number:
+		number := typed.String()
+		if !strings.ContainsAny(number, ".eE") {
+			return number, true
+		}
+		floatValue, err := typed.Float64()
+		if err != nil {
+			return "", false
+		}
+		return serdeFloatString(floatValue, 64)
+	case []interface{}:
+		values := make([]string, len(typed))
+		for index, item := range typed {
+			encoded, ok := canonicalJSONValue(item)
+			if !ok {
+				return "", false
+			}
+			values[index] = encoded
+		}
+		return "[" + strings.Join(values, ",") + "]", true
+	case map[string]interface{}:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		values := make([]string, 0, len(keys))
+		for _, key := range keys {
+			encodedKey, _ := json.MarshalNoEscape(key)
+			encodedValue, ok := canonicalJSONValue(typed[key])
+			if !ok {
+				return "", false
+			}
+			values = append(values, string(encodedKey)+":"+encodedValue)
+		}
+		return "{" + strings.Join(values, ",") + "}", true
+	default:
+		decoded, ok := normalizeJSONValue(value)
+		if !ok {
+			return "", false
+		}
+		return canonicalJSONValue(decoded)
+	}
+}
+
+func serdeFloatString(value float64, bitSize int) (string, bool) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "", false
+	}
+
+	absolute := math.Abs(value)
+	if absolute != 0 && (absolute < 1e-6 || absolute >= 1e16) {
+		formatted := strconv.FormatFloat(value, 'e', -1, bitSize)
+		exponentIndex := strings.LastIndexByte(formatted, 'e')
+		exponent, err := strconv.Atoi(formatted[exponentIndex+1:])
+		if err != nil {
+			return "", false
+		}
+		return formatted[:exponentIndex] + "e" + fmt.Sprintf("%+d", exponent), true
+	}
+
+	formatted := strconv.FormatFloat(value, 'f', -1, bitSize)
+	if math.Trunc(value) == value {
+		formatted += ".0"
+	}
+	return formatted, true
 }
 
 func variantToString(v interface{}) string {

--- a/featureflags.go
+++ b/featureflags.go
@@ -1171,27 +1171,27 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 	}
 
 	if operator == "icontains" {
-		return strings.Contains(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+		return strings.Contains(asciiLower(valueToString(override_value)), asciiLower(valueToString(value))), nil
 	}
 
 	if operator == "not_icontains" {
-		return !strings.Contains(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+		return !strings.Contains(asciiLower(valueToString(override_value)), asciiLower(valueToString(value))), nil
 	}
 
 	if operator == "starts_with" {
-		return strings.HasPrefix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+		return strings.HasPrefix(asciiLower(valueToString(override_value)), asciiLower(valueToString(value))), nil
 	}
 
 	if operator == "not_starts_with" {
-		return !strings.HasPrefix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+		return !strings.HasPrefix(asciiLower(valueToString(override_value)), asciiLower(valueToString(value))), nil
 	}
 
 	if operator == "ends_with" {
-		return strings.HasSuffix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+		return strings.HasSuffix(asciiLower(valueToString(override_value)), asciiLower(valueToString(value))), nil
 	}
 
 	if operator == "not_ends_with" {
-		return !strings.HasSuffix(strings.ToLower(valueToString(override_value)), strings.ToLower(valueToString(value))), nil
+		return !strings.HasSuffix(asciiLower(valueToString(override_value)), asciiLower(valueToString(value))), nil
 	}
 
 	if operator == "regex" {
@@ -1752,22 +1752,30 @@ func interfaceToFloat(val interface{}) (float64, error) {
 
 // exactMatch reports whether override_value matches value for the "exact"
 // operator: equal to value for a scalar, or contained in value for a list.
-// The comparison is case-insensitive and made after string coercion, matching
-// the icontains/starts_with operators in this file and the exact operator in
-// the reference SDKs (e.g. posthog-python's str_iequals). Plain Go "=="
-// was case-sensitive and type-strict, so e.g. exact "US" did not match a "us"
-// property value and exact 1 did not match a "1" property value.
+// The flags service stringifies both values and applies Unicode lowercasing
+// before comparing them. This intentionally differs from EqualFold for cases
+// such as capital sigma and final sigma.
 func exactMatch(value interface{}, override_value interface{}) bool {
-	overrideStr := valueToString(override_value)
+	overrideStr := strings.ToLower(valueToString(override_value))
 	if list, ok := value.([]interface{}); ok {
 		for _, item := range list {
-			if strings.EqualFold(valueToString(item), overrideStr) {
+			if strings.ToLower(valueToString(item)) == overrideStr {
 				return true
 			}
 		}
 		return false
 	}
-	return strings.EqualFold(valueToString(value), overrideStr)
+	return strings.ToLower(valueToString(value)) == overrideStr
+}
+
+func asciiLower(value string) string {
+	lowered := []byte(value)
+	for i, character := range lowered {
+		if character >= 'A' && character <= 'Z' {
+			lowered[i] = character + ('a' - 'A')
+		}
+	}
+	return string(lowered)
 }
 
 func containsVariant(variantList []FlagVariant, key string) bool {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli v1.22.17
 	golang.org/x/sys v0.21.0
+	golang.org/x/text v0.21.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## :bulb: Motivation and Context

Local feature flag evaluation did not consistently match the released Rust flags service for property filters.

This is part of [PostHog/posthog#78019](https://github.com/PostHog/posthog/issues/78019).

This change:

- folds only ASCII `A-Z` for contains, prefix, and suffix operators
- uses full Unicode lowercasing for `exact` and `is_not`
- applies the released backend's boolean-array precedence, including its current empty-array behavior
- stringifies null, arrays, objects, and representable numbers using the backend's canonical JSON forms
- returns an inconclusive result for integral `float64` filter values whose original JSON integer/float kind was lost
- preserves ordinary ANY membership for non-boolean-like filter arrays
- adds a patch changeset for `posthog-go`

The proposed backend behavior change in [PostHog/posthog#90694](https://github.com/PostHog/posthog/pull/90694) is a separate draft. This PR continues to match the currently released backend until that proposal is accepted and shipped.

### Runtime limitation

Go's normal JSON decoding collapses `323` and `323.0` into the same `float64` filter value. Local evaluation now falls back to the server for ambiguous integral filter numbers instead of guessing. Known string filter spellings and caller-provided integer or floating-point property types still use their canonical forms.

## :green_heart: How did you test it?

The new focused tests reproduced these failures before the fix:

- boolean-like arrays used ordinary ANY membership instead of aggregate backend truthiness
- empty arrays did not use the backend's vacuous `all()` behavior
- null, arrays, and objects used Go-specific text rather than canonical JSON
- negative zero and exponent forms differed from `serde_json`
- integral decoded filter numbers produced a local answer despite lost type information

After the fix:

- `go test ./...`
- `go test -race . -run 'TestMatchPropertyExact' -count=1`
- `go vet ./...`
- `gofmt` and `git diff --check`
- local autoreview reported no actionable findings after two accepted review fixes for typed containers and recursively ambiguous numbers

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this user-directed compatibility fix using the address-pr-comments, check-pr, autoreview, and karpathy-guidelines skills. The final implementation keeps `x/text/cases.Lower` because verification showed it already matches the backend's final-sigma and dotted-I behavior.
