### PR TITLE
fix: not_regex should handle all value types like regex

### DIFF
--- a/.changeset/fix-not-regex-value-types.md
+++ b/.changeset/fix-not-regex-value-types.md
@@ -2,4 +2,4 @@
 "posthog-go": patch
 ---
 
-Fix `not_regex` local flag evaluation erroring on non-string/int property values. The `not_regex` operator used a manual string/int type switch and returned an error for other types, most notably `float64`, which is what JSON numbers deserialize to, so it failed on a numeric property value even though `regex` handled it. `not_regex` now coerces both sides with `valueToString`, mirroring `regex`.
+Fix `not_regex` local flag evaluation erroring on non-string/int property values. The `not_regex` operator used a manual string/int type switch and returned an error for other types, most notably `float64`, which is what JSON numbers deserialize to, so it failed on a numeric property value even though `regex` handled it. `not_regex` now coerces both sides with `valueToString`, mirroring `regex`. It also no longer coerces a `nil` property value to the Go-specific `<nil>` string; like the server, a null property now yields no-match for `not_regex`.

--- a/.changeset/fix-not-regex-value-types.md
+++ b/.changeset/fix-not-regex-value-types.md
@@ -2,4 +2,4 @@
 "posthog-go": patch
 ---
 
-Fix `not_regex` local flag evaluation erroring on non-string/int property values. The `not_regex` operator used a manual string/int type switch and returned an error for other types, most notably `float64`, which is what JSON numbers deserialize to, so it failed on a numeric property value even though `regex` handled it. `not_regex` now coerces both sides with `valueToString`, mirroring `regex`. It also no longer coerces a `nil` property value to the Go-specific `<nil>` string; like the server, a null property now yields no-match for `not_regex`.
+Fix `not_regex` local flag evaluation erroring on non-string/int property values. The `not_regex` operator used a manual string/int type switch and returned an error for other types, most notably `float64`, which is what JSON numbers deserialize to, so it failed on a numeric property value even though `regex` handled it. `not_regex` now coerces both sides with `valueToString`, mirroring `regex`. An explicit `nil` property value is represented as `null`, matching the feature flags evaluation service rather than Go's default `<nil>` representation.

--- a/.changeset/fix-not-regex-value-types.md
+++ b/.changeset/fix-not-regex-value-types.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Fix `not_regex` local flag evaluation erroring on non-string/int property values. The `not_regex` operator used a manual string/int type switch and returned an error for other types, most notably `float64`, which is what JSON numbers deserialize to, so it failed on a numeric property value even though `regex` handled it. `not_regex` now coerces both sides with `valueToString`, mirroring `regex`.

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -309,6 +309,20 @@ func TestMatchPropertyRegex(t *testing.T) {
 	}
 }
 
