### PR TITLE
fix(flags): accept a numeric operand stored as a string

### DIFF
--- a/.changeset/accept-string-numeric-operands.md
+++ b/.changeset/accept-string-numeric-operands.md
@@ -1,0 +1,5 @@
+---
+"posthog-go": patch
+---
+
+Fix local evaluation falling back to the API for `gt`, `gte`, `lt` and `lte` when the operand is stored as a string. The PostHog API stores a numeric comparison operand as a string, and its filters validation requires one, so most flags using these operators hold a string. `interfaceToFloat` had a case for every numeric type and none for `string`, so the operand was not orderable. The error it returned was not an `InconclusiveMatchError`, so the caller did not try other conditions either and fell back to the API for a flag it could have matched locally. A string operand is now parsed with `strconv.ParseFloat`, matching what the Python, Node, Ruby and PHP SDKs already do. A value that is not a finite number, including `"NaN"` and `"Inf"`, stays not orderable.

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -370,9 +370,15 @@ func TestMatchPropertyNumberStoredAsString(t *testing.T) {
 }
 
 func TestMatchPropertyNonNumericStringIsNotOrderable(t *testing.T) {
-	property := FlagProperty{Key: "Number", Value: "not-a-number", Operator: "gt"}
-	_, err := matchProperty(property, NewProperties().Set("Number", 7))
-	require.Error(t, err)
+	// ParseFloat accepts "NaN" and "Inf", and a NaN comparison is false whichever way it is
+	// asked, so accepting one would answer the condition instead of falling back.
+	for _, value := range []string{"not-a-number", "NaN", "Inf", "-Inf"} {
+		t.Run(value, func(t *testing.T) {
+			property := FlagProperty{Key: "Number", Value: value, Operator: "gt"}
+			_, err := matchProperty(property, NewProperties().Set("Number", 7))
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestMatchPropertyNumber(t *testing.T) {

--- a/feature_flags_matching_test.go
+++ b/feature_flags_matching_test.go
@@ -343,6 +343,38 @@ func TestMatchPropertyStringOperatorsUseASCIICaseFolding(t *testing.T) {
 	}
 }
 
+func TestMatchPropertyNumberStoredAsString(t *testing.T) {
+	// The flags API stores these operands as strings, so local evaluation has to read that
+	// form or it falls back to the API for a flag it could have matched itself.
+	for _, test := range []struct {
+		name     string
+		value    interface{}
+		operator string
+		override interface{}
+		expected bool
+	}{
+		{"gt matches", "5", "gt", 7, true},
+		{"gt does not match", "5", "gt", 3, false},
+		{"gte matches on equal", "5", "gte", 5, true},
+		{"lt matches", "5", "lt", 4, true},
+		{"lte matches on equal", "5", "lte", 5, true},
+		{"decimal operand", "1.5", "gt", 2, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			property := FlagProperty{Key: "Number", Value: test.value, Operator: test.operator}
+			matched, err := matchProperty(property, NewProperties().Set("Number", test.override))
+			require.NoError(t, err)
+			require.Equal(t, test.expected, matched)
+		})
+	}
+}
+
+func TestMatchPropertyNonNumericStringIsNotOrderable(t *testing.T) {
+	property := FlagProperty{Key: "Number", Value: "not-a-number", Operator: "gt"}
+	_, err := matchProperty(property, NewProperties().Set("Number", 7))
+	require.Error(t, err)
+}
+
 func TestMatchPropertyNumber(t *testing.T) {
 	property := FlagProperty{
 		Key:      "Number",

--- a/featureflags.go
+++ b/featureflags.go
@@ -1748,7 +1748,9 @@ func interfaceToFloat(val interface{}) (float64, error) {
 		// parses that form. Without this the value is not orderable and the caller falls back
 		// to the API for a flag it could evaluate locally.
 		parsed, err := strconv.ParseFloat(t, 64)
-		if err != nil {
+		// ParseFloat accepts "NaN" and "Inf". A NaN comparison is false whichever way it is
+		// asked, so accepting one would answer the condition instead of falling back.
+		if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
 			return 0.0, errors.New("argument not orderable")
 		}
 		i = parsed

--- a/featureflags.go
+++ b/featureflags.go
@@ -1743,6 +1743,15 @@ func interfaceToFloat(val interface{}) (float64, error) {
 		i = float64(t)
 	case uint64:
 		i = float64(t)
+	case string:
+		// The flags API stores a numeric comparison operand as a string, and every other SDK
+		// parses that form. Without this the value is not orderable and the caller falls back
+		// to the API for a flag it could evaluate locally.
+		parsed, err := strconv.ParseFloat(t, 64)
+		if err != nil {
+			return 0.0, errors.New("argument not orderable")
+		}
+		i = parsed
 	default:
 		errMessage := "argument not orderable"
 		return 0.0, errors.New(errMessage)


### PR DESCRIPTION
## Problem

A flag condition like `version >= 5` cannot be evaluated locally when the operand is stored as `"5"` rather than `5`. The SDK falls back to the API for a flag it could have matched itself.

`interfaceToFloat` has a case for every numeric type and none for `string`, so the operand is not orderable. The error it returns is not an `InconclusiveMatchError`, so the caller does not try other conditions either.

The PostHog API stores this operand as a string. Its filters validation requires one, so most stored flags using these operators hold a string today. Python, Node, Ruby, PHP and .NET all parse either form.

## Changes

- `interfaceToFloat` parses a string operand with `strconv.ParseFloat`.
- A string that is not a number stays not orderable, as before.

## How did you test this code?

Added a table test over `gt`, `gte`, `lt` and `lte` with the operand stored as a string, including a decimal, plus a case asserting a non-numeric string still errors.

Verified the tests fail for the right reason: removing the `string` case makes every case fail with "argument not orderable".

`go test ./...` passes, `go vet` is clean, `gofmt` reports nothing.

Found while looking at how each SDK handles this operand across PostHog/posthog#99342. .NET has the opposite bug, where a JSON number is read through its cohort-id constructor and every comparison passes; a separate PR covers that.
