### PR TITLE
feat: report $release_id from POSTHOG_RELEASE_ID on exceptions

### DIFF
--- a/.changeset/release-id-env.md
+++ b/.changeset/release-id-env.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": minor
+---
+
+Report a `$release_id` on `$exception` events when `POSTHOG_RELEASE_ID` is set in the environment. This is the native, deploy-time counterpart to injecting `$release_id` into a web bundle: a build tool creates the release with `posthog-cli release resolve`, launches the app with the printed id in `POSTHOG_RELEASE_ID`, and the SDK stamps it on each exception so the server resolves that exception's release by a direct id lookup — no release name or version has to match anything the app reports. Only exception events carry it (that is where a release is resolved), the variable is read once, and an unset or blank value changes nothing.

--- a/capture_v1.go
+++ b/capture_v1.go
@@ -359,6 +359,10 @@ func (msg Exception) apifyEvent() apiEvent {
 	if len(msg.DebugImages) > 0 {
 		myProperties.Set("$debug_images", msg.DebugImages)
 	}
+	// The release id from POSTHOG_RELEASE_ID, if set (see error_tracking.go APIfy for the v0 path).
+	if releaseID := releaseIDFromEnv(); releaseID != nil {
+		myProperties.Set("$release_id", *releaseID)
+	}
 
 	return apiEvent{
 		event:      "$exception",

--- a/error_tracking.go
+++ b/error_tracking.go
@@ -146,6 +146,9 @@ type ExceptionInApiProperties struct {
 	ExceptionList []ExceptionItem `json:"$exception_list"`
 	// ExceptionFingerprint is sent as $exception_fingerprint when provided.
 	ExceptionFingerprint *string `json:"$exception_fingerprint,omitempty"`
+	// ReleaseId is sent as $release_id when POSTHOG_RELEASE_ID is set, so the server resolves the
+	// exception's release by a direct id lookup. Only exception events carry it.
+	ReleaseId *string `json:"$release_id,omitempty"`
 
 	// Custom is flattened into the wire "properties" on marshal.
 	// Typed fields win on collision.
@@ -258,6 +261,7 @@ func (msg Exception) APIfy() APIMessage {
 			DebugImages:          msg.DebugImages,
 			ExceptionList:        msg.ExceptionList,
 			ExceptionFingerprint: msg.ExceptionFingerprint,
+			ReleaseId:            releaseIDFromEnv(),
 			Custom:               msg.Properties,
 		},
 	}

--- a/release_env.go
+++ b/release_env.go
@@ -1,0 +1,40 @@
+package posthog
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// releaseIDEnvVar is the environment variable the SDK reads the release id from.
+//
+// This is the native, deploy-time counterpart to injecting $release_id into a web bundle. A
+// compiled binary has no bundle, so a build tool creates the release with `posthog-cli release
+// resolve`, launches the app with the printed id in this variable, and the SDK reports it as
+// $release_id on every exception — so the server resolves the exception's release by a direct id
+// lookup, with no release name or version having to match anything the app reports.
+const releaseIDEnvVar = "POSTHOG_RELEASE_ID"
+
+var (
+	releaseIDOnce  sync.Once
+	releaseIDValue *string
+)
+
+// releaseIDFromEnv returns the release id from POSTHOG_RELEASE_ID, read once. It returns nil when
+// the variable is unset or blank, so no $release_id is sent.
+func releaseIDFromEnv() *string {
+	releaseIDOnce.Do(func() {
+		releaseIDValue = normalizeReleaseID(os.Getenv(releaseIDEnvVar))
+	})
+	return releaseIDValue
+}
+
+// normalizeReleaseID trims the raw value and treats a blank string as unset, so POSTHOG_RELEASE_ID=
+// (or whitespace) does not send an empty $release_id.
+func normalizeReleaseID(raw string) *string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/release_env_test.go
+++ b/release_env_test.go
@@ -1,0 +1,71 @@
+package posthog
+
+import "testing"
+
+func TestNormalizeReleaseID(t *testing.T) {
+	if got := normalizeReleaseID(""); got != nil {
+		t.Errorf("unset: want nil, got %q", *got)
+	}
+	if got := normalizeReleaseID("   "); got != nil {
+		t.Errorf("blank: want nil, got %q", *got)
+	}
+	const id = "01a04245-8c54-0000-7530-28eed93002b0"
+	if got := normalizeReleaseID("  " + id + "  "); got == nil || *got != id {
+		t.Errorf("value: want %q trimmed, got %v", id, got)
+	}
+}
+
+// forceReleaseID pins the cached POSTHOG_RELEASE_ID value for a test and restores it afterwards,
+// bypassing the process-global env read (which is behind a sync.Once).
+func forceReleaseID(t *testing.T, value *string) {
+	t.Helper()
+	releaseIDOnce.Do(func() {}) // spend the Once so releaseIDFromEnv returns releaseIDValue
+	old := releaseIDValue
+	releaseIDValue = value
+	t.Cleanup(func() { releaseIDValue = old })
+}
+
+func TestReleaseIDIsAddedOnlyToExceptionEvents(t *testing.T) {
+	const id = "01a04245-8c54-0000-7530-28eed93002b0"
+	forceReleaseID(t, Ptr(id))
+
+	exc := Exception{
+		DistinctId:    "user-1",
+		ExceptionList: []ExceptionItem{{Type: "Error", Value: "boom"}},
+	}
+
+	// v0 / callback path.
+	api, ok := exc.APIfy().(ExceptionInApi)
+	if !ok {
+		t.Fatalf("APIfy did not return ExceptionInApi")
+	}
+	if api.Properties.ReleaseId == nil || *api.Properties.ReleaseId != id {
+		t.Errorf("APIfy: want $release_id %q, got %v", id, api.Properties.ReleaseId)
+	}
+
+	// v1 path.
+	if got, _ := exc.apifyEvent().properties["$release_id"].(string); got != id {
+		t.Errorf("apifyEvent: want $release_id %q, got %q", id, got)
+	}
+
+	// A non-exception event must not carry it — the release is only resolved on exceptions.
+	capEv := Capture{Event: "custom_event", DistinctId: "user-1"}.apifyEvent()
+	if _, present := capEv.properties["$release_id"]; present {
+		t.Errorf("capture event must not carry $release_id")
+	}
+}
+
+func TestReleaseIDAbsentWhenUnset(t *testing.T) {
+	forceReleaseID(t, nil)
+
+	exc := Exception{
+		DistinctId:    "user-1",
+		ExceptionList: []ExceptionItem{{Type: "Error", Value: "boom"}},
+	}
+	if api := exc.APIfy().(ExceptionInApi); api.Properties.ReleaseId != nil {
+		t.Errorf("unset: want nil $release_id, got %q", *api.Properties.ReleaseId)
+	}
+	if _, present := exc.apifyEvent().properties["$release_id"]; present {
+		t.Errorf("unset: exception must not carry $release_id")
+	}
+}


### PR DESCRIPTION
## Problem

A compiled Go binary carries no release. A JavaScript build injects `$release_id` into its bundle, but a Go binary has neither.

## Change

Report a `$release_id` on `$exception` events when `POSTHOG_RELEASE_ID` is set in the environment — the native, deploy-time counterpart to the web `$release_id`:

1. A build tool runs `posthog-cli release resolve` to create the release and print its id.
2. It launches the app with that id in `POSTHOG_RELEASE_ID`.
3. The SDK reads the variable at runtime and stamps `$release_id` on each exception.

The server then resolves each exception's release by a direct id lookup, so no release name or version has to match anything the app reports.

Only `$exception` events carry the property — that is the only event the server resolves a release from, so a normal `Capture` does not need it. The id is read once (cached) and added on both the v0 (`APIfy`) and v1 (`apifyEvent`) exception paths, so it is consistent across capture modes. An unset or blank value changes nothing. **No binary patching and no code signing.**

**Contract:** the variable is `POSTHOG_RELEASE_ID`, holding the release id (a UUID) that `posthog-cli release resolve` prints. Upload the Go binary's symbols release-independent with `symbol-sets upload --release-mode=event` (PostHog/posthog#89834), so one symbol set serves every release.

This mirrors the Rust SDK change (PostHog/posthog-rs#239): the env-var flow is SDK-agnostic — any native SDK that reads `POSTHOG_RELEASE_ID` participates.

## How did you test this code?

`go test ./...` — new unit tests for the value normalization (unset → none, blank → none, surrounding whitespace trimmed) and for the exception scoping: a `$release_id` lands on an `$exception` (verified on both the v0 `APIfy` and the v1 `apifyEvent` wire paths), **not** on a non-exception `Capture`, and not at all when unset. The full suite stays green; `go vet` and `gofmt` clean.

<details>
<summary>new tests</summary>

```
--- PASS: TestNormalizeReleaseID
--- PASS: TestReleaseIDIsAddedOnlyToExceptionEvents
--- PASS: TestReleaseIDAbsentWhenUnset
ok  github.com/posthog/posthog-go
```

</details>

The positive env-read path is exercised through the wire-format structs (`ExceptionInApi` / the v1 event) rather than by faking the env: the variable is read behind a `sync.Once`, so a test pins the cached value directly.

**End to end against a local PostHog stack**, run by the agent (Claude). A minimal `go-release-env` example (a plain posthog-go app, `alpha → beta → gamma` → capture) is built against this branch, its symbols upload release-independent, its exception resolves its release purely from the reported `$release_id`, and its frames show Go source context.

<details>
<summary>posthog-cli — release-independent <code>symbol-sets upload</code> of the Go binary, then <code>release resolve</code></summary>

```
# Go embeds DWARF, so the CLI reads it straight from the Mach-O (built with -ldflags=-compressdwarf=false).
# --include-source bundles the .go files so frames show source context.
$ posthog-cli symbol-sets upload --directory . --release-mode=event --include-source
INFO  Found 1 native debug file(s) and 0 dSYM bundle(s)
INFO  Processing .../go-release-env (debug id 75F086B0-0548-3B10-E94D-E63C7F5129AB)
INFO  Collected 40 source files
INFO  --release-mode=event: uploading symbol sets release-independent; the release is carried on each event as $release_id (POSTHOG_RELEASE_ID)
INFO  Upload summary: 1 chunk(s) uploaded, 0 skipped

# the release is named here, and its id is what the app reports
$ posthog-cli release resolve --release-name go-release-env --release-version 2.0.0
01a04367-c799-0000-dbe9-a7b5d6121d6b
```

</details>

<details>
<summary>the app, launched with the resolved id in <code>POSTHOG_RELEASE_ID</code></summary>

```
$ export POSTHOG_RELEASE_ID=$(posthog-cli release resolve --release-name go-release-env --release-version 2.0.0)
$ ./go-release-env
starting — release 01a04367-c799-0000-dbe9-a7b5d6121d6b (from POSTHOG_RELEASE_ID)
stopping
```

</details>

Read back server-side (a dev-login session over the local API): the `$exception` (`$lib = posthog-go`) carries the reported `$release_id`, cymbal resolved it into a `$exception_release`, and the app frames symbolicate to source off the uploaded symbol set:

```
$lib               : posthog-go
$release_id        : 01a04367-c799-0000-dbe9-a7b5d6121d6b
frames (in app)    : main.gamma three.go:11  main.beta two.go:6  main.alpha one.go:6  main.main main.go:30
$exception_release : { project: "go-release-env", version: "2.0.0", id: 01a04367-c799-… }
```

| Symbolicated stack trace, with Go source context | Release resolved via the reported `$release_id` |
| --- | --- |
| ![go-stack](https://raw.githubusercontent.com/PostHog/pr-assets/c76745b12b5d2bf423e89b5fb0c8d51b7f4f9a82/2026/08/aba83601-bb28-4663-9021-0b71b29f11e4.png) | ![go-release](https://raw.githubusercontent.com/PostHog/pr-assets/94e5d603e11818fa3586eb691ed796d98983415c/2026/08/455bd53d-e3fa-4180-8c34-fb5ad2d688f7.png) |

The binary carries no release-specific code — only `POSTHOG_RELEASE_ID` in the environment names the release. This matches the Rust pair (PostHog/posthog-rs#239); the two SDKs produce the identical `$exception` shape.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in Claude Code, directed by @ablaszkiewicz (DRI). This brings the env-variable `$release_id` approach (already done for Rust in PostHog/posthog-rs#239, with the CLI side in PostHog/posthog#89834) to the Go SDK. The repo was cloned locally for this change. The end-to-end verification above was run by the agent against a local PostHog dev stack (ingestion + cymbal), with screenshots uploaded via `hogli pr:upload-image`; the example data is invented (`go-release-env`) and draws on no customer material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