+func TestMatchPropertyNotRegexHandlesAllValueTypes(t *testing.T) {
+	// not_regex must coerce like regex does. JSON numbers arrive as float64,
+	// which the old manual type switch rejected with an error even though
+	// regex handled it.
+	for _, ov := range []interface{}{"123", 123, 123.0, float64(123)} {
+		m, err := matchProperty(FlagProperty{Key: "k", Value: "^1", Operator: "not_regex"}, NewProperties().Set("k", ov))
+		require.NoError(t, err)
+		require.False(t, m) // "123" matches ^1, so not_regex is false
+	}
+	m, err := matchProperty(FlagProperty{Key: "k", Value: "^9", Operator: "not_regex"}, NewProperties().Set("k", 123.0))
+	require.NoError(t, err)
+	require.True(t, m) // "123" does not match ^9
+}
+
 func TestMatchPropertyContains(t *testing.T) {
 	shouldMatch := []interface{}{"value", "value2", "value3", "value4", "343tfvalue5"}
 

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -322,17 +322,19 @@ func TestMatchPropertyNotRegexHandlesAllValueTypes(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, m) // "123" does not match ^9
 
-	// A nil property value must not be coerced to Go's "<nil>" string. Like the
-	// server (posthog-python only allows None for "is_not"), a regex operator
-	// yields no-match for a null property.
+	// The feature flags evaluation service stringifies a null property as "null"
+	// before matching it. not_regex must negate the regex result as usual.
 	m, err = matchProperty(FlagProperty{Key: "k", Value: "^1", Operator: "not_regex"}, NewProperties().Set("k", nil))
 	require.NoError(t, err)
-	require.False(t, m)
-	// Regression guard: a pattern that would match the literal "<nil>" must not
-	// sneak through for a null property.
-	m, err = matchProperty(FlagProperty{Key: "k", Value: "^<nil>$", Operator: "not_regex"}, NewProperties().Set("k", nil))
+	require.True(t, m)
+	m, err = matchProperty(FlagProperty{Key: "k", Value: "^null$", Operator: "not_regex"}, NewProperties().Set("k", nil))
 	require.NoError(t, err)
 	require.False(t, m)
+	// Regression guard: Go's default "<nil>" representation must not leak into
+	// local evaluation.
+	m, err = matchProperty(FlagProperty{Key: "k", Value: "^<nil>$", Operator: "not_regex"}, NewProperties().Set("k", nil))
+	require.NoError(t, err)
+	require.True(t, m)
 }
 
 func TestMatchPropertyContains(t *testing.T) {

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -321,6 +321,18 @@ func TestMatchPropertyNotRegexHandlesAllValueTypes(t *testing.T) {
 	m, err := matchProperty(FlagProperty{Key: "k", Value: "^9", Operator: "not_regex"}, NewProperties().Set("k", 123.0))
 	require.NoError(t, err)
 	require.True(t, m) // "123" does not match ^9
+
+	// A nil property value must not be coerced to Go's "<nil>" string. Like the
+	// server (posthog-python only allows None for "is_not"), a regex operator
+	// yields no-match for a null property.
+	m, err = matchProperty(FlagProperty{Key: "k", Value: "^1", Operator: "not_regex"}, NewProperties().Set("k", nil))
+	require.NoError(t, err)
+	require.False(t, m)
+	// Regression guard: a pattern that would match the literal "<nil>" must not
+	// sneak through for a null property.
+	m, err = matchProperty(FlagProperty{Key: "k", Value: "^<nil>$", Operator: "not_regex"}, NewProperties().Set("k", nil))
+	require.NoError(t, err)
+	require.False(t, m)
 }
 
 func TestMatchPropertyContains(t *testing.T) {

--- a/featureflags.go
+++ b/featureflags.go
@@ -1215,12 +1215,11 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 	}
 
 	if operator == "not_regex" {
-		// A nil property value never matches a regex operator. The server and
-		// posthog-python list only "is_not" in NONE_VALUES_ALLOWED_OPERATORS, so
-		// a null property yields no-match there rather than being coerced to the
-		// Go-specific "<nil>" string (which would spuriously satisfy not_regex).
+		// The feature flags evaluation service stringifies an explicit JSON null
+		// as "null" before regex matching. Avoid Go's default "<nil>" representation.
+		overrideValueString := valueToString(override_value)
 		if override_value == nil {
-			return false, nil
+			overrideValueString = "null"
 		}
 		// Mirror the "regex" branch above: coerce both sides with valueToString
 		// so all property/flag value types are handled. The previous manual
@@ -1233,7 +1232,7 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 			return false, nil
 		}
 
-		return !r.MatchString(valueToString(override_value)), nil
+		return !r.MatchString(overrideValueString), nil
 	}
 
 	if operator == "gt" {

--- a/featureflags.go
+++ b/featureflags.go
@@ -1215,32 +1215,18 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 	}
 
 	if operator == "not_regex" {
-		var pattern string
-
-		if valueString, ok := value.(string); ok {
-			pattern = valueString
-		} else if valueInt, ok := value.(int); ok {
-			pattern = strconv.Itoa(valueInt)
-		} else {
-			return false, errors.New("regex expression not allowed")
-		}
-
-		r, err := getOrCompileRegex(pattern)
+		// Mirror the "regex" branch above: coerce both sides with valueToString
+		// so all property/flag value types are handled. The previous manual
+		// string/int type switch errored on other types, most notably float64,
+		// which is what JSON numbers deserialize to, so not_regex failed on a
+		// numeric property value even though regex handled it.
+		r, err := getOrCompileRegex(valueToString(value))
 		// invalid regex
 		if err != nil {
 			return false, nil
 		}
 
-		var match bool
-		if valueString, ok := override_value.(string); ok {
-			match = r.MatchString(valueString)
-		} else if valueInt, ok := override_value.(int); ok {
-			match = r.MatchString(strconv.Itoa(valueInt))
-		} else {
-			return false, errors.New("value type not supported")
-		}
-
-		return !match, nil
+		return !r.MatchString(valueToString(override_value)), nil
 	}
 
 	if operator == "gt" {

--- a/featureflags.go
+++ b/featureflags.go
@@ -1215,6 +1215,13 @@ func matchProperty(property FlagProperty, properties Properties) (bool, error) {
 	}
 
 	if operator == "not_regex" {
+		// A nil property value never matches a regex operator. The server and
+		// posthog-python list only "is_not" in NONE_VALUES_ALLOWED_OPERATORS, so
+		// a null property yields no-match there rather than being coerced to the
+		// Go-specific "<nil>" string (which would spuriously satisfy not_regex).
+		if override_value == nil {
+			return false, nil
+		}
 		// Mirror the "regex" branch above: coerce both sides with valueToString
 		// so all property/flag value types are handled. The previous manual
 		// string/int type switch errored on other types, most notably float64,


### PR DESCRIPTION
## Problem

The `regex` and `not_regex` operators handle value types differently. `regex` coerces both sides with `valueToString`, so it accepts strings, ints, floats, and bools:

```go
if operator == "regex" {
    r, err := getOrCompileRegex(valueToString(value))
    if err != nil { return false, nil }
    return r.MatchString(valueToString(override_value)), nil
}
```

`not_regex` instead uses a manual `string`/`int` type switch and returns an error for anything else:

```go
if valueString, ok := override_value.(string); ok {
    match = r.MatchString(valueString)
} else if valueInt, ok := override_value.(int); ok {
    match = r.MatchString(strconv.Itoa(valueInt))
} else {
    return false, errors.New("value type not supported")
}
```

The important gap is `float64`: JSON numbers deserialize to `float64`, so a `not_regex` condition on a numeric property value errors out even though the same value works with `regex`:

```
regex     ^1  vs float64(123)  ->  (true,  <nil>)
not_regex ^1  vs float64(123)  ->  (false, "value type not supported")   ❌
```

## Fix

Make `not_regex` mirror `regex`, coercing both the pattern and the property value with `valueToString`. This handles all value types and keeps the two operators consistent. Added `TestMatchPropertyNotRegexHandlesAllValueTypes` (string, int, float64).

## Testing

`go test .` passes (full package suite, including the new test).
